### PR TITLE
Update to work with FPP v3.1.0, add version check

### DIFF
--- a/fprime_python_model/fpp_ast/fpp_ast.py
+++ b/fprime_python_model/fpp_ast/fpp_ast.py
@@ -204,10 +204,13 @@ class DefAliasType:
     :type name: Ident
     :param type_name: Type name that the alias type represents
     :type type_name: AstNode[TypeName]
+    :param is_dictionary_def: Whether the alias type is a dictionary definition
+    :type is_dictionary_def: bool
     """
 
     name: Ident
     type_name: AstNode["TypeName"]
+    is_dictionary_def: bool
 
 
 @dataclass
@@ -225,6 +228,8 @@ class DefArray:
     :type default: Optional[AstNode[Expr]]
     :param format: Format string
     :type format: Optional[AstNode[str]]
+    :param is_dictionary_def: Whether the array is a dictionary definition
+    :type is_dictionary_def: bool
     """
 
     name: Ident
@@ -232,6 +237,7 @@ class DefArray:
     elt_type: AstNode["TypeName"]
     default: Optional[AstNode["Expr"]]
     format: Optional[AstNode[str]]
+    is_dictionary_def: bool
 
 
 @dataclass
@@ -299,11 +305,13 @@ class DefConstant:
     :type name: Ident
     :param value: Value of the constant
     :type value: AstNode[Expr]
-
+    :param is_dictionary_def: Whether the constant is a dictionary definition
+    :type is_dictionary_def: bool
     """
 
     name: Ident
     value: AstNode["Expr"]
+    is_dictionary_def: bool
 
 
 @dataclass
@@ -319,12 +327,15 @@ class DefEnum:
     :type constants: List[Annotated[AstNode[DefEnumConstant]]]
     :param default: Default value of the enum
     :type default: Optional[AstNode[Expr]]
+    :param is_dictionary_def: Whether the enum is a dictionary definition
+    :type is_dictionary_def: bool
     """
 
     name: Ident
     type_name: Optional[AstNode["TypeName"]]
     constants: List[Annotated[AstNode["DefEnumConstant"]]]
     default: Optional[AstNode["Expr"]]
+    is_dictionary_def: bool
 
 
 @dataclass
@@ -497,11 +508,14 @@ class DefStruct:
     :type members: List[Annotated[AstNode[StructMember]]]
     :param default: Default value of the struct
     :type default: Optional[AstNode[Expr]]
+    :param is_dictionary_def: Whether the struct is a dictionary definition
+    :type is_dictionary_def: bool
     """
 
     name: Ident
     members: List[Annotated[AstNode["StructTypeMember"]]]
     default: Optional[AstNode["Expr"]]
+    is_dictionary_def: bool
 
 
 @dataclass
@@ -1178,6 +1192,21 @@ class ExprArray(Expr):
 
 
 @dataclass
+class ExprArraySubscript(Expr):
+    """
+    Array expression
+
+    :param e1: Expression AST node
+    :type e1: AstNode[Expr]
+    :param e2: Expression AST node
+    :type e2: AstNode[Expr]
+    """
+
+    e1: AstNode[Expr]
+    e2: AstNode[Expr]
+
+
+@dataclass
 class ExprBinop(Expr):
     """
     Binary operation expression
@@ -1704,6 +1733,21 @@ class SpecContainer:
 
 
 @dataclass
+class EventThrottle:
+    """
+    Event throttle
+
+    :param count: Maximum throttle count
+    :type count: AstNode[Expr]
+    :param every: Throttle period
+    :type every: Optional[AstNode[Expr]]
+    """
+
+    count: AstNode[Expr]
+    every: Optional[AstNode[Expr]]
+
+
+@dataclass
 class SpecEvent:
     """
     Event specifier
@@ -1719,7 +1763,7 @@ class SpecEvent:
     :param format: Event format string
     :type format: AstNode[str]
     :param throttle: Event throttle
-    :type throttle: Optional[AstNode[Expr]]
+    :type throttle: Optional[AstNode[EventThrottle]]
     """
 
     name: Ident
@@ -1727,7 +1771,7 @@ class SpecEvent:
     severity: "SpecEventSeverity"
     id: Optional[AstNode[Expr]]
     format: AstNode[str]
-    throttle: Optional[AstNode[Expr]]
+    throttle: Optional[AstNode[EventThrottle]]
 
 
 class SpecEventSeverity(Enum):
@@ -1813,11 +1857,14 @@ class SpecLoc:
     :type symbol: AstNode[QualIdent]
     :param file: Path of the FPP source file
     :type file: AstNode[str]
+    :param is_dictionary_def: Whether the location specifier specified the location of a dictionary definition
+    :type is_dictionary_def: bool
     """
 
     kind: "SpecLocKind"
     symbol: AstNode[QualIdent]
     file: AstNode[str]
+    is_dictionary_def: bool
 
 
 class SpecLocKind(Enum):

--- a/fprime_python_model/fpp_ast/fpp_ast.py
+++ b/fprime_python_model/fpp_ast/fpp_ast.py
@@ -1888,7 +1888,7 @@ class SpecLocKind(Enum):
     PORT = "port"
     STATE_MACHINE = "state machine"
     TOPOLOGY = "topology"
-    TYPE = "type "
+    TYPE = "type"
     INTERFACE = "interface"
 
     def __str__(self):

--- a/fprime_python_model/fpp_ast/fpp_locations.py
+++ b/fprime_python_model/fpp_ast/fpp_locations.py
@@ -7,7 +7,15 @@ from pathlib import Path
 class Location:
     path: Path
     pos: str
-    includingLoc: Optional[str]
+    including_loc: Optional["Location"]
 
     def __hash__(self):
-        return hash((self.path, self.pos, self.includingLoc))
+        return hash((self.path, self.pos, self.including_loc))
+
+    def __str__(self):
+        includes_str = ""
+        if self.including_loc:
+            includes_str = (
+                f"\nincluded at {self.including_loc.path}:{self.including_loc.pos}"
+            )
+        return f"{self.path}:{self.pos}{includes_str}"

--- a/fprime_python_model/fpp_version.py
+++ b/fprime_python_model/fpp_version.py
@@ -1,0 +1,8 @@
+from packaging.version import Version
+
+MIN_FPP_VERSION = Version("3.1.0a10")
+
+
+def check_version(to_check: str, msg: str) -> None:
+    if Version(to_check) < MIN_FPP_VERSION:
+        raise ValueError(f"{msg}\nMinimum supported: {MIN_FPP_VERSION}")

--- a/fprime_python_model/model.py
+++ b/fprime_python_model/model.py
@@ -3,7 +3,7 @@ from packaging.version import Version
 from typing import Dict, List
 from fprime_python_model.fpp_ast.fpp_ast_node import AstNode, AstId
 from fprime_python_model.fpp_ast.fpp_ast import Annotated
-from fprime_python_model.translators.ast_translator import translate_ast_json
+from fprime_python_model.translators.ast_translator import AstTranslator
 from fprime_python_model.translators.loc_map_translator import (
     translate_location_map_json,
 )
@@ -12,8 +12,7 @@ from fprime_python_model.translators.construct_ast_id_map import ConstructAstMap
 from fprime_python_model.fpp_ast.fpp_ast import TransUnit
 from fprime_python_model.fpp_ast.fpp_locations import Location
 from fprime_python_model.semantics.analysis import Analysis
-
-MIN_FPP_VERSION = Version("3.1.0a10")
+from fprime_python_model.fpp_version import check_version
 
 
 class FprimePythonModel:
@@ -47,21 +46,24 @@ class FprimePythonModel:
                 data = json.load(f)
                 # Remove leading "v" and git hash
                 version_string = str(data["fppVersion"]).lstrip("v").split("-")[0]
-                fpp_version = Version(version_string)
-                if fpp_version < MIN_FPP_VERSION:
-                    raise ValueError(
-                        f'JSON file "{file}" was generated with an incompatible FPP version ({fpp_version}). '
-                        f"Minimum supported is {MIN_FPP_VERSION}."
-                    )
+                check_version(
+                    version_string,
+                    f'JSON file "{file}" was generated with an incompatible version of FPP ({version_string}).',
+                )
 
     def _load(self):
         self._location_map = translate_location_map_json(self.fpp_locations_json_file)
-        self._ast = translate_ast_json(self.fpp_ast_json_file)
+        self._ast = AstTranslator(
+            self.fpp_ast_json_file, self.location_map
+        ).translate_ast_json()
         self._ast_id_map, self._annotated_ast_id_map = (
             ConstructAstMap().construct_ast_map(self._ast)
         )
         self._analysis = AnalysisTranslator(
-            self._ast_id_map, self._annotated_ast_id_map, self.fpp_analysis_json_file
+            self.ast_id_map,
+            self.annotated_ast_id_map,
+            self.fpp_analysis_json_file,
+            self.location_map,
         ).translate_analysis_json()
 
     @property
@@ -85,4 +87,4 @@ class FprimePythonModel:
         return self._ast_id_map
 
     def get_location(self, node: AstNode) -> Location:
-        return self.location_map[node._id]
+        return self.location_map[node.get_id()]

--- a/fprime_python_model/model.py
+++ b/fprime_python_model/model.py
@@ -1,3 +1,5 @@
+import json
+from packaging.version import Version
 from typing import Dict, List
 from fprime_python_model.fpp_ast.fpp_ast_node import AstNode, AstId
 from fprime_python_model.fpp_ast.fpp_ast import Annotated
@@ -10,6 +12,8 @@ from fprime_python_model.translators.construct_ast_id_map import ConstructAstMap
 from fprime_python_model.fpp_ast.fpp_ast import TransUnit
 from fprime_python_model.fpp_ast.fpp_locations import Location
 from fprime_python_model.semantics.analysis import Analysis
+
+MIN_FPP_VERSION = Version("3.1.0a10")
 
 
 class FprimePythonModel:
@@ -29,7 +33,26 @@ class FprimePythonModel:
         self._location_map: Dict[int, Location] = dict()
         self._analysis: Analysis = Analysis()
 
+        self._check_fpp_version()
         self._load()
+
+    def _check_fpp_version(self):
+        json_files = [
+            self.fpp_ast_json_file,
+            self.fpp_locations_json_file,
+            self.fpp_analysis_json_file,
+        ]
+        for file in json_files:
+            with open(file, "r") as f:
+                data = json.load(f)
+                # Remove leading "v" and git hash
+                version_string = str(data["fppVersion"]).lstrip("v").split("-")[0]
+                fpp_version = Version(version_string)
+                if fpp_version < MIN_FPP_VERSION:
+                    raise ValueError(
+                        f'JSON file "{file}" was generated with an incompatible FPP version ({fpp_version}). '
+                        f"Minimum supported is {MIN_FPP_VERSION}."
+                    )
 
     def _load(self):
         self._location_map = translate_location_map_json(self.fpp_locations_json_file)

--- a/fprime_python_model/semantics/event.py
+++ b/fprime_python_model/semantics/event.py
@@ -8,6 +8,18 @@ EventId: TypeAlias = int
 
 
 @dataclass
+class TimeInterval:
+    seconds: int
+    useconds: int
+
+
+@dataclass
+class Throttle:
+    count: int
+    every: Optional[TimeInterval]
+
+
+@dataclass
 class Event:
     """
     An FPP event
@@ -22,7 +34,7 @@ class Event:
 
     a_node: fpp_ast.Annotated[AstNode[fpp_ast.SpecEvent]]
     format: Format
-    throttle: Optional[int]
+    throttle: Optional[Throttle]
 
     def get_name(self) -> fpp_ast.Ident:
         """

--- a/fprime_python_model/semantics/name_group.py
+++ b/fprime_python_model/semantics/name_group.py
@@ -3,14 +3,17 @@ from typing import List
 
 
 class NameGroup(Enum):
-    COMPONENT_INSTANCE = "ComponentInstance"
-    COMPONENT = "Component"
-    PORT = "Port"
-    STATE_MACHINE = "StateMachine"
-    TOPOLOGY = "Topology"
-    INTERFACE = "Interface"
-    TYPE = "Type"
-    VALUE = "Value"
+    COMPONENT_INSTANCE = "component instance"
+    COMPONENT = "component"
+    PORT = "port"
+    STATE_MACHINE = "state machine"
+    TOPOLOGY = "topology"
+    INTERFACE = "interface"
+    TYPE = "type"
+    VALUE = "constant"
+
+    def __str__(self):
+        return self.value
 
 
 name_groups: List[NameGroup] = [

--- a/fprime_python_model/semantics/state_machine_name_group.py
+++ b/fprime_python_model/semantics/state_machine_name_group.py
@@ -3,10 +3,13 @@ from typing import List
 
 
 class StateMachineNameGroup(Enum):
-    ACTION = "Action"
-    GUARD = "Guard"
-    SIGNAL = "Signal"
-    STATE = "State"
+    ACTION = "action"
+    GUARD = "guard"
+    SIGNAL = "signal"
+    STATE = "state"
+
+    def __str__(self):
+        return self.value
 
 
 name_groups: List[StateMachineNameGroup] = [

--- a/fprime_python_model/semantics/symbol.py
+++ b/fprime_python_model/semantics/symbol.py
@@ -5,7 +5,9 @@ from fprime_python_model.fpp_ast.fpp_ast_node import AstNode
 
 
 class Symbol(SymbolInterface):
-    pass
+
+    def is_dictionary_def(self):
+        return False
 
 
 @dataclass
@@ -29,6 +31,9 @@ class AliasTypeSymbol(Symbol):
     def get_unqualified_name(self):
         return self.node[1].data.name
 
+    def is_dictionary_def(self):
+        return self.node[1].data.is_dictionary_def
+
 
 @dataclass
 class ArraySymbol(Symbol):
@@ -39,6 +44,9 @@ class ArraySymbol(Symbol):
 
     def get_unqualified_name(self):
         return self.node[1].data.name
+
+    def is_dictionary_def(self):
+        return self.node[1].data.is_dictionary_def
 
 
 @dataclass
@@ -73,6 +81,9 @@ class ConstantSymbol(Symbol):
     def get_unqualified_name(self):
         return self.node[1].data.name
 
+    def is_dictionary_def(self):
+        return self.node[1].data.is_dictionary_def
+
 
 @dataclass
 class EnumSymbol(Symbol):
@@ -83,6 +94,9 @@ class EnumSymbol(Symbol):
 
     def get_unqualified_name(self):
         return self.node[1].data.name
+
+    def is_dictionary_def(self):
+        return self.node[1].data.is_dictionary_def
 
 
 @dataclass
@@ -149,6 +163,9 @@ class StructSymbol(Symbol):
 
     def get_unqualified_name(self):
         return self.node[1].data.name
+
+    def is_dictionary_def(self):
+        return self.node[1].data.is_dictionary_def
 
 
 @dataclass

--- a/fprime_python_model/translators/analysis_translator.py
+++ b/fprime_python_model/translators/analysis_translator.py
@@ -177,12 +177,14 @@ class AnalysisTranslator:
         ast_map: Dict[AstId, AstNode],
         annotated_ast_map: Dict[AstId, fpp_ast.Annotated[AstNode]],
         analysis_json_file: str,
+        location_map: Dict[AstId, Location],
     ):
         self.ast_map: Dict[AstId, AstNode] = ast_map
         self.annotated_ast_map: Dict[AstId, fpp_ast.Annotated[AstNode]] = (
             annotated_ast_map
         )
         self.analysis_json_file: str = analysis_json_file
+        self.location_map = location_map
 
         self.component_map: Dict[AstId, Component] = dict()
         self.component_instance_map: Dict[AstId, ComponentInstance] = dict()
@@ -259,7 +261,9 @@ class AnalysisTranslator:
             case "Topology":
                 return TopologySymbol(a_node)
             case _:
-                raise InvalidFppToJsonField(symbol_type)
+                raise InvalidFppToJsonField(
+                    symbol_type, self.location_map.get(node_id, None)
+                )
 
     def translate_state_machine_symbol(
         self, symbol_type: str, node_id: AstId
@@ -277,7 +281,9 @@ class AnalysisTranslator:
             case "Guard":
                 return GuardSymbol(a_node)
             case _:
-                raise InvalidFppToJsonField(symbol_type)
+                raise InvalidFppToJsonField(
+                    symbol_type, self.location_map.get(node_id, None)
+                )
 
     def get_symbol_type_from_node(self, a_node: fpp_ast.Annotated[AstNode[T]]) -> str:
         _, node, _ = a_node
@@ -724,7 +730,9 @@ class AnalysisTranslator:
                 )
                 return InternalPortInstance(a_node, priority, queue_full)
             case _:
-                raise InvalidFppToJsonField(p_type)
+                raise InvalidFppToJsonField(
+                    p_type, self.location_map.get(a_node[1].get_id(), None)
+                )
 
     def translate_special_port_instance(
         self, d: Dict[str, dict]

--- a/fprime_python_model/translators/analysis_translator.py
+++ b/fprime_python_model/translators/analysis_translator.py
@@ -107,7 +107,7 @@ from fprime_python_model.translators.ast_translator import (
     translate_pattern_kind,
 )
 from fprime_python_model.semantics.tlm_channel import TlmChannel, TlmChannelId, Limits
-from fprime_python_model.semantics.event import Event, EventId
+from fprime_python_model.semantics.event import Event, EventId, Throttle, TimeInterval
 from fprime_python_model.semantics.param import Param, ParamId
 from fprime_python_model.semantics.state_machine_instance import StateMachineInstance
 from fprime_python_model.semantics.container import Container, ContainerId
@@ -368,7 +368,7 @@ class AnalysisTranslator:
             case "Value":
                 return NameGroup.VALUE
             case _:
-                raise InternalError("Encountered invalid name group.")
+                raise InternalError(f"Encountered invalid name group {ng}.")
 
     def translate_scope(self, d: Dict[str, dict]) -> Scope:
         scope = Scope()
@@ -788,11 +788,23 @@ class AnalysisTranslator:
         low_limits = self.translate_limits(d["lowLimits"])
         high_limits = self.translate_limits(d["highLimits"])
         return TlmChannel(a_node, c_type, update, format, low_limits, high_limits)
+    
+    def translate_time_interval(self, d: Dict[str, int]) -> TimeInterval:
+        return TimeInterval(
+            d["seconds"],
+            d["useconds"]
+        )
+
+    def translate_throttle(self, d: Dict[str, dict]) -> Throttle:
+        return Throttle(
+            d["count"],
+            self.translate_optional(d["every"], self.translate_time_interval)
+        )
 
     def translate_event(self, d: Dict[str, dict]) -> Event:
         a_node = self.get_annotated_ast_node_by_id(int(d["aNode"]["astNodeId"]))
         format = self.translate_format(d["format"])
-        throttle = self.translate_optional(d["throttle"], int)
+        throttle = self.translate_optional(d["throttle"], self.translate_throttle)
         return Event(a_node, format, throttle)
 
     def translate_param(self, d: Dict[str, dict]) -> Param:

--- a/fprime_python_model/translators/analysis_translator.py
+++ b/fprime_python_model/translators/analysis_translator.py
@@ -788,17 +788,14 @@ class AnalysisTranslator:
         low_limits = self.translate_limits(d["lowLimits"])
         high_limits = self.translate_limits(d["highLimits"])
         return TlmChannel(a_node, c_type, update, format, low_limits, high_limits)
-    
+
     def translate_time_interval(self, d: Dict[str, int]) -> TimeInterval:
-        return TimeInterval(
-            d["seconds"],
-            d["useconds"]
-        )
+        return TimeInterval(d["seconds"], d["useconds"])
 
     def translate_throttle(self, d: Dict[str, dict]) -> Throttle:
         return Throttle(
             d["count"],
-            self.translate_optional(d["every"], self.translate_time_interval)
+            self.translate_optional(d["every"], self.translate_time_interval),
         )
 
     def translate_event(self, d: Dict[str, dict]) -> Event:

--- a/fprime_python_model/translators/analysis_translator.py
+++ b/fprime_python_model/translators/analysis_translator.py
@@ -223,12 +223,8 @@ class AnalysisTranslator:
             qual_name_json: Dict = ls[0][1]
             spec_loc_kind = translate_spec_loc_kind(kind_json)
             spec_loc_qualified_name = self.translate_qualified_name(qual_name_json)
-            spec_loc = fpp_ast.SpecLoc(
-                translate_spec_loc_kind(ls[1]["kind"]),
-                self.ast_map[ls[1]["symbol"]["astNodeId"]],
-                self.ast_map[ls[1]["file"]["astNodeId"]],
-            )
-            out_dict[(spec_loc_kind, spec_loc_qualified_name)] = spec_loc
+            spec_loc_a_node = self.get_annotated_ast_node_by_id(ls[1]["astNodeId"])
+            out_dict[(spec_loc_kind, spec_loc_qualified_name)] = spec_loc_a_node[1].data
         return out_dict
 
     def translate_symbol(self, symbol_type: str, node_id: AstId) -> Symbol:
@@ -794,7 +790,7 @@ class AnalysisTranslator:
 
     def translate_throttle(self, d: Dict[str, dict]) -> Throttle:
         return Throttle(
-            d["count"],
+            self.require_type(d["count"], int),
             self.translate_optional(d["every"], self.translate_time_interval),
         )
 

--- a/fprime_python_model/translators/ast_translator.py
+++ b/fprime_python_model/translators/ast_translator.py
@@ -108,6 +108,14 @@ def translate_expr(expr_dict: dict) -> AstNode[fpp_ast.Expr]:
         for e in data["ExprArray"]["elts"]:
             elts.append(translate_expr(e))
         return AstNode.create_with_id(fpp_ast.ExprArray(elts), id)
+    elif "ExprArraySubscript" in data:
+        return AstNode.create_with_id(
+            fpp_ast.ExprArraySubscript(
+                translate_expr(data["ExprArraySubscript"]["e1"]),
+                translate_expr(data["ExprArraySubscript"]["e2"]),
+            ),
+            id,
+        )
     elif "ExprBinop" in data:
         return AstNode.create_with_id(
             fpp_ast.ExprBinop(
@@ -172,6 +180,16 @@ def translate_expr(expr_dict: dict) -> AstNode[fpp_ast.Expr]:
         )
     else:
         raise InvalidFppToJsonDictionary("expression", expr_dict)
+
+
+def translate_throttle(d: Dict[str, dict]) -> AstNode[fpp_ast.EventThrottle]:
+    return AstNode.create_with_id(
+        fpp_ast.EventThrottle(
+            translate_expr(d["AstNode"]["data"]["count"]),
+            translate_optional(d["AstNode"]["data"]["every"], translate_expr),
+        ),
+        d["AstNode"]["id"],
+    )
 
 
 def translate_transition_expr(te: dict) -> AstNode[fpp_ast.TransitionExpr]:
@@ -293,7 +311,9 @@ def translate_def_abs_type(data: dict, id: AstId) -> AstNode[fpp_ast.DefAbsType]
 
 def translate_def_alias_type(data: dict, id: AstId) -> AstNode[fpp_ast.DefAliasType]:
     return AstNode.create_with_id(
-        fpp_ast.DefAliasType(data["name"], translate_type_name(data["typeName"])),
+        fpp_ast.DefAliasType(
+            data["name"], translate_type_name(data["typeName"]), data["isDictionaryDef"]
+        ),
         id,
     )
 
@@ -306,6 +326,7 @@ def translate_def_array(data: dict, id: AstId) -> AstNode[fpp_ast.DefArray]:
             translate_type_name(data["eltType"]),
             translate_optional(data["default"], translate_expr),
             translate_optional(data["format"], translate_string),
+            data["isDictionaryDef"],
         ),
         id,
     )
@@ -313,7 +334,10 @@ def translate_def_array(data: dict, id: AstId) -> AstNode[fpp_ast.DefArray]:
 
 def translate_def_constant(data: dict, id: AstId) -> AstNode[fpp_ast.DefConstant]:
     return AstNode.create_with_id(
-        fpp_ast.DefConstant(data["name"], translate_expr(data["value"])), id
+        fpp_ast.DefConstant(
+            data["name"], translate_expr(data["value"]), data["isDictionaryDef"]
+        ),
+        id,
     )
 
 
@@ -336,6 +360,7 @@ def translate_def_enum(data: dict, id: AstId) -> AstNode[fpp_ast.DefEnum]:
             translate_optional(data["typeName"], translate_type_name),
             constants,
             translate_optional(data["default"], translate_expr),
+            data["isDictionaryDef"],
         ),
         id,
     )
@@ -360,6 +385,7 @@ def translate_def_struct(data: dict, id: AstId) -> AstNode[fpp_ast.DefStruct]:
             data["name"],
             struct_members,
             translate_optional(data["default"], translate_expr),
+            data["isDictionaryDef"],
         ),
         id,
     )
@@ -449,7 +475,7 @@ def translate_component_members(l: list) -> List[fpp_ast.ComponentMember]:
                             translate_severity(data["severity"]),
                             translate_optional(data["id"], translate_expr),
                             translate_string(data["format"]),
-                            translate_optional(data["throttle"], translate_expr),
+                            translate_optional(data["throttle"], translate_throttle),
                         ),
                         id,
                     )

--- a/fprime_python_model/translators/ast_translator.py
+++ b/fprime_python_model/translators/ast_translator.py
@@ -1,6 +1,7 @@
 import json
 from typing import Dict, List, Callable, Any, Tuple, Optional
 import os
+from fprime_python_model.fpp_ast.fpp_locations import Location
 from fprime_python_model.fpp_ast import fpp_ast
 from fprime_python_model.fpp_ast.fpp_ast_node import AstNode, AstId
 from fprime_python_model.utils.error import (
@@ -11,631 +12,17 @@ from fprime_python_model.utils.error import (
 from fprime_python_model.utils.error import InternalError
 
 
-def read_ast_node(a_node: dict) -> Tuple[Any, AstId]:
-    return a_node["AstNode"]["data"], a_node["AstNode"]["id"]
-
-
-def translate_string(d: dict) -> AstNode[str]:
-    data, id = read_ast_node(d)
-    return AstNode.create_with_id(data, id)
-
-
-def translate_ident(d: dict) -> AstNode[fpp_ast.Ident]:
-    data, id = read_ast_node(d)
-    return AstNode.create_with_id(fpp_ast.Ident(data), id)
-
-
-def translate_qual_ident(d: dict) -> AstNode[fpp_ast.QualIdent]:
-    data, id = read_ast_node(d)
-    if data.get("Unqualified"):
-        return AstNode.create_with_id(
-            fpp_ast.Unqualified(data["Unqualified"]["name"]), id
-        )
-    elif data.get("Qualified"):
-        qualified = data["Qualified"]
-        qualifier_dict = qualified["qualifier"]
-        return AstNode.create_with_id(
-            fpp_ast.Qualified(
-                translate_qual_ident(qualifier_dict), translate_ident(qualified["name"])
-            ),
-            id,
-        )
+def get_queue_full(d: dict) -> fpp_ast.QueueFull:
+    if "Assert" in d:
+        return fpp_ast.QueueFull.ASSERT
+    elif "Block" in d:
+        return fpp_ast.QueueFull.BLOCK
+    elif "Drop" in d:
+        return fpp_ast.QueueFull.DROP
+    elif "Hook" in d:
+        return fpp_ast.QueueFull.HOOK
     else:
-        raise InternalError("Could not translate qualified identifier")
-
-
-def translate_formal_params(params_list: List) -> fpp_ast.FormalParamList:
-    params = []
-    for p in params_list:
-        node = p[1]
-        data, id = read_ast_node(node)
-        name = data["name"]
-        kind = fpp_ast.FormalParamKind.REF
-        if "Value" in data["kind"]:
-            kind = fpp_ast.FormalParamKind.VALUE
-        type_name_node = translate_type_name(data["typeName"])
-        formal_param = fpp_ast.FormalParam(kind, name, type_name_node)
-        param_ast_node = AstNode.create_with_id(formal_param, id)
-        params.append(annotate(p[0], param_ast_node, p[2]))
-    return params
-
-
-def translate_type_name(tn: dict) -> AstNode[fpp_ast.TypeName]:
-    data, id = read_ast_node(tn)
-    if "TypeNameFloat" in data:
-        name = list(data["TypeNameFloat"]["name"].keys())[0]
-        return AstNode.create_with_id(fpp_ast.TypeNameFloat(name), id)
-    elif "TypeNameInt" in data:
-        name = list(data["TypeNameInt"]["name"].keys())[0]
-        return AstNode.create_with_id(fpp_ast.TypeNameInt(name), id)
-    elif "TypeNameQualIdent" in data:
-        return AstNode.create_with_id(
-            fpp_ast.TypeNameQualIdent(
-                translate_qual_ident(data["TypeNameQualIdent"]["name"])
-            ),
-            id,
-        )
-    elif "TypeNameBool" in data:
-        return AstNode.create_with_id(fpp_ast.TypeNameBool(), id)
-    elif "TypeNameString" in data:
-        return AstNode.create_with_id(
-            fpp_ast.TypeNameString(
-                translate_optional(data["TypeNameString"]["size"], translate_expr)
-            ),
-            id,
-        )
-    else:
-        raise Exception(f"Invalid type name dictionary {data}")
-
-
-def translate_binop(d: dict) -> fpp_ast.Binop:
-    if "Add" in d:
-        return fpp_ast.Binop.ADD
-    elif "Sub" in d:
-        return fpp_ast.Binop.SUB
-    elif "Mul" in d:
-        return fpp_ast.Binop.MUL
-    elif "Div" in d:
-        return fpp_ast.Binop.DIV
-    else:
-        raise Exception(f"Invalid Binop JSON {d}")
-
-
-def translate_expr(expr_dict: dict) -> AstNode[fpp_ast.Expr]:
-    data, id = read_ast_node(expr_dict)
-    if "ExprArray" in data:
-        elts = []
-        for e in data["ExprArray"]["elts"]:
-            elts.append(translate_expr(e))
-        return AstNode.create_with_id(fpp_ast.ExprArray(elts), id)
-    elif "ExprArraySubscript" in data:
-        return AstNode.create_with_id(
-            fpp_ast.ExprArraySubscript(
-                translate_expr(data["ExprArraySubscript"]["e1"]),
-                translate_expr(data["ExprArraySubscript"]["e2"]),
-            ),
-            id,
-        )
-    elif "ExprBinop" in data:
-        return AstNode.create_with_id(
-            fpp_ast.ExprBinop(
-                translate_expr(data["ExprBinop"]["e1"]),
-                translate_binop(data["ExprBinop"]["op"]),
-                translate_expr(data["ExprBinop"]["e2"]),
-            ),
-            id,
-        )
-    elif "ExprDot" in data:
-        return AstNode.create_with_id(
-            fpp_ast.ExprDot(
-                translate_expr(data["ExprDot"]["e"]),
-                translate_ident(data["ExprDot"]["id"]),
-            ),
-            id,
-        )
-    elif "ExprIdent" in data:
-        return AstNode.create_with_id(fpp_ast.ExprIdent(data["ExprIdent"]["value"]), id)
-    elif "ExprLiteralBool" in data:
-        if "True" in data["ExprLiteralBool"]["value"]:
-            literal_bool = fpp_ast.LiteralBool.TRUE
-        else:
-            literal_bool = fpp_ast.LiteralBool.FALSE
-        return AstNode.create_with_id(fpp_ast.ExprLiteralBool(literal_bool), id)
-    elif "ExprLiteralInt" in data:
-        return AstNode.create_with_id(
-            fpp_ast.ExprLiteralInt(data["ExprLiteralInt"]["value"]), id
-        )
-    elif "ExprLiteralFloat" in data:
-        return AstNode.create_with_id(
-            fpp_ast.ExprLiteralFloat(data["ExprLiteralFloat"]["value"]), id
-        )
-    elif "ExprLiteralString" in data:
-        return AstNode.create_with_id(
-            fpp_ast.ExprLiteralString(data["ExprLiteralString"]["value"]), id
-        )
-    elif "ExprParen" in data:
-        return AstNode.create_with_id(
-            fpp_ast.ExprParen(
-                translate_expr(data["ExprParen"]["e"]),
-            ),
-            id,
-        )
-    elif "ExprStruct" in data:
-        members = []
-        for m in data["ExprStruct"]["members"]:
-            members.append(
-                AstNode.create_with_id(
-                    fpp_ast.StructMember(
-                        m["AstNode"]["data"]["name"],
-                        translate_expr(m["AstNode"]["data"]["value"]),
-                    ),
-                    m["AstNode"]["id"],
-                )
-            )
-        return AstNode.create_with_id(fpp_ast.ExprStruct(members), id)
-    elif "ExprUnop" in data:
-        return AstNode.create_with_id(
-            fpp_ast.ExprUnop(fpp_ast.Unop.MINUS, translate_expr(data["ExprUnop"]["e"])),
-            id,
-        )
-    else:
-        raise InvalidFppToJsonDictionary("expression", expr_dict)
-
-
-def translate_throttle(d: Dict[str, dict]) -> AstNode[fpp_ast.EventThrottle]:
-    return AstNode.create_with_id(
-        fpp_ast.EventThrottle(
-            translate_expr(d["AstNode"]["data"]["count"]),
-            translate_optional(d["AstNode"]["data"]["every"], translate_expr),
-        ),
-        d["AstNode"]["id"],
-    )
-
-
-def translate_transition_expr(te: dict) -> AstNode[fpp_ast.TransitionExpr]:
-    data, id = read_ast_node(te)
-    return AstNode.create_with_id(
-        fpp_ast.TransitionExpr(
-            translate_actions(data["actions"]), translate_qual_ident(data["target"])
-        ),
-        id,
-    )
-
-
-def translate_transition_or_do(t: dict) -> fpp_ast.TransitionOrDo:
-    if "Transition" in t:
-        return fpp_ast.Transition(
-            translate_transition_expr(t["Transition"]["transition"])
-        )
-    elif "Do" in t:
-        return fpp_ast.Do(translate_actions(t["Do"]["actions"]))
-    else:
-        raise InvalidFppToJsonDictionary("Transition or Do", t)
-
-
-def translate_actions(l: List) -> List[AstNode[fpp_ast.Ident]]:
-    actions = []
-    for a in l:
-        actions.append(translate_ident(a))
-    return actions
-
-
-def annotate(l1: List[str], d: fpp_ast.T, l2: List[str]) -> fpp_ast.Annotated:
-    return (l1, d, l2)
-
-
-def translate_limit_kind(d: dict) -> AstNode[fpp_ast.LimitKind]:
-    data, id = read_ast_node(d)
-    limit_kind = fpp_ast.LimitKind.RED
-    if "Yellow" in data:
-        limit_kind = fpp_ast.LimitKind.YELLOW
-    elif "Orange" in data:
-        limit_kind = fpp_ast.LimitKind.ORANGE
-    elif "Red" in data:
-        limit_kind = fpp_ast.LimitKind.RED
-    else:
-        raise InvalidFppToJsonDictionary("limit kind", d)
-    return AstNode.create_with_id(limit_kind, id)
-
-
-def translate_spec_tlm_channel_update(d: dict) -> fpp_ast.SpecTlmChannelUpdate:
-    if "Always" in d:
-        return fpp_ast.SpecTlmChannelUpdate.ALWAYS
-    elif "OnChange" in d:
-        return fpp_ast.SpecTlmChannelUpdate.ON_CHANGE
-    else:
-        raise InvalidFppToJsonDictionary("telemetry channel update", d)
-
-
-def translate_limits(l: List) -> List[fpp_ast.Limit]:
-    limits = []
-    for e in l:
-        limits.append((translate_limit_kind(e[0]), translate_expr(e[1])))
-    return limits
-
-
-def translate_spec_loc_kind(d: dict) -> fpp_ast.SpecLocKind:
-    if "Component" in d:
-        return fpp_ast.SpecLocKind.COMPONENT
-    elif "ComponentInstance" in d:
-        return fpp_ast.SpecLocKind.COMPONENT_INSTANCE
-    elif "Constant" in d:
-        return fpp_ast.SpecLocKind.CONSTANT
-    elif "Port" in d:
-        return fpp_ast.SpecLocKind.PORT
-    elif "StateMachine" in d:
-        return fpp_ast.SpecLocKind.STATE_MACHINE
-    elif "Topology" in d:
-        return fpp_ast.SpecLocKind.TOPOLOGY
-    elif "Type" in d:
-        return fpp_ast.SpecLocKind.TYPE
-    elif "Interface" in d:
-        return fpp_ast.SpecLocKind.INTERFACE
-    else:
-        raise InvalidFppToJsonDictionary("spec loc kind", d)
-
-
-def translate_spec_command_kind(d: dict) -> fpp_ast.SpecCommandKind:
-    if "Async" in d:
-        return fpp_ast.SpecCommandKind.ASYNC
-    elif "Sync" in d:
-        return fpp_ast.SpecCommandKind.SYNC
-    elif "Guarded" in d:
-        return fpp_ast.SpecCommandKind.GUARDED
-    else:
-        raise InvalidFppToJsonDictionary("command kind", d)
-
-
-def translate_severity(d: dict) -> fpp_ast.SpecEventSeverity:
-    if "ActivityHigh" in d:
-        return fpp_ast.SpecEventSeverity.ACTIVITY_HIGH
-    elif "ActivityLow" in d:
-        return fpp_ast.SpecEventSeverity.ACTIVITY_LOW
-    elif "Command" in d:
-        return fpp_ast.SpecEventSeverity.COMMAND
-    elif "Diagnostic" in d:
-        return fpp_ast.SpecEventSeverity.DIAGNOSTIC
-    elif "Fatal" in d:
-        return fpp_ast.SpecEventSeverity.FATAL
-    elif "WarningHigh" in d:
-        return fpp_ast.SpecEventSeverity.WARNING_HIGH
-    elif "WarningLow" in d:
-        return fpp_ast.SpecEventSeverity.WARNING_LOW
-    else:
-        raise InvalidFppToJsonDictionary("event severity", d)
-
-
-def translate_def_abs_type(data: dict, id: AstId) -> AstNode[fpp_ast.DefAbsType]:
-    return AstNode.create_with_id(fpp_ast.DefAbsType(data["name"]), id)
-
-
-def translate_def_alias_type(data: dict, id: AstId) -> AstNode[fpp_ast.DefAliasType]:
-    return AstNode.create_with_id(
-        fpp_ast.DefAliasType(
-            data["name"], translate_type_name(data["typeName"]), data["isDictionaryDef"]
-        ),
-        id,
-    )
-
-
-def translate_def_array(data: dict, id: AstId) -> AstNode[fpp_ast.DefArray]:
-    return AstNode.create_with_id(
-        fpp_ast.DefArray(
-            data["name"],
-            translate_expr(data["size"]),
-            translate_type_name(data["eltType"]),
-            translate_optional(data["default"], translate_expr),
-            translate_optional(data["format"], translate_string),
-            data["isDictionaryDef"],
-        ),
-        id,
-    )
-
-
-def translate_def_constant(data: dict, id: AstId) -> AstNode[fpp_ast.DefConstant]:
-    return AstNode.create_with_id(
-        fpp_ast.DefConstant(
-            data["name"], translate_expr(data["value"]), data["isDictionaryDef"]
-        ),
-        id,
-    )
-
-
-def translate_def_enum(data: dict, id: AstId) -> AstNode[fpp_ast.DefEnum]:
-    constants = []
-    for c in data["constants"]:
-        const = c[1]
-        const_data, const_id = read_ast_node(const)
-        node = AstNode.create_with_id(
-            fpp_ast.DefEnumConstant(
-                const_data["name"],
-                translate_optional(const_data["value"], translate_expr),
-            ),
-            const_id,
-        )
-        constants.append(annotate(c[0], node, c[2]))
-    return AstNode.create_with_id(
-        fpp_ast.DefEnum(
-            data["name"],
-            translate_optional(data["typeName"], translate_type_name),
-            constants,
-            translate_optional(data["default"], translate_expr),
-            data["isDictionaryDef"],
-        ),
-        id,
-    )
-
-
-def translate_def_struct(data: dict, id: AstId) -> AstNode[fpp_ast.DefStruct]:
-    struct_members = []
-    for m in data["members"]:
-        member_data, member_id = read_ast_node(m[1])
-        node = AstNode.create_with_id(
-            fpp_ast.StructTypeMember(
-                member_data["name"],
-                translate_optional(member_data["size"], translate_expr),
-                translate_type_name(member_data["typeName"]),
-                translate_optional(member_data["format"], translate_string),
-            ),
-            member_id,
-        )
-        struct_members.append(annotate(m[0], node, m[2]))
-    return AstNode.create_with_id(
-        fpp_ast.DefStruct(
-            data["name"],
-            struct_members,
-            translate_optional(data["default"], translate_expr),
-            data["isDictionaryDef"],
-        ),
-        id,
-    )
-
-
-def translate_component_members(l: list) -> List[fpp_ast.ComponentMember]:
-    members = []
-    for m in l:
-        m_dict: dict = m[1]
-        m_key = list(m_dict.keys())[0]
-        data, id = read_ast_node(m_dict[m_key]["node"])
-        member: Optional[fpp_ast.ComponentMemberNode] = None
-        match m_key:
-            case "DefAbsType":
-                member = fpp_ast.ComponentMemberDefAbsType(
-                    translate_def_abs_type(data, id)
-                )
-            case "DefAliasType":
-                member = fpp_ast.ComponentMemberDefAliasType(
-                    translate_def_alias_type(data, id)
-                )
-            case "DefArray":
-                member = fpp_ast.ComponentMemberDefArray(translate_def_array(data, id))
-            case "DefConstant":
-                member = fpp_ast.ComponentMemberDefConstant(
-                    translate_def_constant(data, id)
-                )
-            case "DefEnum":
-                member = fpp_ast.ComponentMemberDefEnum(translate_def_enum(data, id))
-            case "DefStruct":
-                member = fpp_ast.ComponentMemberDefStruct(
-                    translate_def_struct(data, id)
-                )
-            case "DefStateMachine":
-                member = fpp_ast.ComponentMemberDefStateMachine(
-                    translate_state_machine(data, id)
-                )
-            case "SpecStateMachineInstance":
-                member = fpp_ast.ComponentMemberSpecStateMachineInstance(
-                    AstNode.create_with_id(
-                        fpp_ast.SpecStateMachineInstance(
-                            data["name"],
-                            translate_qual_ident(data["stateMachine"]),
-                            translate_optional(data["priority"], translate_expr),
-                            translate_optional(data["queueFull"], get_queue_full),
-                        ),
-                        id,
-                    )
-                )
-            case "SpecCommand":
-                member = fpp_ast.ComponentMemberSpecCommand(
-                    AstNode.create_with_id(
-                        fpp_ast.SpecCommand(
-                            translate_spec_command_kind(data["kind"]),
-                            data["name"],
-                            translate_formal_params(data["params"]),
-                            translate_optional(data["opcode"], translate_expr),
-                            translate_optional(data["priority"], translate_expr),
-                            translate_optional(data["queueFull"], translate_queue_full),
-                        ),
-                        id,
-                    )
-                )
-            case "SpecTlmChannel":
-                member = fpp_ast.ComponentMemberSpecTlmChannel(
-                    AstNode.create_with_id(
-                        fpp_ast.SpecTlmChannel(
-                            data["name"],
-                            translate_type_name(data["typeName"]),
-                            translate_optional(data["id"], translate_expr),
-                            translate_optional(
-                                data["update"], translate_spec_tlm_channel_update
-                            ),
-                            translate_optional(data["format"], translate_string),
-                            translate_limits(data["low"]),
-                            translate_limits(data["high"]),
-                        ),
-                        id,
-                    )
-                )
-            case "SpecEvent":
-                member = fpp_ast.ComponentMemberSpecEvent(
-                    AstNode.create_with_id(
-                        fpp_ast.SpecEvent(
-                            data["name"],
-                            translate_formal_params(data["params"]),
-                            translate_severity(data["severity"]),
-                            translate_optional(data["id"], translate_expr),
-                            translate_string(data["format"]),
-                            translate_optional(data["throttle"], translate_throttle),
-                        ),
-                        id,
-                    )
-                )
-            case "SpecRecord":
-                member = fpp_ast.ComponentMemberSpecRecord(
-                    AstNode.create_with_id(
-                        fpp_ast.SpecRecord(
-                            data["name"],
-                            translate_type_name(data["recordType"]),
-                            data["isArray"],
-                            translate_optional(data["id"], translate_expr),
-                        ),
-                        id,
-                    )
-                )
-            case "SpecContainer":
-                member = fpp_ast.ComponentMemberSpecContainer(
-                    AstNode.create_with_id(
-                        fpp_ast.SpecContainer(
-                            data["name"],
-                            translate_optional(data["id"], translate_expr),
-                            translate_optional(data["defaultPriority"], translate_expr),
-                        ),
-                        id,
-                    )
-                )
-            case "SpecParam":
-                member = fpp_ast.ComponentMemberSpecParam(
-                    AstNode.create_with_id(
-                        fpp_ast.SpecParam(
-                            data["name"],
-                            translate_type_name(data["typeName"]),
-                            translate_optional(data["default"], translate_expr),
-                            translate_optional(data["id"], translate_expr),
-                            translate_optional(data["setOpcode"], translate_expr),
-                            translate_optional(data["saveOpcode"], translate_expr),
-                            data["isExternal"],
-                        ),
-                        id,
-                    )
-                )
-            case "SpecPortMatching":
-                member = fpp_ast.ComponentMemberSpecPortMatching(
-                    AstNode.create_with_id(
-                        fpp_ast.SpecPortMatching(
-                            translate_ident(data["port1"]),
-                            translate_ident(data["port2"]),
-                        ),
-                        id,
-                    )
-                )
-            case "SpecInternalPort":
-                member = fpp_ast.ComponentMemberSpecInternalPort(
-                    AstNode.create_with_id(
-                        fpp_ast.SpecInternalPort(
-                            data["name"],
-                            translate_formal_params(data["params"]),
-                            translate_optional(data["priority"], translate_expr),
-                            translate_optional(data["queueFull"], get_queue_full),
-                        ),
-                        id,
-                    )
-                )
-            case "SpecPortInstance":
-                member = fpp_ast.ComponentMemberSpecPortInstance(
-                    AstNode.create_with_id(translate_port_instance(data), id)
-                )
-            case "SpecImportInterface":
-                member = fpp_ast.ComponentMemberSpecImportInterface(
-                    AstNode.create_with_id(
-                        fpp_ast.SpecImport(translate_qual_ident(data["sym"])), id
-                    )
-                )
-            case _:
-                raise InvalidFppToJsonField(m_key)
-        members.append(fpp_ast.ComponentMember(annotate(m[0], member, m[2])))
-    return members
-
-
-def translate_state_members(l: List) -> List[fpp_ast.StateMember]:
-    members = []
-    for m in l:
-        m_dict: dict = m[1]
-        m_key = list(m_dict.keys())[0]
-        data, id = read_ast_node(m_dict[m_key]["node"])
-        member: Optional[fpp_ast.StateMemberNode] = None
-        match m_key:
-            case "DefChoice":
-                member = fpp_ast.StateMemberDefChoice(
-                    AstNode.create_with_id(
-                        fpp_ast.DefChoice(
-                            data["name"],
-                            translate_ident(data["guard"]),
-                            translate_transition_expr(data["ifTransition"]),
-                            translate_transition_expr(data["elseTransition"]),
-                        ),
-                        id,
-                    )
-                )
-            case "DefState":
-                member = fpp_ast.StateMemberDefState(
-                    AstNode.create_with_id(
-                        fpp_ast.DefState(
-                            data["name"], translate_state_members(data["members"])
-                        ),
-                        id,
-                    )
-                )
-            case "SpecStateEntry":
-                member = fpp_ast.StateMemberSpecStateEntry(
-                    AstNode.create_with_id(
-                        fpp_ast.SpecStateEntry(translate_actions(data["actions"])), id
-                    )
-                )
-            case "SpecStateExit":
-                member = fpp_ast.StateMemberSpecStateExit(
-                    AstNode.create_with_id(
-                        fpp_ast.SpecStateExit(translate_actions(data["actions"])), id
-                    )
-                )
-            case "SpecInitialTransition":
-                member = fpp_ast.StateMemberSpecInitialTransition(
-                    AstNode.create_with_id(
-                        fpp_ast.SpecInitialTransition(
-                            translate_transition_expr(data["transition"])
-                        ),
-                        id,
-                    )
-                )
-            case "SpecStateTransition":
-                signal = translate_ident(data["signal"])
-                transition_or_do = translate_transition_or_do(data["transitionOrDo"])
-                member = fpp_ast.StateMemberSpecStateTransition(
-                    AstNode.create_with_id(
-                        fpp_ast.SpecStateTransition(
-                            signal,
-                            translate_optional(data["guard"], translate_ident),
-                            transition_or_do,
-                        ),
-                        id,
-                    )
-                )
-            case _:
-                raise InvalidFppToJsonField(m_key)
-        members.append(fpp_ast.StateMember(annotate(m[0], member, m[2])))
-    return members
-
-
-def translate_port_instance_identifier(
-    d: dict,
-) -> AstNode[fpp_ast.PortInstanceIdentifier]:
-    data, id = read_ast_node(d)
-    return AstNode.create_with_id(
-        fpp_ast.PortInstanceIdentifier(
-            translate_qual_ident(data["componentInstance"]),
-            translate_ident(data["portName"]),
-        ),
-        id,
-    )
+        raise InvalidFppToJsonDictionary("queue full behavior", d)
 
 
 def translate_pattern_kind(d: dict) -> fpp_ast.PatternKind:
@@ -657,28 +44,6 @@ def translate_pattern_kind(d: dict) -> fpp_ast.PatternKind:
             return fpp_ast.PatternKind.TIME
         case _:
             raise InvalidFppToJsonDictionary("pattern kind", d)
-
-
-def translate_tlm_channel_identifier(d: dict) -> AstNode[fpp_ast.TlmChannelIdentifier]:
-    data, id = read_ast_node(d)
-    return AstNode.create_with_id(
-        fpp_ast.TlmChannelIdentifier(
-            translate_qual_ident(data["componentInstance"]),
-            translate_ident(data["channelName"]),
-        ),
-        id,
-    )
-
-
-def translate_special_input_kind(d: dict) -> fpp_ast.SpecialInputKind:
-    if "Async" in d:
-        return fpp_ast.SpecialInputKind.ASYNC
-    elif "Sync" in d:
-        return fpp_ast.SpecialInputKind.SYNC
-    elif "Guarded" in d:
-        return fpp_ast.SpecialInputKind.GUARDED
-    else:
-        raise InvalidFppToJsonDictionary("special input kind", d)
 
 
 def translate_special_kind(d: dict) -> fpp_ast.SpecialKind:
@@ -709,7 +74,7 @@ def translate_special_kind(d: dict) -> fpp_ast.SpecialKind:
     elif "TimeGet" in d:
         return fpp_ast.SpecialKind.TIME_GET
     else:
-        raise InvalidFppToJsonDictionary("special kind", d)
+        raise InvalidFppToJsonDictionary("special port instance kind", d)
 
 
 def translate_general_kind(d: dict) -> fpp_ast.GeneralKind:
@@ -722,449 +87,1188 @@ def translate_general_kind(d: dict) -> fpp_ast.GeneralKind:
     elif "SyncInput" in d:
         return fpp_ast.GeneralKind.SYNC_INPUT
     else:
-        raise InvalidFppToJsonDictionary("general kind", d)
+        raise InvalidFppToJsonDictionary("general port instance kind", d)
 
 
-def translate_optional(
-    d: dict, func: Callable[[Any], fpp_ast.T]
-) -> Optional[fpp_ast.T]:
-    if "Some" in d:
-        return func(d["Some"])
+def translate_spec_tlm_channel_update(d: dict) -> fpp_ast.SpecTlmChannelUpdate:
+    if "Always" in d:
+        return fpp_ast.SpecTlmChannelUpdate.ALWAYS
+    elif "OnChange" in d:
+        return fpp_ast.SpecTlmChannelUpdate.ON_CHANGE
     else:
-        return None
+        raise InvalidFppToJsonDictionary("telemetry channel update", d)
 
 
-def get_queue_full(d: dict) -> fpp_ast.QueueFull:
-    if "Assert" in d:
-        return fpp_ast.QueueFull.ASSERT
-    elif "Block" in d:
-        return fpp_ast.QueueFull.BLOCK
-    elif "Drop" in d:
-        return fpp_ast.QueueFull.DROP
-    elif "Hook" in d:
-        return fpp_ast.QueueFull.HOOK
+def translate_spec_loc_kind(d: dict) -> fpp_ast.SpecLocKind:
+    if "Component" in d:
+        return fpp_ast.SpecLocKind.COMPONENT
+    elif "ComponentInstance" in d:
+        return fpp_ast.SpecLocKind.COMPONENT_INSTANCE
+    elif "Constant" in d:
+        return fpp_ast.SpecLocKind.CONSTANT
+    elif "Port" in d:
+        return fpp_ast.SpecLocKind.PORT
+    elif "StateMachine" in d:
+        return fpp_ast.SpecLocKind.STATE_MACHINE
+    elif "Topology" in d:
+        return fpp_ast.SpecLocKind.TOPOLOGY
+    elif "Type" in d:
+        return fpp_ast.SpecLocKind.TYPE
+    elif "Interface" in d:
+        return fpp_ast.SpecLocKind.INTERFACE
     else:
-        raise InvalidFppToJsonDictionary("queue full", d)
+        raise InvalidFppToJsonDictionary("location specifier kind", d)
 
 
-def translate_queue_full(d: dict) -> AstNode[fpp_ast.QueueFull]:
-    data, id = read_ast_node(d)
-    return AstNode.create_with_id(get_queue_full(data), id)
+class AstTranslator:
+    def __init__(self, ast_json_file: str, location_map: Dict[AstId, Location]):
+        self.ast_json_file = ast_json_file
+        self.location_map = location_map
 
+    def read_ast_node(self, a_node: dict) -> Tuple[Any, AstId]:
+        return a_node["AstNode"]["data"], a_node["AstNode"]["id"]
 
-def translate_special_port_instance(d: dict) -> fpp_ast.SpecialPortInstance:
-    return fpp_ast.SpecialPortInstance(
-        translate_optional(d["inputKind"], translate_special_input_kind),
-        translate_special_kind(d["kind"]),
-        d["name"],
-        translate_optional(d["priority"], translate_expr),
-        translate_optional(d["queueFull"], translate_queue_full),
-    )
+    def translate_string(self, d: dict) -> AstNode[str]:
+        data, id = self.read_ast_node(d)
+        return AstNode.create_with_id(data, id)
 
+    def translate_ident(self, d: dict) -> AstNode[fpp_ast.Ident]:
+        data, id = self.read_ast_node(d)
+        return AstNode.create_with_id(fpp_ast.Ident(data), id)
 
-def translate_general_port_instance(d: dict) -> fpp_ast.GeneralPortInstance:
-    return fpp_ast.GeneralPortInstance(
-        translate_general_kind(d["kind"]),
-        d["name"],
-        translate_optional(d["size"], translate_expr),
-        translate_optional(d["port"], translate_qual_ident),
-        translate_optional(d["priority"], translate_expr),
-        translate_optional(d["queueFull"], translate_queue_full),
-    )
+    def translate_qual_ident(self, d: dict) -> AstNode[fpp_ast.QualIdent]:
+        data, id = self.read_ast_node(d)
+        if data.get("Unqualified"):
+            return AstNode.create_with_id(
+                fpp_ast.Unqualified(data["Unqualified"]["name"]), id
+            )
+        elif data.get("Qualified"):
+            qualified = data["Qualified"]
+            qualifier_dict = qualified["qualifier"]
+            return AstNode.create_with_id(
+                fpp_ast.Qualified(
+                    self.translate_qual_ident(qualifier_dict),
+                    self.translate_ident(qualified["name"]),
+                ),
+                id,
+            )
+        else:
+            raise InternalError("Could not translate qualified identifier")
 
+    def translate_formal_params(self, params_list: List) -> fpp_ast.FormalParamList:
+        params = []
+        for p in params_list:
+            node = p[1]
+            data, id = self.read_ast_node(node)
+            name = data["name"]
+            kind = fpp_ast.FormalParamKind.REF
+            if "Value" in data["kind"]:
+                kind = fpp_ast.FormalParamKind.VALUE
+            type_name_node = self.translate_type_name(data["typeName"])
+            formal_param = fpp_ast.FormalParam(kind, name, type_name_node)
+            param_ast_node = AstNode.create_with_id(formal_param, id)
+            params.append(self.annotate(p[0], param_ast_node, p[2]))
+        return params
 
-def translate_port_instance(d: dict) -> fpp_ast.SpecPortInstance:
-    if "Special" in d:
-        return translate_special_port_instance(d["Special"])
-    elif "General" in d:
-        return translate_general_port_instance(d["General"])
-    else:
-        raise InvalidFppToJsonDictionary("port instance", d)
+    def translate_type_name(self, tn: dict) -> AstNode[fpp_ast.TypeName]:
+        data, id = self.read_ast_node(tn)
+        if "TypeNameFloat" in data:
+            name = list(data["TypeNameFloat"]["name"].keys())[0]
+            return AstNode.create_with_id(fpp_ast.TypeNameFloat(name), id)
+        elif "TypeNameInt" in data:
+            name = list(data["TypeNameInt"]["name"].keys())[0]
+            return AstNode.create_with_id(fpp_ast.TypeNameInt(name), id)
+        elif "TypeNameQualIdent" in data:
+            return AstNode.create_with_id(
+                fpp_ast.TypeNameQualIdent(
+                    self.translate_qual_ident(data["TypeNameQualIdent"]["name"])
+                ),
+                id,
+            )
+        elif "TypeNameBool" in data:
+            return AstNode.create_with_id(fpp_ast.TypeNameBool(), id)
+        elif "TypeNameString" in data:
+            return AstNode.create_with_id(
+                fpp_ast.TypeNameString(
+                    self.translate_optional(
+                        data["TypeNameString"]["size"], self.translate_expr
+                    )
+                ),
+                id,
+            )
+        else:
+            raise Exception(f"Invalid type name dictionary {data}")
 
+    def translate_binop(self, d: dict) -> fpp_ast.Binop:
+        if "Add" in d:
+            return fpp_ast.Binop.ADD
+        elif "Sub" in d:
+            return fpp_ast.Binop.SUB
+        elif "Mul" in d:
+            return fpp_ast.Binop.MUL
+        elif "Div" in d:
+            return fpp_ast.Binop.DIV
+        else:
+            raise Exception(f"Invalid Binop JSON {d}")
 
-def translate_init_specs(l: list) -> List[fpp_ast.Annotated[AstNode[fpp_ast.SpecInit]]]:
-    specs = []
-    for e in l:
-        spec_node = e[1]
-        data = spec_node["AstNode"]["data"]
-        id = spec_node["AstNode"]["id"]
-        spec = AstNode.create_with_id(
-            fpp_ast.SpecInit(translate_expr(data["phase"]), data["code"]), id
+    def translate_expr(self, expr_dict: dict) -> AstNode[fpp_ast.Expr]:
+        data, id = self.read_ast_node(expr_dict)
+        if "ExprArray" in data:
+            elts = []
+            for e in data["ExprArray"]["elts"]:
+                elts.append(self.translate_expr(e))
+            return AstNode.create_with_id(fpp_ast.ExprArray(elts), id)
+        elif "ExprArraySubscript" in data:
+            return AstNode.create_with_id(
+                fpp_ast.ExprArraySubscript(
+                    self.translate_expr(data["ExprArraySubscript"]["e1"]),
+                    self.translate_expr(data["ExprArraySubscript"]["e2"]),
+                ),
+                id,
+            )
+        elif "ExprBinop" in data:
+            return AstNode.create_with_id(
+                fpp_ast.ExprBinop(
+                    self.translate_expr(data["ExprBinop"]["e1"]),
+                    self.translate_binop(data["ExprBinop"]["op"]),
+                    self.translate_expr(data["ExprBinop"]["e2"]),
+                ),
+                id,
+            )
+        elif "ExprDot" in data:
+            return AstNode.create_with_id(
+                fpp_ast.ExprDot(
+                    self.translate_expr(data["ExprDot"]["e"]),
+                    self.translate_ident(data["ExprDot"]["id"]),
+                ),
+                id,
+            )
+        elif "ExprIdent" in data:
+            return AstNode.create_with_id(
+                fpp_ast.ExprIdent(data["ExprIdent"]["value"]), id
+            )
+        elif "ExprLiteralBool" in data:
+            if "True" in data["ExprLiteralBool"]["value"]:
+                literal_bool = fpp_ast.LiteralBool.TRUE
+            else:
+                literal_bool = fpp_ast.LiteralBool.FALSE
+            return AstNode.create_with_id(fpp_ast.ExprLiteralBool(literal_bool), id)
+        elif "ExprLiteralInt" in data:
+            return AstNode.create_with_id(
+                fpp_ast.ExprLiteralInt(data["ExprLiteralInt"]["value"]), id
+            )
+        elif "ExprLiteralFloat" in data:
+            return AstNode.create_with_id(
+                fpp_ast.ExprLiteralFloat(data["ExprLiteralFloat"]["value"]), id
+            )
+        elif "ExprLiteralString" in data:
+            return AstNode.create_with_id(
+                fpp_ast.ExprLiteralString(data["ExprLiteralString"]["value"]), id
+            )
+        elif "ExprParen" in data:
+            return AstNode.create_with_id(
+                fpp_ast.ExprParen(
+                    self.translate_expr(data["ExprParen"]["e"]),
+                ),
+                id,
+            )
+        elif "ExprStruct" in data:
+            members = []
+            for m in data["ExprStruct"]["members"]:
+                members.append(
+                    AstNode.create_with_id(
+                        fpp_ast.StructMember(
+                            m["AstNode"]["data"]["name"],
+                            self.translate_expr(m["AstNode"]["data"]["value"]),
+                        ),
+                        m["AstNode"]["id"],
+                    )
+                )
+            return AstNode.create_with_id(fpp_ast.ExprStruct(members), id)
+        elif "ExprUnop" in data:
+            return AstNode.create_with_id(
+                fpp_ast.ExprUnop(
+                    fpp_ast.Unop.MINUS, self.translate_expr(data["ExprUnop"]["e"])
+                ),
+                id,
+            )
+        else:
+            raise InvalidFppToJsonDictionary(
+                "expression", expr_dict, self.location_map.get(id, None)
+            )
+
+    def translate_throttle(self, d: Dict[str, dict]) -> AstNode[fpp_ast.EventThrottle]:
+        return AstNode.create_with_id(
+            fpp_ast.EventThrottle(
+                self.translate_expr(d["AstNode"]["data"]["count"]),
+                self.translate_optional(
+                    d["AstNode"]["data"]["every"], self.translate_expr
+                ),
+            ),
+            d["AstNode"]["id"],
         )
-        specs.append(annotate(e[0], spec, e[2]))
-    return specs
 
+    def translate_transition_expr(self, te: dict) -> AstNode[fpp_ast.TransitionExpr]:
+        data, id = self.read_ast_node(te)
+        return AstNode.create_with_id(
+            fpp_ast.TransitionExpr(
+                self.translate_actions(data["actions"]),
+                self.translate_qual_ident(data["target"]),
+            ),
+            id,
+        )
 
-def translate_state_machine(data: dict, id: AstId) -> AstNode[fpp_ast.DefStateMachine]:
-    if data["members"] == "None":
-        sm_members = []
-    else:
-        sm_members = translate_state_machine_members(data["members"])
-    return AstNode.create_with_id(fpp_ast.DefStateMachine(data["name"], sm_members), id)
-
-
-def translate_interface_members(l: List) -> List[fpp_ast.InterfaceMember]:
-    members = []
-    for m in l:
-        m_dict: dict = m[1]
-        m_key = list(m_dict.keys())[0]
-        id = m_dict[m_key]["node"]["AstNode"]["id"]
-        data: dict = m_dict[m_key]["node"]["AstNode"]["data"]
-        member: Optional[fpp_ast.InterfaceMemberNode] = None
-        match m_key:
-            case "SpecPortInstance":
-                member = fpp_ast.InterfaceMemberSpecPortInstance(
-                    AstNode.create_with_id(translate_port_instance(data), id)
-                )
-            case "SpecImportInterface":
-                member = fpp_ast.InterfaceMemberSpecImportInterface(
-                    AstNode.create_with_id(
-                        fpp_ast.SpecImport(translate_qual_ident(data["sym"])), id
-                    )
-                )
-            case _:
-                raise InvalidFppToJsonField(m_key)
-        members.append(fpp_ast.InterfaceMember(annotate(m[0], member, m[2])))
-    return members
-
-
-def translate_tlm_packet_set_members(d: dict) -> List[fpp_ast.TlmPacketSetMember]:
-    members = []
-    for member in d:
-        node = member[1]
-        if "SpecTlmPacket" in node:
-            spec_tlm_pkt_data, spec_tlm_pkt_id = read_ast_node(
-                node["SpecTlmPacket"]["node"]
+    def translate_transition_or_do(self, t: dict) -> fpp_ast.TransitionOrDo:
+        if "Transition" in t:
+            return fpp_ast.Transition(
+                self.translate_transition_expr(t["Transition"]["transition"])
             )
-            tlm_pkt_members: List[fpp_ast.TlmPacketMember] = []
-            for m in spec_tlm_pkt_data["members"]:
-                if "TlmChannelIdentifier" in m:
-                    chan_ident_node = m["TlmChannelIdentifier"]["node"]
-                    tlm_pkt_members.append(
-                        fpp_ast.TlmPacketMemberTlmChannelIdentifier(
-                            translate_tlm_channel_identifier(chan_ident_node)
-                        )
-                    )
-            pkt = fpp_ast.TlmPacketSetMemberSpecTlmPacket(
-                AstNode.create_with_id(
-                    fpp_ast.SpecTlmPacket(
-                        spec_tlm_pkt_data["name"],
-                        translate_optional(spec_tlm_pkt_data["id"], translate_expr),
-                        translate_expr(spec_tlm_pkt_data["group"]),
-                        tlm_pkt_members,
+        elif "Do" in t:
+            return fpp_ast.Do(self.translate_actions(t["Do"]["actions"]))
+        else:
+            raise InvalidFppToJsonDictionary("Transition or Do", t)
+
+    def translate_actions(self, l: List) -> List[AstNode[fpp_ast.Ident]]:
+        actions = []
+        for a in l:
+            actions.append(self.translate_ident(a))
+        return actions
+
+    def annotate(self, l1: List[str], d: fpp_ast.T, l2: List[str]) -> fpp_ast.Annotated:
+        return (l1, d, l2)
+
+    def translate_limit_kind(self, d: dict) -> AstNode[fpp_ast.LimitKind]:
+        data, id = self.read_ast_node(d)
+        limit_kind = fpp_ast.LimitKind.RED
+        if "Yellow" in data:
+            limit_kind = fpp_ast.LimitKind.YELLOW
+        elif "Orange" in data:
+            limit_kind = fpp_ast.LimitKind.ORANGE
+        elif "Red" in data:
+            limit_kind = fpp_ast.LimitKind.RED
+        else:
+            raise InvalidFppToJsonDictionary(
+                "limit kind", d, self.location_map.get(id, None)
+            )
+        return AstNode.create_with_id(limit_kind, id)
+
+    def translate_limits(self, l: List) -> List[fpp_ast.Limit]:
+        limits = []
+        for e in l:
+            limits.append((self.translate_limit_kind(e[0]), self.translate_expr(e[1])))
+        return limits
+
+    def translate_spec_command_kind(self, d: dict) -> fpp_ast.SpecCommandKind:
+        if "Async" in d:
+            return fpp_ast.SpecCommandKind.ASYNC
+        elif "Sync" in d:
+            return fpp_ast.SpecCommandKind.SYNC
+        elif "Guarded" in d:
+            return fpp_ast.SpecCommandKind.GUARDED
+        else:
+            raise InvalidFppToJsonDictionary("command kind", d)
+
+    def translate_severity(self, d: dict) -> fpp_ast.SpecEventSeverity:
+        if "ActivityHigh" in d:
+            return fpp_ast.SpecEventSeverity.ACTIVITY_HIGH
+        elif "ActivityLow" in d:
+            return fpp_ast.SpecEventSeverity.ACTIVITY_LOW
+        elif "Command" in d:
+            return fpp_ast.SpecEventSeverity.COMMAND
+        elif "Diagnostic" in d:
+            return fpp_ast.SpecEventSeverity.DIAGNOSTIC
+        elif "Fatal" in d:
+            return fpp_ast.SpecEventSeverity.FATAL
+        elif "WarningHigh" in d:
+            return fpp_ast.SpecEventSeverity.WARNING_HIGH
+        elif "WarningLow" in d:
+            return fpp_ast.SpecEventSeverity.WARNING_LOW
+        else:
+            raise InvalidFppToJsonDictionary("event severity", d)
+
+    def translate_def_abs_type(
+        self, data: dict, id: AstId
+    ) -> AstNode[fpp_ast.DefAbsType]:
+        return AstNode.create_with_id(fpp_ast.DefAbsType(data["name"]), id)
+
+    def translate_def_alias_type(
+        self, data: dict, id: AstId
+    ) -> AstNode[fpp_ast.DefAliasType]:
+        return AstNode.create_with_id(
+            fpp_ast.DefAliasType(
+                data["name"],
+                self.translate_type_name(data["typeName"]),
+                data["isDictionaryDef"],
+            ),
+            id,
+        )
+
+    def translate_def_array(self, data: dict, id: AstId) -> AstNode[fpp_ast.DefArray]:
+        return AstNode.create_with_id(
+            fpp_ast.DefArray(
+                data["name"],
+                self.translate_expr(data["size"]),
+                self.translate_type_name(data["eltType"]),
+                self.translate_optional(data["default"], self.translate_expr),
+                self.translate_optional(data["format"], self.translate_string),
+                data["isDictionaryDef"],
+            ),
+            id,
+        )
+
+    def translate_def_constant(
+        self, data: dict, id: AstId
+    ) -> AstNode[fpp_ast.DefConstant]:
+        return AstNode.create_with_id(
+            fpp_ast.DefConstant(
+                data["name"],
+                self.translate_expr(data["value"]),
+                data["isDictionaryDef"],
+            ),
+            id,
+        )
+
+    def translate_def_enum(self, data: dict, id: AstId) -> AstNode[fpp_ast.DefEnum]:
+        constants = []
+        for c in data["constants"]:
+            const = c[1]
+            const_data, const_id = self.read_ast_node(const)
+            node = AstNode.create_with_id(
+                fpp_ast.DefEnumConstant(
+                    const_data["name"],
+                    self.translate_optional(const_data["value"], self.translate_expr),
+                ),
+                const_id,
+            )
+            constants.append(self.annotate(c[0], node, c[2]))
+        return AstNode.create_with_id(
+            fpp_ast.DefEnum(
+                data["name"],
+                self.translate_optional(data["typeName"], self.translate_type_name),
+                constants,
+                self.translate_optional(data["default"], self.translate_expr),
+                data["isDictionaryDef"],
+            ),
+            id,
+        )
+
+    def translate_def_struct(self, data: dict, id: AstId) -> AstNode[fpp_ast.DefStruct]:
+        struct_members = []
+        for m in data["members"]:
+            member_data, member_id = self.read_ast_node(m[1])
+            node = AstNode.create_with_id(
+                fpp_ast.StructTypeMember(
+                    member_data["name"],
+                    self.translate_optional(member_data["size"], self.translate_expr),
+                    self.translate_type_name(member_data["typeName"]),
+                    self.translate_optional(
+                        member_data["format"], self.translate_string
                     ),
-                    spec_tlm_pkt_id,
-                )
+                ),
+                member_id,
             )
-            members.append(
-                fpp_ast.TlmPacketSetMember(annotate(member[0], pkt, member[2]))
-            )
-        elif "SpecInclude" in node:
-            raise NotSupportedInFppToJsonException("SpecInclude")
-    return members
+            struct_members.append(self.annotate(m[0], node, m[2]))
+        return AstNode.create_with_id(
+            fpp_ast.DefStruct(
+                data["name"],
+                struct_members,
+                self.translate_optional(data["default"], self.translate_expr),
+                data["isDictionaryDef"],
+            ),
+            id,
+        )
 
-
-def translate_topology_members(l: List) -> List[fpp_ast.TopologyMember]:
-    members = []
-    for m in l:
-        m_dict: dict = m[1]
-        m_key = list(m_dict.keys())[0]
-        id = m_dict[m_key]["node"]["AstNode"]["id"]
-        data: dict = m_dict[m_key]["node"]["AstNode"]["data"]
-        member: Optional[fpp_ast.TopologyMemberNode] = None
-        match m_key:
-            case "SpecCompInstance":
-                visibility = fpp_ast.Visibility.PRIVATE
-                if "Public" in data["visibility"]:
-                    visibility = fpp_ast.Visibility.PUBLIC
-                member = fpp_ast.TopologyMemberSpecCompInstance(
-                    AstNode.create_with_id(
-                        fpp_ast.SpecCompInstance(
-                            visibility, translate_qual_ident(data["instance"])
-                        ),
-                        id,
+    def translate_component_members(self, l: list) -> List[fpp_ast.ComponentMember]:
+        members = []
+        for m in l:
+            m_dict: dict = m[1]
+            m_key = list(m_dict.keys())[0]
+            data, id = self.read_ast_node(m_dict[m_key]["node"])
+            member: Optional[fpp_ast.ComponentMemberNode] = None
+            match m_key:
+                case "DefAbsType":
+                    member = fpp_ast.ComponentMemberDefAbsType(
+                        self.translate_def_abs_type(data, id)
                     )
-                )
-            case "SpecConnectionGraph":
-                if "Direct" in data:
-                    connections = []
-                    for c in data["Direct"]["connections"]:
-                        connections.append(
-                            fpp_ast.Connection(
-                                c["isUnmatched"],
-                                translate_port_instance_identifier(c["fromPort"]),
-                                translate_optional(c["fromIndex"], translate_expr),
-                                translate_port_instance_identifier(c["toPort"]),
-                                translate_optional(c["toIndex"], translate_expr),
-                            )
-                        )
-                    member = fpp_ast.TopologyMemberSpecConnectionGraph(
+                case "DefAliasType":
+                    member = fpp_ast.ComponentMemberDefAliasType(
+                        self.translate_def_alias_type(data, id)
+                    )
+                case "DefArray":
+                    member = fpp_ast.ComponentMemberDefArray(
+                        self.translate_def_array(data, id)
+                    )
+                case "DefConstant":
+                    member = fpp_ast.ComponentMemberDefConstant(
+                        self.translate_def_constant(data, id)
+                    )
+                case "DefEnum":
+                    member = fpp_ast.ComponentMemberDefEnum(
+                        self.translate_def_enum(data, id)
+                    )
+                case "DefStruct":
+                    member = fpp_ast.ComponentMemberDefStruct(
+                        self.translate_def_struct(data, id)
+                    )
+                case "DefStateMachine":
+                    member = fpp_ast.ComponentMemberDefStateMachine(
+                        self.translate_state_machine(data, id)
+                    )
+                case "SpecStateMachineInstance":
+                    member = fpp_ast.ComponentMemberSpecStateMachineInstance(
                         AstNode.create_with_id(
-                            fpp_ast.Direct(data["Direct"]["name"], connections), id
+                            fpp_ast.SpecStateMachineInstance(
+                                data["name"],
+                                self.translate_qual_ident(data["stateMachine"]),
+                                self.translate_optional(
+                                    data["priority"], self.translate_expr
+                                ),
+                                self.translate_optional(
+                                    data["queueFull"], get_queue_full
+                                ),
+                            ),
+                            id,
                         )
                     )
-                elif "Pattern" in data:
-                    targets = []
-                    for t in data["Pattern"]["targets"]:
-                        targets.append(translate_qual_ident(t))
-                    connection_graph: fpp_ast.SpecConnectionGraph = fpp_ast.Pattern(
-                        translate_pattern_kind(data["Pattern"]["kind"]),
-                        translate_qual_ident(data["Pattern"]["source"]),
-                        targets,
+                case "SpecCommand":
+                    member = fpp_ast.ComponentMemberSpecCommand(
+                        AstNode.create_with_id(
+                            fpp_ast.SpecCommand(
+                                self.translate_spec_command_kind(data["kind"]),
+                                data["name"],
+                                self.translate_formal_params(data["params"]),
+                                self.translate_optional(
+                                    data["opcode"], self.translate_expr
+                                ),
+                                self.translate_optional(
+                                    data["priority"], self.translate_expr
+                                ),
+                                self.translate_optional(
+                                    data["queueFull"], self.translate_queue_full
+                                ),
+                            ),
+                            id,
+                        )
                     )
+                case "SpecTlmChannel":
+                    member = fpp_ast.ComponentMemberSpecTlmChannel(
+                        AstNode.create_with_id(
+                            fpp_ast.SpecTlmChannel(
+                                data["name"],
+                                self.translate_type_name(data["typeName"]),
+                                self.translate_optional(
+                                    data["id"], self.translate_expr
+                                ),
+                                self.translate_optional(
+                                    data["update"], translate_spec_tlm_channel_update
+                                ),
+                                self.translate_optional(
+                                    data["format"], self.translate_string
+                                ),
+                                self.translate_limits(data["low"]),
+                                self.translate_limits(data["high"]),
+                            ),
+                            id,
+                        )
+                    )
+                case "SpecEvent":
+                    member = fpp_ast.ComponentMemberSpecEvent(
+                        AstNode.create_with_id(
+                            fpp_ast.SpecEvent(
+                                data["name"],
+                                self.translate_formal_params(data["params"]),
+                                self.translate_severity(data["severity"]),
+                                self.translate_optional(
+                                    data["id"], self.translate_expr
+                                ),
+                                self.translate_string(data["format"]),
+                                self.translate_optional(
+                                    data["throttle"], self.translate_throttle
+                                ),
+                            ),
+                            id,
+                        )
+                    )
+                case "SpecRecord":
+                    member = fpp_ast.ComponentMemberSpecRecord(
+                        AstNode.create_with_id(
+                            fpp_ast.SpecRecord(
+                                data["name"],
+                                self.translate_type_name(data["recordType"]),
+                                data["isArray"],
+                                self.translate_optional(
+                                    data["id"], self.translate_expr
+                                ),
+                            ),
+                            id,
+                        )
+                    )
+                case "SpecContainer":
+                    member = fpp_ast.ComponentMemberSpecContainer(
+                        AstNode.create_with_id(
+                            fpp_ast.SpecContainer(
+                                data["name"],
+                                self.translate_optional(
+                                    data["id"], self.translate_expr
+                                ),
+                                self.translate_optional(
+                                    data["defaultPriority"], self.translate_expr
+                                ),
+                            ),
+                            id,
+                        )
+                    )
+                case "SpecParam":
+                    member = fpp_ast.ComponentMemberSpecParam(
+                        AstNode.create_with_id(
+                            fpp_ast.SpecParam(
+                                data["name"],
+                                self.translate_type_name(data["typeName"]),
+                                self.translate_optional(
+                                    data["default"], self.translate_expr
+                                ),
+                                self.translate_optional(
+                                    data["id"], self.translate_expr
+                                ),
+                                self.translate_optional(
+                                    data["setOpcode"], self.translate_expr
+                                ),
+                                self.translate_optional(
+                                    data["saveOpcode"], self.translate_expr
+                                ),
+                                data["isExternal"],
+                            ),
+                            id,
+                        )
+                    )
+                case "SpecPortMatching":
+                    member = fpp_ast.ComponentMemberSpecPortMatching(
+                        AstNode.create_with_id(
+                            fpp_ast.SpecPortMatching(
+                                self.translate_ident(data["port1"]),
+                                self.translate_ident(data["port2"]),
+                            ),
+                            id,
+                        )
+                    )
+                case "SpecInternalPort":
+                    member = fpp_ast.ComponentMemberSpecInternalPort(
+                        AstNode.create_with_id(
+                            fpp_ast.SpecInternalPort(
+                                data["name"],
+                                self.translate_formal_params(data["params"]),
+                                self.translate_optional(
+                                    data["priority"], self.translate_expr
+                                ),
+                                self.translate_optional(
+                                    data["queueFull"], get_queue_full
+                                ),
+                            ),
+                            id,
+                        )
+                    )
+                case "SpecPortInstance":
+                    member = fpp_ast.ComponentMemberSpecPortInstance(
+                        AstNode.create_with_id(self.translate_port_instance(data), id)
+                    )
+                case "SpecImportInterface":
+                    member = fpp_ast.ComponentMemberSpecImportInterface(
+                        AstNode.create_with_id(
+                            fpp_ast.SpecImport(self.translate_qual_ident(data["sym"])),
+                            id,
+                        )
+                    )
+                case _:
+                    raise InvalidFppToJsonField(m_key, self.location_map.get(id, None))
+            members.append(fpp_ast.ComponentMember(self.annotate(m[0], member, m[2])))
+        return members
 
-                    member = fpp_ast.TopologyMemberSpecConnectionGraph(
-                        AstNode.create_with_id(connection_graph, id)
+    def translate_state_members(self, l: List) -> List[fpp_ast.StateMember]:
+        members = []
+        for m in l:
+            m_dict: dict = m[1]
+            m_key = list(m_dict.keys())[0]
+            data, id = self.read_ast_node(m_dict[m_key]["node"])
+            member: Optional[fpp_ast.StateMemberNode] = None
+            match m_key:
+                case "DefChoice":
+                    member = fpp_ast.StateMemberDefChoice(
+                        AstNode.create_with_id(
+                            fpp_ast.DefChoice(
+                                data["name"],
+                                self.translate_ident(data["guard"]),
+                                self.translate_transition_expr(data["ifTransition"]),
+                                self.translate_transition_expr(data["elseTransition"]),
+                            ),
+                            id,
+                        )
                     )
-                else:
-                    raise InvalidFppToJsonDictionary("SpecConnectionGraph", data)
-            case "SpecTlmPacketSet":
-                omitted = []
-                for o in data["omitted"]:
-                    omitted.append(translate_tlm_channel_identifier(o))
-                member = fpp_ast.TopologyMemberSpecTlmPacketSet(
-                    AstNode.create_with_id(
-                        fpp_ast.SpecTlmPacketSet(
-                            data["name"],
-                            translate_tlm_packet_set_members(data["members"]),
-                            omitted,
-                        ),
-                        id,
+                case "DefState":
+                    member = fpp_ast.StateMemberDefState(
+                        AstNode.create_with_id(
+                            fpp_ast.DefState(
+                                data["name"],
+                                self.translate_state_members(data["members"]),
+                            ),
+                            id,
+                        )
                     )
-                )
-            case "SpecTopImport":
-                member = fpp_ast.TopologyMemberSpecTopImport(
-                    AstNode.create_with_id(
-                        fpp_ast.SpecImport(translate_qual_ident(data["sym"])), id
+                case "SpecStateEntry":
+                    member = fpp_ast.StateMemberSpecStateEntry(
+                        AstNode.create_with_id(
+                            fpp_ast.SpecStateEntry(
+                                self.translate_actions(data["actions"])
+                            ),
+                            id,
+                        )
                     )
-                )
-            case "SpecInclude":
-                raise NotSupportedInFppToJsonException(m_key)
-            case _:
-                raise InvalidFppToJsonField(m_key)
-        members.append(fpp_ast.TopologyMember(annotate(m[0], member, m[2])))
-    return members
+                case "SpecStateExit":
+                    member = fpp_ast.StateMemberSpecStateExit(
+                        AstNode.create_with_id(
+                            fpp_ast.SpecStateExit(
+                                self.translate_actions(data["actions"])
+                            ),
+                            id,
+                        )
+                    )
+                case "SpecInitialTransition":
+                    member = fpp_ast.StateMemberSpecInitialTransition(
+                        AstNode.create_with_id(
+                            fpp_ast.SpecInitialTransition(
+                                self.translate_transition_expr(data["transition"])
+                            ),
+                            id,
+                        )
+                    )
+                case "SpecStateTransition":
+                    signal = self.translate_ident(data["signal"])
+                    transition_or_do = self.translate_transition_or_do(
+                        data["transitionOrDo"]
+                    )
+                    member = fpp_ast.StateMemberSpecStateTransition(
+                        AstNode.create_with_id(
+                            fpp_ast.SpecStateTransition(
+                                signal,
+                                self.translate_optional(
+                                    data["guard"], self.translate_ident
+                                ),
+                                transition_or_do,
+                            ),
+                            id,
+                        )
+                    )
+                case _:
+                    raise InvalidFppToJsonField(m_key, self.location_map.get(id, None))
+            members.append(fpp_ast.StateMember(self.annotate(m[0], member, m[2])))
+        return members
 
+    def translate_port_instance_identifier(
+        self,
+        d: dict,
+    ) -> AstNode[fpp_ast.PortInstanceIdentifier]:
+        data, id = self.read_ast_node(d)
+        return AstNode.create_with_id(
+            fpp_ast.PortInstanceIdentifier(
+                self.translate_qual_ident(data["componentInstance"]),
+                self.translate_ident(data["portName"]),
+            ),
+            id,
+        )
 
-def translate_module_members(l: List) -> List[fpp_ast.ModuleMember]:
-    members = []
-    for m in l:
-        m_dict: dict = m[1]
-        m_key = list(m_dict.keys())[0]
-        data, id = read_ast_node(m_dict[m_key]["node"])
-        member: Optional[fpp_ast.ModuleMemberNode] = None
-        match m_key:
-            case "DefAbsType":
-                member = fpp_ast.ModuleMemberDefAbsType(
-                    translate_def_abs_type(data, id)
-                )
-            case "DefAliasType":
-                member = fpp_ast.ModuleMemberDefAliasType(
-                    translate_def_alias_type(data, id)
-                )
-            case "DefArray":
-                member = fpp_ast.ModuleMemberDefArray(translate_def_array(data, id))
-            case "DefComponent":
-                if "Active" in data["kind"]:
-                    kind = fpp_ast.ComponentKind.ACTIVE
-                elif "Passive" in data["kind"]:
-                    kind = fpp_ast.ComponentKind.PASSIVE
-                elif "Queued" in data["kind"]:
-                    kind = fpp_ast.ComponentKind.QUEUED
-                else:
-                    raise InvalidFppToJsonDictionary("component kind", data)
-                member = fpp_ast.ModuleMemberDefComponent(
-                    AstNode.create_with_id(
-                        fpp_ast.DefComponent(
-                            kind,
-                            data["name"],
-                            translate_component_members(data["members"]),
-                        ),
-                        id,
-                    )
-                )
-            case "DefComponentInstance":
-                member = fpp_ast.ModuleMemberDefComponentInstance(
-                    AstNode.create_with_id(
-                        fpp_ast.DefComponentInstance(
-                            data["name"],
-                            translate_qual_ident(data["component"]),
-                            translate_expr(data["baseId"]),
-                            translate_optional(data["implType"], translate_string),
-                            translate_optional(data["file"], translate_string),
-                            translate_optional(data["queueSize"], translate_expr),
-                            translate_optional(data["stackSize"], translate_expr),
-                            translate_optional(data["priority"], translate_expr),
-                            translate_optional(data["cpu"], translate_expr),
-                            translate_init_specs(data["initSpecs"]),
-                        ),
-                        id,
-                    )
-                )
-            case "DefConstant":
-                member = fpp_ast.ModuleMemberDefConstant(
-                    translate_def_constant(data, id)
-                )
-            case "DefEnum":
-                member = fpp_ast.ModuleMemberDefEnum(translate_def_enum(data, id))
-            case "DefInterface":
-                member = fpp_ast.ModuleMemberDefInterface(
-                    AstNode.create_with_id(
-                        fpp_ast.DefInterface(
-                            data["name"], translate_interface_members(data["members"])
-                        ),
-                        id,
-                    )
-                )
-            case "DefModule":
-                member = fpp_ast.ModuleMemberDefModule(
-                    AstNode.create_with_id(
-                        fpp_ast.DefModule(
-                            data["name"], translate_module_members(data["members"])
-                        ),
-                        id,
-                    )
-                )
-            case "DefPort":
-                member = fpp_ast.ModuleMemberDefPort(
-                    AstNode.create_with_id(
-                        fpp_ast.DefPort(
-                            data["name"],
-                            translate_formal_params(data["params"]),
-                            translate_optional(data["returnType"], translate_type_name),
-                        ),
-                        id,
-                    )
-                )
-            case "DefStateMachine":
-                member = fpp_ast.ModuleMemberDefStateMachine(
-                    translate_state_machine(data, id)
-                )
-            case "DefStruct":
-                member = fpp_ast.ModuleMemberDefStruct(translate_def_struct(data, id))
-            case "DefTopology":
-                member = fpp_ast.ModuleMemberDefTopology(
-                    AstNode.create_with_id(
-                        fpp_ast.DefTopology(
-                            data["name"], translate_topology_members(data["members"])
-                        ),
-                        id,
-                    )
-                )
-            case "SpecInclude":
-                raise NotSupportedInFppToJsonException(m_key)
-            case "SpecLoc":
-                member = fpp_ast.ModuleMemberSpecLoc(
-                    AstNode.create_with_id(
-                        fpp_ast.SpecLoc(
-                            translate_spec_loc_kind(data["kind"]),
-                            translate_qual_ident(data["symbol"]),
-                            translate_string(data["file"]),
-                            data["isDictionaryDef"],
-                        ),
-                        id,
-                    )
-                )
-            case _:
-                raise InvalidFppToJsonField(m_key)
-        members.append(fpp_ast.ModuleMember(annotate(m[0], member, m[2])))
-    return members
+    def translate_tlm_channel_identifier(
+        self, d: dict
+    ) -> AstNode[fpp_ast.TlmChannelIdentifier]:
+        data, id = self.read_ast_node(d)
+        return AstNode.create_with_id(
+            fpp_ast.TlmChannelIdentifier(
+                self.translate_qual_ident(data["componentInstance"]),
+                self.translate_ident(data["channelName"]),
+            ),
+            id,
+        )
 
+    def translate_special_input_kind(self, d: dict) -> fpp_ast.SpecialInputKind:
+        if "Async" in d:
+            return fpp_ast.SpecialInputKind.ASYNC
+        elif "Sync" in d:
+            return fpp_ast.SpecialInputKind.SYNC
+        elif "Guarded" in d:
+            return fpp_ast.SpecialInputKind.GUARDED
+        else:
+            raise InvalidFppToJsonDictionary("special input kind", d)
 
-def translate_state_machine_members(
-    d: Dict[str, List],
-) -> List[fpp_ast.StateMachineMember]:
-    members = []
-    if d.get("Some"):
-        for l in d["Some"]:
-            for k, v in l[1].items():
-                data, id = read_ast_node(v["node"])
-                member: Optional[fpp_ast.StateMachineMemberNode] = None
-                match k:
-                    case "DefAction":
-                        member = fpp_ast.StateMachineMemberDefAction(
-                            AstNode.create_with_id(
-                                fpp_ast.DefAction(
-                                    data["name"],
-                                    translate_optional(
-                                        data["typeName"], translate_type_name
+    def translate_optional(
+        self, d: dict, func: Callable[[Any], fpp_ast.T]
+    ) -> Optional[fpp_ast.T]:
+        if "Some" in d:
+            return func(d["Some"])
+        else:
+            return None
+
+    def translate_queue_full(self, d: dict) -> AstNode[fpp_ast.QueueFull]:
+        data, id = self.read_ast_node(d)
+        return AstNode.create_with_id(get_queue_full(data), id)
+
+    def translate_special_port_instance(self, d: dict) -> fpp_ast.SpecialPortInstance:
+        return fpp_ast.SpecialPortInstance(
+            self.translate_optional(d["inputKind"], self.translate_special_input_kind),
+            translate_special_kind(d["kind"]),
+            d["name"],
+            self.translate_optional(d["priority"], self.translate_expr),
+            self.translate_optional(d["queueFull"], self.translate_queue_full),
+        )
+
+    def translate_general_port_instance(self, d: dict) -> fpp_ast.GeneralPortInstance:
+        return fpp_ast.GeneralPortInstance(
+            translate_general_kind(d["kind"]),
+            d["name"],
+            self.translate_optional(d["size"], self.translate_expr),
+            self.translate_optional(d["port"], self.translate_qual_ident),
+            self.translate_optional(d["priority"], self.translate_expr),
+            self.translate_optional(d["queueFull"], self.translate_queue_full),
+        )
+
+    def translate_port_instance(self, d: dict) -> fpp_ast.SpecPortInstance:
+        if "Special" in d:
+            return self.translate_special_port_instance(d["Special"])
+        elif "General" in d:
+            return self.translate_general_port_instance(d["General"])
+        else:
+            raise InvalidFppToJsonDictionary("port instance", d)
+
+    def translate_init_specs(
+        self, l: list
+    ) -> List[fpp_ast.Annotated[AstNode[fpp_ast.SpecInit]]]:
+        specs = []
+        for e in l:
+            spec_node = e[1]
+            data = spec_node["AstNode"]["data"]
+            id = spec_node["AstNode"]["id"]
+            spec = AstNode.create_with_id(
+                fpp_ast.SpecInit(self.translate_expr(data["phase"]), data["code"]), id
+            )
+            specs.append(self.annotate(e[0], spec, e[2]))
+        return specs
+
+    def translate_state_machine(
+        self, data: dict, id: AstId
+    ) -> AstNode[fpp_ast.DefStateMachine]:
+        if data["members"] == "None":
+            sm_members = []
+        else:
+            sm_members = self.translate_state_machine_members(data["members"])
+        return AstNode.create_with_id(
+            fpp_ast.DefStateMachine(data["name"], sm_members), id
+        )
+
+    def translate_interface_members(self, l: List) -> List[fpp_ast.InterfaceMember]:
+        members = []
+        for m in l:
+            m_dict: dict = m[1]
+            m_key = list(m_dict.keys())[0]
+            id = m_dict[m_key]["node"]["AstNode"]["id"]
+            data: dict = m_dict[m_key]["node"]["AstNode"]["data"]
+            member: Optional[fpp_ast.InterfaceMemberNode] = None
+            match m_key:
+                case "SpecPortInstance":
+                    member = fpp_ast.InterfaceMemberSpecPortInstance(
+                        AstNode.create_with_id(self.translate_port_instance(data), id)
+                    )
+                case "SpecImportInterface":
+                    member = fpp_ast.InterfaceMemberSpecImportInterface(
+                        AstNode.create_with_id(
+                            fpp_ast.SpecImport(self.translate_qual_ident(data["sym"])),
+                            id,
+                        )
+                    )
+                case _:
+                    raise InvalidFppToJsonField(m_key, self.location_map.get(id, None))
+            members.append(fpp_ast.InterfaceMember(self.annotate(m[0], member, m[2])))
+        return members
+
+    def translate_tlm_packet_set_members(
+        self, d: dict
+    ) -> List[fpp_ast.TlmPacketSetMember]:
+        members = []
+        for member in d:
+            node = member[1]
+            if "SpecTlmPacket" in node:
+                spec_tlm_pkt_data, spec_tlm_pkt_id = self.read_ast_node(
+                    node["SpecTlmPacket"]["node"]
+                )
+                tlm_pkt_members: List[fpp_ast.TlmPacketMember] = []
+                for m in spec_tlm_pkt_data["members"]:
+                    if "TlmChannelIdentifier" in m:
+                        chan_ident_node = m["TlmChannelIdentifier"]["node"]
+                        tlm_pkt_members.append(
+                            fpp_ast.TlmPacketMemberTlmChannelIdentifier(
+                                self.translate_tlm_channel_identifier(chan_ident_node)
+                            )
+                        )
+                pkt = fpp_ast.TlmPacketSetMemberSpecTlmPacket(
+                    AstNode.create_with_id(
+                        fpp_ast.SpecTlmPacket(
+                            spec_tlm_pkt_data["name"],
+                            self.translate_optional(
+                                spec_tlm_pkt_data["id"], self.translate_expr
+                            ),
+                            self.translate_expr(spec_tlm_pkt_data["group"]),
+                            tlm_pkt_members,
+                        ),
+                        spec_tlm_pkt_id,
+                    )
+                )
+                members.append(
+                    fpp_ast.TlmPacketSetMember(self.annotate(member[0], pkt, member[2]))
+                )
+            elif "SpecInclude" in node:
+                raise NotSupportedInFppToJsonException("SpecInclude")
+        return members
+
+    def translate_topology_members(self, l: List) -> List[fpp_ast.TopologyMember]:
+        members = []
+        for m in l:
+            m_dict: dict = m[1]
+            m_key = list(m_dict.keys())[0]
+            id = m_dict[m_key]["node"]["AstNode"]["id"]
+            data: dict = m_dict[m_key]["node"]["AstNode"]["data"]
+            member: Optional[fpp_ast.TopologyMemberNode] = None
+            match m_key:
+                case "SpecCompInstance":
+                    visibility = fpp_ast.Visibility.PRIVATE
+                    if "Public" in data["visibility"]:
+                        visibility = fpp_ast.Visibility.PUBLIC
+                    member = fpp_ast.TopologyMemberSpecCompInstance(
+                        AstNode.create_with_id(
+                            fpp_ast.SpecCompInstance(
+                                visibility, self.translate_qual_ident(data["instance"])
+                            ),
+                            id,
+                        )
+                    )
+                case "SpecConnectionGraph":
+                    if "Direct" in data:
+                        connections = []
+                        for c in data["Direct"]["connections"]:
+                            connections.append(
+                                fpp_ast.Connection(
+                                    c["isUnmatched"],
+                                    self.translate_port_instance_identifier(
+                                        c["fromPort"]
                                     ),
-                                ),
-                                id,
-                            )
-                        )
-                    case "DefChoice":
-                        member = fpp_ast.StateMachineMemberDefChoice(
-                            AstNode.create_with_id(
-                                fpp_ast.DefChoice(
-                                    data["name"],
-                                    translate_ident(data["guard"]),
-                                    translate_transition_expr(data["ifTransition"]),
-                                    translate_transition_expr(data["elseTransition"]),
-                                ),
-                                id,
-                            )
-                        )
-                    case "DefGuard":
-                        member = fpp_ast.StateMachineMemberDefGuard(
-                            AstNode.create_with_id(
-                                fpp_ast.DefGuard(
-                                    data["name"],
-                                    translate_optional(
-                                        data["typeName"], translate_type_name
+                                    self.translate_optional(
+                                        c["fromIndex"], self.translate_expr
                                     ),
-                                ),
-                                id,
-                            )
-                        )
-                    case "DefSignal":
-                        member = fpp_ast.StateMachineMemberDefSignal(
-                            AstNode.create_with_id(
-                                fpp_ast.DefSignal(
-                                    data["name"],
-                                    translate_optional(
-                                        data["typeName"], translate_type_name
+                                    self.translate_port_instance_identifier(
+                                        c["toPort"]
                                     ),
-                                ),
-                                id,
+                                    self.translate_optional(
+                                        c["toIndex"], self.translate_expr
+                                    ),
+                                )
                             )
-                        )
-                    case "DefState":
-                        member = fpp_ast.StateMachineMemberDefState(
+                        member = fpp_ast.TopologyMemberSpecConnectionGraph(
                             AstNode.create_with_id(
-                                fpp_ast.DefState(
-                                    data["name"],
-                                    translate_state_members(data["members"]),
-                                ),
-                                id,
+                                fpp_ast.Direct(data["Direct"]["name"], connections), id
                             )
                         )
-                    case "SpecInitialTransition":
-                        member = fpp_ast.StateMachineMemberSpecInitialTransition(
-                            AstNode.create_with_id(
-                                fpp_ast.SpecInitialTransition(
-                                    translate_transition_expr(data["transition"])
-                                ),
-                                id,
-                            )
+                    elif "Pattern" in data:
+                        targets = []
+                        for t in data["Pattern"]["targets"]:
+                            targets.append(self.translate_qual_ident(t))
+                        connection_graph: fpp_ast.SpecConnectionGraph = fpp_ast.Pattern(
+                            translate_pattern_kind(data["Pattern"]["kind"]),
+                            self.translate_qual_ident(data["Pattern"]["source"]),
+                            targets,
                         )
-                    case _:
-                        raise InvalidFppToJsonField(k)
-                members.append(fpp_ast.StateMachineMember(annotate(l[0], member, l[2])))
-    return members
 
+                        member = fpp_ast.TopologyMemberSpecConnectionGraph(
+                            AstNode.create_with_id(connection_graph, id)
+                        )
+                    else:
+                        raise InvalidFppToJsonDictionary(
+                            "connection graph", data, self.location_map.get(id, None)
+                        )
+                case "SpecTlmPacketSet":
+                    omitted = []
+                    for o in data["omitted"]:
+                        omitted.append(self.translate_tlm_channel_identifier(o))
+                    member = fpp_ast.TopologyMemberSpecTlmPacketSet(
+                        AstNode.create_with_id(
+                            fpp_ast.SpecTlmPacketSet(
+                                data["name"],
+                                self.translate_tlm_packet_set_members(data["members"]),
+                                omitted,
+                            ),
+                            id,
+                        )
+                    )
+                case "SpecTopImport":
+                    member = fpp_ast.TopologyMemberSpecTopImport(
+                        AstNode.create_with_id(
+                            fpp_ast.SpecImport(self.translate_qual_ident(data["sym"])),
+                            id,
+                        )
+                    )
+                case "SpecInclude":
+                    raise NotSupportedInFppToJsonException(m_key)
+                case _:
+                    raise InvalidFppToJsonField(m_key, self.location_map.get(id, None))
+            members.append(fpp_ast.TopologyMember(self.annotate(m[0], member, m[2])))
+        return members
 
-def translate_trans_unit_list(l: List) -> List[fpp_ast.TransUnit]:
-    trans_units = []
-    for tu in l:
-        trans_unit_members = translate_module_members(tu["members"])
-        trans_units.append(fpp_ast.TransUnit(trans_unit_members))
-    return trans_units
+    def translate_module_members(self, l: List) -> List[fpp_ast.ModuleMember]:
+        members = []
+        for m in l:
+            m_dict: dict = m[1]
+            m_key = list(m_dict.keys())[0]
+            data, id = self.read_ast_node(m_dict[m_key]["node"])
+            member: Optional[fpp_ast.ModuleMemberNode] = None
+            match m_key:
+                case "DefAbsType":
+                    member = fpp_ast.ModuleMemberDefAbsType(
+                        self.translate_def_abs_type(data, id)
+                    )
+                case "DefAliasType":
+                    member = fpp_ast.ModuleMemberDefAliasType(
+                        self.translate_def_alias_type(data, id)
+                    )
+                case "DefArray":
+                    member = fpp_ast.ModuleMemberDefArray(
+                        self.translate_def_array(data, id)
+                    )
+                case "DefComponent":
+                    if "Active" in data["kind"]:
+                        kind = fpp_ast.ComponentKind.ACTIVE
+                    elif "Passive" in data["kind"]:
+                        kind = fpp_ast.ComponentKind.PASSIVE
+                    elif "Queued" in data["kind"]:
+                        kind = fpp_ast.ComponentKind.QUEUED
+                    else:
+                        raise InvalidFppToJsonDictionary(
+                            "component kind", data, self.location_map.get(id, None)
+                        )
+                    member = fpp_ast.ModuleMemberDefComponent(
+                        AstNode.create_with_id(
+                            fpp_ast.DefComponent(
+                                kind,
+                                data["name"],
+                                self.translate_component_members(data["members"]),
+                            ),
+                            id,
+                        )
+                    )
+                case "DefComponentInstance":
+                    member = fpp_ast.ModuleMemberDefComponentInstance(
+                        AstNode.create_with_id(
+                            fpp_ast.DefComponentInstance(
+                                data["name"],
+                                self.translate_qual_ident(data["component"]),
+                                self.translate_expr(data["baseId"]),
+                                self.translate_optional(
+                                    data["implType"], self.translate_string
+                                ),
+                                self.translate_optional(
+                                    data["file"], self.translate_string
+                                ),
+                                self.translate_optional(
+                                    data["queueSize"], self.translate_expr
+                                ),
+                                self.translate_optional(
+                                    data["stackSize"], self.translate_expr
+                                ),
+                                self.translate_optional(
+                                    data["priority"], self.translate_expr
+                                ),
+                                self.translate_optional(
+                                    data["cpu"], self.translate_expr
+                                ),
+                                self.translate_init_specs(data["initSpecs"]),
+                            ),
+                            id,
+                        )
+                    )
+                case "DefConstant":
+                    member = fpp_ast.ModuleMemberDefConstant(
+                        self.translate_def_constant(data, id)
+                    )
+                case "DefEnum":
+                    member = fpp_ast.ModuleMemberDefEnum(
+                        self.translate_def_enum(data, id)
+                    )
+                case "DefInterface":
+                    member = fpp_ast.ModuleMemberDefInterface(
+                        AstNode.create_with_id(
+                            fpp_ast.DefInterface(
+                                data["name"],
+                                self.translate_interface_members(data["members"]),
+                            ),
+                            id,
+                        )
+                    )
+                case "DefModule":
+                    member = fpp_ast.ModuleMemberDefModule(
+                        AstNode.create_with_id(
+                            fpp_ast.DefModule(
+                                data["name"],
+                                self.translate_module_members(data["members"]),
+                            ),
+                            id,
+                        )
+                    )
+                case "DefPort":
+                    member = fpp_ast.ModuleMemberDefPort(
+                        AstNode.create_with_id(
+                            fpp_ast.DefPort(
+                                data["name"],
+                                self.translate_formal_params(data["params"]),
+                                self.translate_optional(
+                                    data["returnType"], self.translate_type_name
+                                ),
+                            ),
+                            id,
+                        )
+                    )
+                case "DefStateMachine":
+                    member = fpp_ast.ModuleMemberDefStateMachine(
+                        self.translate_state_machine(data, id)
+                    )
+                case "DefStruct":
+                    member = fpp_ast.ModuleMemberDefStruct(
+                        self.translate_def_struct(data, id)
+                    )
+                case "DefTopology":
+                    member = fpp_ast.ModuleMemberDefTopology(
+                        AstNode.create_with_id(
+                            fpp_ast.DefTopology(
+                                data["name"],
+                                self.translate_topology_members(data["members"]),
+                            ),
+                            id,
+                        )
+                    )
+                case "SpecInclude":
+                    raise NotSupportedInFppToJsonException(m_key)
+                case "SpecLoc":
+                    member = fpp_ast.ModuleMemberSpecLoc(
+                        AstNode.create_with_id(
+                            fpp_ast.SpecLoc(
+                                translate_spec_loc_kind(data["kind"]),
+                                self.translate_qual_ident(data["symbol"]),
+                                self.translate_string(data["file"]),
+                                data["isDictionaryDef"],
+                            ),
+                            id,
+                        )
+                    )
+                case _:
+                    raise InvalidFppToJsonField(m_key, self.location_map.get(id, None))
+            members.append(fpp_ast.ModuleMember(self.annotate(m[0], member, m[2])))
+        return members
 
+    def translate_state_machine_members(
+        self,
+        d: Dict[str, List],
+    ) -> List[fpp_ast.StateMachineMember]:
+        members = []
+        if d.get("Some"):
+            for l in d["Some"]:
+                for k, v in l[1].items():
+                    data, id = self.read_ast_node(v["node"])
+                    member: Optional[fpp_ast.StateMachineMemberNode] = None
+                    match k:
+                        case "DefAction":
+                            member = fpp_ast.StateMachineMemberDefAction(
+                                AstNode.create_with_id(
+                                    fpp_ast.DefAction(
+                                        data["name"],
+                                        self.translate_optional(
+                                            data["typeName"], self.translate_type_name
+                                        ),
+                                    ),
+                                    id,
+                                )
+                            )
+                        case "DefChoice":
+                            member = fpp_ast.StateMachineMemberDefChoice(
+                                AstNode.create_with_id(
+                                    fpp_ast.DefChoice(
+                                        data["name"],
+                                        self.translate_ident(data["guard"]),
+                                        self.translate_transition_expr(
+                                            data["ifTransition"]
+                                        ),
+                                        self.translate_transition_expr(
+                                            data["elseTransition"]
+                                        ),
+                                    ),
+                                    id,
+                                )
+                            )
+                        case "DefGuard":
+                            member = fpp_ast.StateMachineMemberDefGuard(
+                                AstNode.create_with_id(
+                                    fpp_ast.DefGuard(
+                                        data["name"],
+                                        self.translate_optional(
+                                            data["typeName"], self.translate_type_name
+                                        ),
+                                    ),
+                                    id,
+                                )
+                            )
+                        case "DefSignal":
+                            member = fpp_ast.StateMachineMemberDefSignal(
+                                AstNode.create_with_id(
+                                    fpp_ast.DefSignal(
+                                        data["name"],
+                                        self.translate_optional(
+                                            data["typeName"], self.translate_type_name
+                                        ),
+                                    ),
+                                    id,
+                                )
+                            )
+                        case "DefState":
+                            member = fpp_ast.StateMachineMemberDefState(
+                                AstNode.create_with_id(
+                                    fpp_ast.DefState(
+                                        data["name"],
+                                        self.translate_state_members(data["members"]),
+                                    ),
+                                    id,
+                                )
+                            )
+                        case "SpecInitialTransition":
+                            member = fpp_ast.StateMachineMemberSpecInitialTransition(
+                                AstNode.create_with_id(
+                                    fpp_ast.SpecInitialTransition(
+                                        self.translate_transition_expr(
+                                            data["transition"]
+                                        )
+                                    ),
+                                    id,
+                                )
+                            )
+                        case _:
+                            raise InvalidFppToJsonField(
+                                k, self.location_map.get(id, None)
+                            )
+                    members.append(
+                        fpp_ast.StateMachineMember(self.annotate(l[0], member, l[2]))
+                    )
+        return members
 
-def translate_ast_json(file: str) -> List[fpp_ast.TransUnit]:
-    if not os.path.exists(file):
-        raise FileNotFoundError(f'File "{file}" not found')
-    with open(file, "r") as f:
-        data: Dict = json.load(f)
-        return translate_trans_unit_list(data["ast"])
+    def translate_trans_unit_list(self, l: List) -> List[fpp_ast.TransUnit]:
+        trans_units = []
+        for tu in l:
+            trans_unit_members = self.translate_module_members(tu["members"])
+            trans_units.append(fpp_ast.TransUnit(trans_unit_members))
+        return trans_units
+
+    def translate_ast_json(self) -> List[fpp_ast.TransUnit]:
+        if not os.path.exists(self.ast_json_file):
+            raise FileNotFoundError(f'File "{self.ast_json_file}" not found')
+        with open(self.ast_json_file, "r") as f:
+            data: Dict = json.load(f)
+            return self.translate_trans_unit_list(data["ast"])

--- a/fprime_python_model/translators/ast_translator.py
+++ b/fprime_python_model/translators/ast_translator.py
@@ -1060,6 +1060,7 @@ def translate_module_members(l: List) -> List[fpp_ast.ModuleMember]:
                             translate_spec_loc_kind(data["kind"]),
                             translate_qual_ident(data["symbol"]),
                             translate_string(data["file"]),
+                            data["isDictionaryDef"],
                         ),
                         id,
                     )

--- a/fprime_python_model/translators/construct_ast_id_map.py
+++ b/fprime_python_model/translators/construct_ast_id_map.py
@@ -214,6 +214,15 @@ class ConstructAstMap(AstVisitor):
         self, _in: In, a_node: AstNode[fpp_ast.Expr], e: fpp_ast.ExprArray
     ) -> Out:
         self.add_node_to_map(a_node)
+        for elem in e.elts:
+            self.add_node_to_map(elem)
+
+    def expr_array_subscript_node(
+        self, _in: In, a_node: AstNode[fpp_ast.Expr], e: fpp_ast.ExprArraySubscript
+    ) -> Out:
+        self.add_node_to_map(a_node)
+        self.expr_node(e.e1)
+        self.expr_node(e.e2)
 
     def expr_binop_node(
         self, _in: In, a_node: AstNode[fpp_ast.Expr], e: fpp_ast.ExprBinop
@@ -324,7 +333,7 @@ class ConstructAstMap(AstVisitor):
             self.add_node_to_map(data.id)
         self.add_node_to_map(data.format)
         if data.throttle:
-            self.expr_node(data.throttle)
+            self.throttle(data.throttle)
 
     def spec_include_annotated_node(
         self, _in: In, a_node: fpp_ast.Annotated[AstNode[fpp_ast.SpecInclude]]
@@ -630,6 +639,12 @@ class ConstructAstMap(AstVisitor):
             limit_kind, limit_val = limit
             self.add_node_to_map(limit_kind)
             self.expr_node(limit_val)
+
+    def throttle(self, throttle: AstNode[fpp_ast.EventThrottle]) -> Out:
+        data = throttle.data
+        self.expr_node(data.count)
+        if data.every:
+            self.expr_node(data.every)
 
     def construct_ast_map(
         self, tu_list: List[fpp_ast.TransUnit]

--- a/fprime_python_model/translators/loc_map_translator.py
+++ b/fprime_python_model/translators/loc_map_translator.py
@@ -1,9 +1,20 @@
 from fprime_python_model.fpp_ast.fpp_locations import Location
 import json
-from typing import Dict
+from typing import Dict, Optional
 import os
 from fprime_python_model.fpp_ast.fpp_ast_node import AstId
 from pathlib import Path
+
+
+def translate_including_loc(d: dict) -> Optional[Location]:
+    if "Some" in d:
+        return Location(
+            Path(d["Some"]["file"]),
+            d["Some"]["pos"],
+            translate_including_loc(d["Some"]["includingLoc"]),
+        )
+    else:
+        return None
 
 
 def translate_location_map_json(file: str) -> dict[AstId, Location]:
@@ -14,7 +25,11 @@ def translate_location_map_json(file: str) -> dict[AstId, Location]:
         data: Dict[str, dict] = json.load(f)
         for k, v in data["locationMap"].items():
             try:
-                loc_map[int(k)] = Location(Path(v["file"]), v["pos"], v["includingLoc"])
+                loc_map[int(k)] = Location(
+                    Path(v["file"]),
+                    v["pos"],
+                    translate_including_loc(v["includingLoc"]),
+                )
             except KeyError as e:
                 raise KeyError(f"Location map for ID {k} is missing required field {e}")
     return loc_map

--- a/fprime_python_model/utils/error.py
+++ b/fprime_python_model/utils/error.py
@@ -1,19 +1,33 @@
+from fprime_python_model.fpp_ast.fpp_locations import Location
+from typing import Optional
+import json
+
+
 class InternalError(Exception):
     def __init__(self, message):
         self.message = message
         super().__init__(self.message)
 
 
+# Field not supported by fpp-to-json
 class NotSupportedInFppToJsonException(Exception):
     def __init__(self, field: str):
-        super().__init__(f"The {field} field is not supported in fpp-to-json")
+        super().__init__(f'The "{field}" field is not supported in fpp-to-json')
 
 
+# Error for invalid JSON field with optional node location
 class InvalidFppToJsonField(Exception):
-    def __init__(self, field: str):
-        super().__init__(f"The {field} field is not valid")
+    def __init__(self, field: str, node_location: Optional[Location] = None):
+        msg = f'The "{field}" field is not valid.'
+        if node_location:
+            msg += f"\nLocation: {str(node_location)}"
+        super().__init__(msg)
 
 
+# Error for invalid JSON dictionary with optional node location
 class InvalidFppToJsonDictionary(Exception):
-    def __init__(self, name: str, dict: dict):
-        super().__init__(f"The {name} dictionary is invalid: {dict}")
+    def __init__(self, name: str, dict: dict, node_location: Optional[Location] = None):
+        msg = f"Encountered invalid JSON dictionary when translating {name}. Invalid dictionary is:\n{json.dumps(dict, indent=2)}."
+        if node_location:
+            msg += f"\nLocation: {str(node_location)}"
+        super().__init__(msg)

--- a/fprime_python_model/utils/fpp_ast_visitor.py
+++ b/fprime_python_model/utils/fpp_ast_visitor.py
@@ -127,6 +127,11 @@ class AstVisitor(ABC, Generic[In, Out]):
     ) -> Out:
         return self.default(_in)
 
+    def expr_array_subscript_node(
+        self, _in: In, node: AstNode[fpp_ast.Expr], e: fpp_ast.ExprArraySubscript
+    ) -> Out:
+        return self.default(_in)
+
     def expr_binop_node(
         self, _in: In, node: AstNode[fpp_ast.Expr], e: fpp_ast.ExprBinop
     ) -> Out:
@@ -383,6 +388,8 @@ class AstVisitor(ABC, Generic[In, Out]):
         match expr:
             case fpp_ast.ExprArray():
                 return self.expr_array_node(_in, node, expr)
+            case fpp_ast.ExprArraySubscript():
+                return self.expr_array_subscript_node(_in, node, expr)
             case fpp_ast.ExprBinop():
                 return self.expr_binop_node(_in, node, expr)
             case fpp_ast.ExprDot():

--- a/fprime_python_model/utils/fpp_ast_writer.py
+++ b/fprime_python_model/utils/fpp_ast_writer.py
@@ -12,7 +12,7 @@ Out: TypeAlias = List[Line]
 
 class AstWriter(AstVisitor, LineUtils):
 
-    def ident(self, s: str) -> List[Line]:
+    def ident(self, s: str) -> Out:
         return self.lines(f"ident {s}")
 
     def write_trans_unit(self, tu: fpp_ast.TransUnit) -> Out:
@@ -25,10 +25,13 @@ class AstWriter(AstVisitor, LineUtils):
         a_node: fpp_ast.Annotated[AstNode[fpp_ast.DefAliasType]],
     ) -> Out:
         _, node, _ = a_node
-        return self.lines("def alias type") + list(
+        data = node.data
+        return self.prefix_with_dictionary(
+            "def alias type", data.is_dictionary_def
+        ) + list(
             map(
                 self.indent_in,
-                self.ident(node.data.name) + self.type_name_node(node.data.type_name),
+                self.ident(data.name) + self.type_name_node(data.type_name),
             )
         )
 
@@ -62,7 +65,7 @@ class AstWriter(AstVisitor, LineUtils):
     ):
         _, node, _ = a_node
         data = node.data
-        result = self.lines("def array")
+        result = self.prefix_with_dictionary("def array", data.is_dictionary_def)
         concat_list = (
             self.ident(data.name)
             + self.add_prefix("size", self.expr_node)(data.size)
@@ -152,7 +155,7 @@ class AstWriter(AstVisitor, LineUtils):
     ):
         _, node, _ = a_node
         data = node.data
-        result = self.lines("def constant")
+        result = self.prefix_with_dictionary("def constant", data.is_dictionary_def)
         concat_list = self.ident(data.name) + self.expr_node(data.value)
         return result + list(map(self.indent_in, concat_list))
 
@@ -162,7 +165,7 @@ class AstWriter(AstVisitor, LineUtils):
     ):
         _, node, _ = a_node
         data = node.data
-        result = self.lines("def enum")
+        result = self.prefix_with_dictionary("def enum", data.is_dictionary_def)
         enum_constant_lines = [
             self.annotate_node(self.def_enum_constant)(c) for c in data.constants
         ]
@@ -259,7 +262,7 @@ class AstWriter(AstVisitor, LineUtils):
     ):
         _, node, _ = a_node
         data = node.data
-        result = self.lines("def struct")
+        result = self.prefix_with_dictionary("def struct", data.is_dictionary_def)
         struct_type_member_lines = [
             self.annotate_node(self.struct_type_member)(m) for m in data.members
         ]
@@ -297,6 +300,15 @@ class AstWriter(AstVisitor, LineUtils):
         result = self.lines("expr array")
         concat_list = self.flatten([self.expr_node(el) for el in e.elts])
         return result + [self.indent_in(line) for line in concat_list]
+
+    @override
+    def expr_array_subscript_node(
+        self, _in: In, node: AstNode[fpp_ast.Expr], e: fpp_ast.ExprArraySubscript
+    ):
+        result = self.lines("expr array subscript")
+        return result + [
+            self.indent_in(line) for line in self.expr_node(e.e1) + self.expr_node(e.e2)
+        ]
 
     @override
     def expr_binop_node(
@@ -477,6 +489,14 @@ class AstWriter(AstVisitor, LineUtils):
     ):
         _, node, _ = a_node
         data = node.data
+
+        def throttle_clause(throttle: AstNode[fpp_ast.EventThrottle]) -> Out:
+            return self.add_prefix("throttle", self.expr_node)(
+                throttle.data.count
+            ) + self.lines_opt(
+                self.add_prefix("every", self.expr_node), throttle.data.every
+            )
+
         result = self.lines("spec event")
         concat_list = (
             self.ident(data.name)
@@ -484,7 +504,7 @@ class AstWriter(AstVisitor, LineUtils):
             + self.lines(f"severity {str(data.severity)}")
             + self.lines_opt(self.add_prefix("id", self.expr_node), data.id)
             + self.add_prefix("format", self.string)(data.format.data)
-            + self.lines_opt(self.add_prefix("throttle", self.expr_node), data.throttle)
+            + self.lines_opt(throttle_clause, data.throttle)
         )
         return result + [self.indent_in(line) for line in concat_list]
 
@@ -702,19 +722,19 @@ class AstWriter(AstVisitor, LineUtils):
         _, node, _ = a_node
         tc = node.data
 
-        def update(u: fpp_ast.SpecTlmChannelUpdate) -> List[Line]:
+        def update(u: fpp_ast.SpecTlmChannelUpdate) -> Out:
             return self.lines(f"update {u}")
 
-        def kind(k: fpp_ast.LimitKind) -> List[Line]:
+        def kind(k: fpp_ast.LimitKind) -> Out:
             return self.lines(str(k))
 
-        def limit(l: fpp_ast.Limit) -> List[Line]:
+        def limit(l: fpp_ast.Limit) -> Out:
             k, en = l
             return self.lines("limit") + list(
                 map(self.indent_in, kind(k.data) + self.expr_node(en))
             )
 
-        def limits(name: str, ls: List[fpp_ast.Limit]) -> List[Line]:
+        def limits(name: str, ls: List[fpp_ast.Limit]) -> Out:
             return self.flatten(list(map(self.add_prefix_no_indent(name, limit), ls)))
 
         lines_out = self.lines("spec tlm channel") + list(
@@ -841,10 +861,10 @@ class AstWriter(AstVisitor, LineUtils):
             for line in self.lines_opt(self.add_prefix("size", self.expr_node), tn.size)
         ]
 
-    def expr_node(self, node):
+    def expr_node(self, node) -> Out:
         return self.match_expr_node(None, node)
 
-    def annotate(self, pre: List[str], lines: Out, post: List[str]) -> List[Line]:
+    def annotate(self, pre: List[str], lines: Out, post: List[str]) -> Out:
         def pre_line(s: str) -> Line:
             return self.line(f"@ {s}")
 
@@ -864,10 +884,10 @@ class AstWriter(AstVisitor, LineUtils):
 
         return wrapped
 
-    def queue_full(self, qf: fpp_ast.QueueFull) -> List[Line]:
+    def queue_full(self, qf: fpp_ast.QueueFull) -> Out:
         return self.lines(f"queue full {qf}")
 
-    def spec_init(self, si: fpp_ast.SpecInit) -> List[Line]:
+    def spec_init(self, si: fpp_ast.SpecInit) -> Out:
         return self.lines("spec init") + list(
             map(
                 self.indent_in,
@@ -878,7 +898,7 @@ class AstWriter(AstVisitor, LineUtils):
             )
         )
 
-    def formal_param(self, fp: fpp_ast.FormalParam) -> List[Line]:
+    def formal_param(self, fp: fpp_ast.FormalParam) -> Out:
         def kind(k: fpp_ast.FormalParamKind) -> str:
             match k:
                 case fpp_ast.FormalParamKind.REF:
@@ -896,60 +916,60 @@ class AstWriter(AstVisitor, LineUtils):
         )
         return result
 
-    def formal_param_list(self, params: fpp_ast.FormalParamList) -> List[Line]:
+    def formal_param_list(self, params: fpp_ast.FormalParamList) -> Out:
         return [
             line
             for param in params
             for line in self.annotate_node(self.formal_param)(param)
         ]
 
-    def binop(self, op: fpp_ast.Binop) -> List[Line]:
+    def binop(self, op: fpp_ast.Binop) -> Out:
         return self.lines(f"binop {op}")
 
-    def unop(self, op: fpp_ast.Unop) -> List[Line]:
+    def unop(self, op: fpp_ast.Unop) -> Out:
         return self.lines(f"unop {op}")
 
-    def module_member(self, member: fpp_ast.ModuleMember) -> List[Line]:
+    def module_member(self, member: fpp_ast.ModuleMember) -> Out:
         a1, _, a2 = member.node
         l = self.match_module_member(None, member)
         return self.annotate(a1, l, a2)
 
-    def topology_member(self, member: fpp_ast.TopologyMember) -> List[Line]:
+    def topology_member(self, member: fpp_ast.TopologyMember) -> Out:
         a1, _, a2 = member.node
         l = self.match_topology_member(None, member)
         return self.annotate(a1, l, a2)
 
-    def component_member(self, member: fpp_ast.ComponentMember) -> List[Line]:
+    def component_member(self, member: fpp_ast.ComponentMember) -> Out:
         a1, _, a2 = member.node
         l = self.match_component_member(None, member)
         return self.annotate(a1, l, a2)
 
-    def state_member(self, member: fpp_ast.StateMember) -> List[Line]:
+    def state_member(self, member: fpp_ast.StateMember) -> Out:
         a1, _, a2 = member.node
         l = self.match_state_member(None, member)
         return self.annotate(a1, l, a2)
 
-    def state_machine_member(self, member: fpp_ast.StateMachineMember) -> List[Line]:
+    def state_machine_member(self, member: fpp_ast.StateMachineMember) -> Out:
         a1, _, a2 = member.node
         l = self.match_state_machine_member(None, member)
         return self.annotate(a1, l, a2)
 
-    def tu_member(self, tum: fpp_ast.TUMember) -> List[Line]:
+    def tu_member(self, tum: fpp_ast.TUMember) -> Out:
         return self.module_member(tum)
 
-    def interface_member(self, member: fpp_ast.InterfaceMember) -> List[Line]:
+    def interface_member(self, member: fpp_ast.InterfaceMember) -> Out:
         a1, _, a2 = member.node
         l = self.match_interface_member(None, member)
         return self.annotate(a1, l, a2)
 
-    def struct_member(self, member: fpp_ast.StructMember) -> List[Line]:
+    def struct_member(self, member: fpp_ast.StructMember) -> Out:
         return self.lines("struct member") + list(
             map(
                 self.indent_in, (self.ident(member.name) + self.expr_node(member.value))
             )
         )
 
-    def struct_type_member(self, member: fpp_ast.StructTypeMember) -> List[Line]:
+    def struct_type_member(self, member: fpp_ast.StructTypeMember) -> Out:
         return self.lines("struct type member") + list(
             map(
                 self.indent_in,
@@ -965,7 +985,7 @@ class AstWriter(AstVisitor, LineUtils):
             )
         )
 
-    def tlm_packet_member(self, member: fpp_ast.TlmPacketMember) -> List[Line]:
+    def tlm_packet_member(self, member: fpp_ast.TlmPacketMember) -> Out:
         match member:
             case fpp_ast.TlmPacketMemberSpecInclude():
                 return self.spec_include_annotated_node(None, ([], member.node, []))
@@ -976,20 +996,20 @@ class AstWriter(AstVisitor, LineUtils):
             case _:
                 raise Exception("TlmPacketMember writer not implemented")
 
-    def tlm_packet_set_member(self, member: fpp_ast.TlmPacketSetMember) -> List[Line]:
+    def tlm_packet_set_member(self, member: fpp_ast.TlmPacketSetMember) -> Out:
         a1, _, a2 = member.node
         l = self.match_tlm_packet_set_member(None, member)
         return self.annotate(a1, l, a2)
 
-    def action_list(self, actions: List[AstNode[fpp_ast.Ident]]) -> List[Line]:
+    def action_list(self, actions: List[AstNode[fpp_ast.Ident]]) -> Out:
         return [self.line(f"action ident {node.data}") for node in actions]
 
-    def transition_expr(self, transition: fpp_ast.TransitionExpr) -> List[Line]:
+    def transition_expr(self, transition: fpp_ast.TransitionExpr) -> Out:
         return self.action_list(transition.actions) + self.add_prefix(
             "target", self.apply_to_data(self.qual_ident)
         )(transition.target)
 
-    def string(self, s: str) -> List[Line]:
+    def string(self, s: str) -> Out:
         return [self.line(split_s) for split_s in s.split("\n")]
 
     def apply_to_data(self, f):
@@ -998,13 +1018,11 @@ class AstWriter(AstVisitor, LineUtils):
 
         return inner
 
-    def port_instance_identifier(
-        self, pii: fpp_ast.PortInstanceIdentifier
-    ) -> List[Line]:
+    def port_instance_identifier(self, pii: fpp_ast.PortInstanceIdentifier) -> Out:
         qid = fpp_ast.Qualified(pii.component_instance, pii.port_name)
         return self.qual_ident(qid)
 
-    def tlm_channel_identifier(self, tci: fpp_ast.TlmChannelIdentifier) -> List[Line]:
+    def tlm_channel_identifier(self, tci: fpp_ast.TlmChannelIdentifier) -> Out:
         qid = fpp_ast.Qualified(tci.component_instance, tci.channel_name)
         return self.qual_ident(qid)
 
@@ -1019,11 +1037,11 @@ class AstWriter(AstVisitor, LineUtils):
     def qual_ident(self, qid: fpp_ast.QualIdent) -> Out:
         return self.lines(f"qual ident {self.qual_ident_string(qid)}")
 
-    def def_enum_constant(self, dec: fpp_ast.DefEnumConstant) -> List[Line]:
+    def def_enum_constant(self, dec: fpp_ast.DefEnumConstant) -> Out:
         constants = self.ident(dec.name) + self.lines_opt(self.expr_node, dec.value)
         return self.lines("def enum constant") + list(map(self.indent_in, constants))
 
-    def file_string(self, s: str) -> List[Line]:
+    def file_string(self, s: str) -> Out:
         return self.lines(f"file {s}")
 
     def transition_or_do(self, tod):
@@ -1052,7 +1070,7 @@ class AstWriter(AstVisitor, LineUtils):
 
         return wrapped
 
-    def type_name_node(self, node: AstNode[fpp_ast.TypeName]) -> List[Line]:
+    def type_name_node(self, node: AstNode[fpp_ast.TypeName]) -> Out:
         func: Callable[[AstNode[fpp_ast.TypeName]], List[Line]] = (
             lambda n: self.match_type_name_node((), n)
         )
@@ -1069,3 +1087,9 @@ class AstWriter(AstVisitor, LineUtils):
             else:
                 result.append(item)
         return result
+
+    def prefix_with_dictionary(self, s: str, is_dictionary_def: bool) -> Out:
+        if is_dictionary_def:
+            return self.lines(f"dictionary {s}")
+        else:
+            return self.lines(s)

--- a/fprime_python_model/utils/fpp_writer.py
+++ b/fprime_python_model/utils/fpp_writer.py
@@ -47,7 +47,7 @@ class FppWriter(AstVisitor, LineUtils):
     def annotate(self, pre: List[str], lines: Out, post: List[str]) -> Lines:
         pre1 = [self.line(f"@ {s}") for s in pre]
         post1 = [self.line(f"@< {s}") for s in post]
-        return Lines(pre1 + lines.lines).join(" ", Lines(post1), True)
+        return Lines(pre1 + lines.lines).join(" ", Lines(post1))
 
     def annotate_node(
         self, f: Callable[[T], Out]
@@ -145,7 +145,7 @@ class FppWriter(AstVisitor, LineUtils):
         return (
             self.expr_node(si.phase)
             .add_prefix("phase ")
-            .join(" ", self.string(si.code), False)
+            .join_no_indent(" ", self.string(si.code))
         )
 
     def formal_param(self, fp: fpp_ast.FormalParam) -> Out:
@@ -186,23 +186,23 @@ class FppWriter(AstVisitor, LineUtils):
         return self.annotate(pre, l, post)
 
     def struct_member(self, member: fpp_ast.StructMember) -> Out:
-        return Lines(self.lines(self.ident(member.name))).join(
-            " = ", self.expr_node(member.value), False
+        return Lines(self.lines(self.ident(member.name))).join_no_indent(
+            " = ", self.expr_node(member.value)
         )
 
     def struct_type_member(self, member: fpp_ast.StructTypeMember) -> Out:
         return (
             Lines(self.lines(f"{self.ident(member.name)}:"))
             .join_opt(member.size, " ", self.bracket_expr_node)
-            .join(" ", self.type_name_node(member.type_name), False)
+            .join_no_indent(" ", self.type_name_node(member.type_name))
             .join_opt(member.format, " format ", self.apply_to_data(self.string))
         )
 
     def transition_expr(self, transition: fpp_ast.TransitionExpr) -> Out:
         sep = "enter " if not transition.actions else " enter "
 
-        return self.action_list(transition.actions).join(
-            sep, self.qual_ident(transition.target.data), False
+        return self.action_list(transition.actions).join_no_indent(
+            sep, self.qual_ident(transition.target.data)
         )
 
     def module_member(self, member: fpp_ast.ModuleMember) -> Out:
@@ -292,8 +292,8 @@ class FppWriter(AstVisitor, LineUtils):
                     )
                 )
             )
-            .join("", self.expr_node(data.size), False)
-            .join("] ", self.type_name_node(data.elt_type), False)
+            .join_no_indent("", self.expr_node(data.size))
+            .join_no_indent("] ", self.type_name_node(data.elt_type))
             .join_opt(data.default, " default ", self.expr_node)
             .join_opt(data.format, " format ", self.apply_to_data(self.string))
         )
@@ -354,8 +354,8 @@ class FppWriter(AstVisitor, LineUtils):
 
         return (
             Lines(self.lines(f"instance {self.ident(data.name)}"))
-            .join(": ", self.qual_ident(data.component.data), False)
-            .join(" base id ", self.expr_node(data.base_id), False)
+            .join_no_indent(": ", self.qual_ident(data.component.data))
+            .join_no_indent(" base id ", self.expr_node(data.base_id))
             .join_opt_with_break(
                 data.impl_type, "type ", self.apply_to_data(self.string)
             )
@@ -390,7 +390,7 @@ class FppWriter(AstVisitor, LineUtils):
                     f"constant {self.ident(data.name)}", data.is_dictionary_def
                 )
             )
-        ).join(" = ", self.expr_node(data.value), True)
+        ).join(" = ", self.expr_node(data.value))
 
     def def_enum_annotated_node(
         self, _in, a_node: fpp_ast.Annotated[AstNode[fpp_ast.DefEnum]]
@@ -537,7 +537,7 @@ class FppWriter(AstVisitor, LineUtils):
         )
 
     def expr_dot_node(self, _in, node, e):
-        return self.expr_node(e.e).join(".", Lines(self.lines(e.id.data)), False)
+        return self.expr_node(e.e).join_no_indent(".", Lines(self.lines(e.id.data)))
 
     def expr_ident_node(self, _in, node, e):
         return Lines(self.lines(e.value))
@@ -565,12 +565,16 @@ class FppWriter(AstVisitor, LineUtils):
         return self.add_braces(Lines(struct_lines))
 
     def expr_unop_node(self, _in, node, e):
-        return Lines(self.lines(self.unop(e.op))).join("", self.expr_node(e.e), False)
+        return Lines(self.lines(self.unop(e.op))).join_no_indent(
+            "", self.expr_node(e.e)
+        )
 
     def expr_binop_node(
         self, _in: In, node: AstNode[fpp_ast.Expr], e: fpp_ast.ExprBinop
     ):
-        return self.expr_node(e.e1).join(self.binop(e.op), self.expr_node(e.e2), False)
+        return self.expr_node(e.e1).join_no_indent(
+            self.binop(e.op), self.expr_node(e.e2)
+        )
 
     def spec_command_annotated_node(
         self, _in, a_node: fpp_ast.Annotated[AstNode[fpp_ast.SpecCommand]]
@@ -708,8 +712,8 @@ class FppWriter(AstVisitor, LineUtils):
                     f"locate {self.prefix_with_dictionary(kind, data.is_dictionary_def)}"
                 )
             )
-            .join(" ", self.qual_ident(data.symbol.data), False)
-            .join(" at ", self.string(data.file.data), False)
+            .join_no_indent(" ", self.qual_ident(data.symbol.data))
+            .join_no_indent(" at ", self.string(data.file.data))
         )
 
     def spec_param_annotated_node(
@@ -742,7 +746,7 @@ class FppWriter(AstVisitor, LineUtils):
             return (
                 Lines(self.lines(f"{kind} port {self.ident(i.name)}:"))
                 .join_opt(i.size, " ", self.bracket_expr_node)
-                .join(" ", port(i.port), False)
+                .join_no_indent(" ", port(i.port))
                 .join_opt_with_break(i.priority, "priority ", self.expr_node)
                 .join_opt_with_break(
                     i.queue_full, "", self.apply_to_data(self.queue_full)
@@ -791,7 +795,7 @@ class FppWriter(AstVisitor, LineUtils):
         data = node.data
         return (
             Lines(self.lines(f"product record {self.ident(data.name)}"))
-            .join(": ", record_type(data.record_type, data.is_array), False)
+            .join_no_indent(": ", record_type(data.record_type, data.is_array))
             .join_opt(data.id, " id ", self.expr_node)
         )
 
@@ -800,16 +804,14 @@ class FppWriter(AstVisitor, LineUtils):
     ):
         _, node, _ = a_node
         data = node.data
-        return Lines(self.lines("entry ")).join(
-            "", self.action_list(data.actions), True
-        )
+        return Lines(self.lines("entry ")).join("", self.action_list(data.actions))
 
     def spec_state_exit_annotated_node(
         self, _in, a_node: fpp_ast.Annotated[AstNode[fpp_ast.SpecStateExit]]
     ):
         _, node, _ = a_node
         data = node.data
-        return Lines(self.lines("exit ")).join("", self.action_list(data.actions), True)
+        return Lines(self.lines("exit ")).join("", self.action_list(data.actions))
 
     def spec_state_machine_instance_annotated_node(
         self, _in, a_node: fpp_ast.Annotated[AstNode[fpp_ast.SpecStateMachineInstance]]
@@ -818,7 +820,7 @@ class FppWriter(AstVisitor, LineUtils):
         data = node.data
         return (
             Lines(self.lines(f"state machine instance {self.ident(data.name)}"))
-            .join(": ", self.qual_ident(data.state_machine.data), False)
+            .join_no_indent(": ", self.qual_ident(data.state_machine.data))
             .join_opt_with_break(data.priority, "priority ", self.expr_node)
             .join_opt_with_break(data.queue_full, "", self.queue_full)
         )
@@ -861,7 +863,7 @@ class FppWriter(AstVisitor, LineUtils):
 
         return (
             Lines(self.lines(f"telemetry {self.ident(data.name)}"))
-            .join(": ", self.type_name_node(data.type_name), False)
+            .join_no_indent(": ", self.type_name_node(data.type_name))
             .join_opt(data.id, " id ", self.expr_node)
             .join_opt(data.update, " update ", update)
             .join_opt_with_break(
@@ -876,19 +878,13 @@ class FppWriter(AstVisitor, LineUtils):
     ):
         _, node, _ = a_node
         data = node.data
-        # lines(s"packet ${ident(data.name)}").
-        # joinOpt (data.id) (" id ") (exprNode).
-        # join (" group ") (exprNode(data.group)).
-        # joinNoIndent (" ") (
-        #     addBraces(data.members.flatMap(tlmPacketMember))
-        # )
         member_lines = []
         for m in data.members:
             member_lines += self.tlm_packet_member(m).lines
         return (
             Lines(self.lines(f"packet {self.ident(data.name)}"))
             .join_opt(data.id, " id ", self.expr_node)
-            .join(" group ", self.expr_node(data.group), False)
+            .join_no_indent(" group ", self.expr_node(data.group))
             .join_no_indent(" ", self.add_braces(Lines(member_lines)))
         )
 

--- a/fprime_python_model/utils/fpp_writer.py
+++ b/fprime_python_model/utils/fpp_writer.py
@@ -255,8 +255,12 @@ class FppWriter(AstVisitor, LineUtils):
     ):
         _, node, _ = a_node
         data = node.data
-        return self.prefix_with_dictionary(
-            f"type {self.ident(data.name)} = ", data.is_dictionary_def
+        return Lines(
+            self.lines(
+                self.prefix_with_dictionary(
+                    f"type {self.ident(data.name)} = ", data.is_dictionary_def
+                )
+            )
         ).join("", self.type_name_node(data.type_name))
 
     def def_abs_type_annotated_node(
@@ -281,8 +285,12 @@ class FppWriter(AstVisitor, LineUtils):
         _, node, _ = a_node
         data = node.data
         return (
-            self.prefix_with_dictionary(
-                f"array {self.ident(data.name)} = [", data.is_dictionary_def
+            Lines(
+                self.lines(
+                    self.prefix_with_dictionary(
+                        f"array {self.ident(data.name)} = [", data.is_dictionary_def
+                    )
+                )
             )
             .join("", self.expr_node(data.size), False)
             .join("] ", self.type_name_node(data.elt_type), False)
@@ -376,8 +384,12 @@ class FppWriter(AstVisitor, LineUtils):
     ):
         _, node, _ = a_node
         data = node.data
-        return self.prefix_with_dictionary(
-            f"constant {self.ident(data.name)}", data.is_dictionary_def
+        return Lines(
+            self.lines(
+                self.prefix_with_dictionary(
+                    f"constant {self.ident(data.name)}", data.is_dictionary_def
+                )
+            )
         ).join(" = ", self.expr_node(data.value), True)
 
     def def_enum_annotated_node(
@@ -386,8 +398,12 @@ class FppWriter(AstVisitor, LineUtils):
         _, node, _ = a_node
         data = node.data
 
-        lines = self.prefix_with_dictionary(
-            f"enum {self.ident(data.name)}", data.is_dictionary_def
+        lines = Lines(
+            self.lines(
+                self.prefix_with_dictionary(
+                    f"enum {self.ident(data.name)}", data.is_dictionary_def
+                )
+            )
         ).join_opt(data.type_name, ": ", self.type_name_node)
 
         constants_lines = []
@@ -479,8 +495,12 @@ class FppWriter(AstVisitor, LineUtils):
             out: Lines = self.annotate_node(self.struct_type_member)(m)
             struct_lines += out.lines
         return (
-            self.prefix_with_dictionary(
-                f"struct {self.ident(data.name)}", data.is_dictionary_def
+            Lines(
+                self.lines(
+                    self.prefix_with_dictionary(
+                        f"struct {self.ident(data.name)}", data.is_dictionary_def
+                    )
+                )
             )
             .join_no_indent(" ", self.add_braces(Lines(struct_lines)))
             .join_opt(data.default, " default ", self.expr_node)
@@ -683,7 +703,11 @@ class FppWriter(AstVisitor, LineUtils):
         data = node.data
         kind = str(data.kind)
         return (
-            Lines(self.lines(f"locate {kind}"))
+            Lines(
+                self.lines(
+                    f"locate {self.prefix_with_dictionary(kind, data.is_dictionary_def)}"
+                )
+            )
             .join(" ", self.qual_ident(data.symbol.data), False)
             .join(" at ", self.string(data.file.data), False)
         )
@@ -943,8 +967,8 @@ class FppWriter(AstVisitor, LineUtils):
                 result.append(item)
         return result
 
-    def prefix_with_dictionary(self, s: str, is_dictionary_def) -> Out:
+    def prefix_with_dictionary(self, s: str, is_dictionary_def) -> str:
         if is_dictionary_def:
-            return Lines(self.lines(f"dictionary {s}"))
+            return f"dictionary {s}"
         else:
-            return Lines(self.lines(s))
+            return s

--- a/fprime_python_model/utils/fpp_writer.py
+++ b/fprime_python_model/utils/fpp_writer.py
@@ -255,15 +255,9 @@ class FppWriter(AstVisitor, LineUtils):
     ):
         _, node, _ = a_node
         data = node.data
-        return Lines(self.lines(f"type {self.ident(data.name)} = ")).join(
-            "", self.type_name_node(data.type_name)
-        )
-        # return join_lists(
-        #     IndentMode.NO_INDENT,
-        #     self.lines(f"type {self.ident(data.name)} = "),
-        #     "",
-        #     self.type_name_node(data.type_name),
-        # )
+        return self.prefix_with_dictionary(
+            f"type {self.ident(data.name)} = ", data.is_dictionary_def
+        ).join("", self.type_name_node(data.type_name))
 
     def def_abs_type_annotated_node(
         self, _in: In, a_node: fpp_ast.Annotated[AstNode[fpp_ast.DefAbsType]]
@@ -287,7 +281,9 @@ class FppWriter(AstVisitor, LineUtils):
         _, node, _ = a_node
         data = node.data
         return (
-            Lines(self.lines(f"array {self.ident(data.name)} = ["))
+            self.prefix_with_dictionary(
+                f"array {self.ident(data.name)} = [", data.is_dictionary_def
+            )
             .join("", self.expr_node(data.size), False)
             .join("] ", self.type_name_node(data.elt_type), False)
             .join_opt(data.default, " default ", self.expr_node)
@@ -380,9 +376,9 @@ class FppWriter(AstVisitor, LineUtils):
     ):
         _, node, _ = a_node
         data = node.data
-        return Lines(self.lines(f"constant {self.ident(data.name)}")).join(
-            " = ", self.expr_node(data.value), True
-        )
+        return self.prefix_with_dictionary(
+            f"constant {self.ident(data.name)}", data.is_dictionary_def
+        ).join(" = ", self.expr_node(data.value), True)
 
     def def_enum_annotated_node(
         self, _in, a_node: fpp_ast.Annotated[AstNode[fpp_ast.DefEnum]]
@@ -390,9 +386,9 @@ class FppWriter(AstVisitor, LineUtils):
         _, node, _ = a_node
         data = node.data
 
-        lines = Lines(self.lines(f"enum {self.ident(data.name)}")).join_opt(
-            data.type_name, ": ", self.type_name_node
-        )
+        lines = self.prefix_with_dictionary(
+            f"enum {self.ident(data.name)}", data.is_dictionary_def
+        ).join_opt(data.type_name, ": ", self.type_name_node)
 
         constants_lines = []
         for const in data.constants:
@@ -483,7 +479,9 @@ class FppWriter(AstVisitor, LineUtils):
             out: Lines = self.annotate_node(self.struct_type_member)(m)
             struct_lines += out.lines
         return (
-            Lines(self.lines(f"struct {self.ident(data.name)}"))
+            self.prefix_with_dictionary(
+                f"struct {self.ident(data.name)}", data.is_dictionary_def
+            )
             .join_no_indent(" ", self.add_braces(Lines(struct_lines)))
             .join_opt(data.default, " default ", self.expr_node)
         )
@@ -509,6 +507,13 @@ class FppWriter(AstVisitor, LineUtils):
             [self.line("[")]
             + [self.indent_in(x) for elt in e.elts for x in self.expr_node(elt)]
             + [self.line("]")]
+        )
+
+    def expr_array_subscript_node(
+        self, _in, node: AstNode[fpp_ast.Expr], e: fpp_ast.ExprArraySubscript
+    ):
+        return self.expr_node(e.e1).join(
+            "", self.expr_node(e.e2).add_prefix_and_suffix("[", "]")
         )
 
     def expr_dot_node(self, _in, node, e):
@@ -617,8 +622,10 @@ class FppWriter(AstVisitor, LineUtils):
     def spec_event_annotated_node(
         self, _in, a_node: fpp_ast.Annotated[AstNode[fpp_ast.SpecEvent]]
     ):
-        def event_throttle(throttle: AstNode[fpp_ast.Expr]):
-            return self.expr_node(throttle).add_prefix("throttle ")
+        def event_throttle(throttle: AstNode[fpp_ast.EventThrottle]):
+            return self.expr_node(throttle.data.count).add_prefix("throttle ").join_opt(
+                throttle.data.every, " every ", self.expr_node
+            )
 
         _, node, _ = a_node
         data = node.data
@@ -933,3 +940,9 @@ class FppWriter(AstVisitor, LineUtils):
             else:
                 result.append(item)
         return result
+
+    def prefix_with_dictionary(self, s: str, is_dictionary_def) -> Out:
+        if is_dictionary_def:
+            return Lines(self.lines(f"dictionary {s}"))
+        else:
+            return Lines(self.lines(s))

--- a/fprime_python_model/utils/fpp_writer.py
+++ b/fprime_python_model/utils/fpp_writer.py
@@ -623,8 +623,10 @@ class FppWriter(AstVisitor, LineUtils):
         self, _in, a_node: fpp_ast.Annotated[AstNode[fpp_ast.SpecEvent]]
     ):
         def event_throttle(throttle: AstNode[fpp_ast.EventThrottle]):
-            return self.expr_node(throttle.data.count).add_prefix("throttle ").join_opt(
-                throttle.data.every, " every ", self.expr_node
+            return (
+                self.expr_node(throttle.data.count)
+                .add_prefix("throttle ")
+                .join_opt(throttle.data.every, " every ", self.expr_node)
             )
 
         _, node, _ = a_node

--- a/fprime_python_model/utils/line_utils.py
+++ b/fprime_python_model/utils/line_utils.py
@@ -6,7 +6,12 @@ from enum import Enum
 T = TypeVar("T")
 
 
-@dataclass
+class IndentMode(Enum):
+    INDENT = "Indent"
+    NO_INDENT = "NoIndent"
+
+
+@dataclass(frozen=True)
 class Indentation:
     value: int = 0
 
@@ -20,10 +25,10 @@ class Indentation:
         return " " * self.value
 
 
+@dataclass(frozen=True)
 class Line:
-    def __init__(self, string: str = "", indent: Indentation | None = None):
-        self.string = string
-        self.indent = indent or Indentation(0)
+    string: str = ""
+    indent: Indentation = Indentation(0)
 
     def __str__(self) -> str:
         return f"{self.indent}{self.string}" if self.string else ""
@@ -38,12 +43,7 @@ class Line:
         return Line(self.string, Indentation(n))
 
     def get_size(self) -> int:
-        return int(self.indent.value) + len(self.string)
-
-
-class IndentMode(Enum):
-    INDENT = "Indent"
-    NO_INDENT = "NoIndent"
+        return self.indent.value + len(self.string)
 
 
 @dataclass
@@ -63,41 +63,28 @@ class Lines:
         return "\n".join(str(l) for l in self.lines)
 
     def add_suffix(self, suffix: str) -> Lines:
-        return self.join("", Lines([Line(suffix)]), False)
+        return Lines(add_suffix(self.lines, suffix))
 
     def add_prefix(self, prefix: str) -> Lines:
-        return Lines([Line(prefix)]).join("", self, False)
+        return Lines(add_prefix(prefix, self.lines))
 
     def add_prefix_and_suffix(self, prefix: str, suffix: str) -> Lines:
-        return self.add_prefix(prefix).add_suffix(suffix)
+        return Lines(add_prefix_and_suffix(prefix, self.lines, suffix))
 
-    def join(
-        self, sep: str, other: Lines, indent: bool = True
-    ) -> Lines:  # avoid passing boolean into func
-        if not other:
-            return self
-
-        *prefix, last1 = self.lines
-        first2, *rest2 = other.lines
-        joined = join(sep, last1, first2)
-
-        if indent:
-            indent_size = last1.get_size() + len(sep)
-            rest2 = [ln.indent_in(indent_size) for ln in rest2]
-
-        return Lines(prefix + [joined] + rest2)
+    def join(self, sep: str, other: Lines) -> Lines:
+        return Lines(join_lists(IndentMode.INDENT, self.lines, sep, other.lines))
 
     def join_no_indent(self, sep: str, other: Lines) -> Lines:
-        return self.join(sep, other, indent=False)
+        return Lines(join_lists(IndentMode.NO_INDENT, self.lines, sep, other.lines))
 
     def join_with_break(self, sep: str, other: Lines) -> Lines:
         if not other.lines and not sep:
             return self
+
         result = self.add_suffix(" \\")
-        indented = []
-        for l in other.add_prefix(sep).lines:
-            indented.append(Line(l.string, l.indent.indent_in(2)))
-        # result += [Line(sep + l.string, l.indent.indent_in(2)) for l in other.lines]
+        indented = [
+            Line(l.string, l.indent.indent_in(2)) for l in other.add_prefix(sep).lines
+        ]
         return Lines(result.lines + indented)
 
     def join_opt(
@@ -155,10 +142,8 @@ def blank() -> Line:
 
 
 def blank_separated(f: Callable[[T], List[Line]], items: List[T]) -> List[Line]:
-    """Apply f to each item and insert blank lines between results."""
-    if not items:
-        return []
-    result = []
+    """Apply f to each item and insert blank lines between lists of lines."""
+    result: List[Line] = []
     for i, item in enumerate(items):
         result.extend(f(item))
         if i < len(items) - 1:
@@ -167,7 +152,7 @@ def blank_separated(f: Callable[[T], List[Line]], items: List[T]) -> List[Line]:
 
 
 class LineUtils:
-    """Convenience utilities for manipulating Lines."""
+    """Convenience utilities for manipulating lines."""
 
     indent_increment = 2
     q = '"'
@@ -179,11 +164,10 @@ class LineUtils:
         return Line(s)
 
     def lines(self, s: str) -> List[Line]:
-        """Create multiple lines from a string, removing leading '|' markers."""
         stripped = "\n".join(
             part.split("|", 1)[1] if "|" in part else part for part in s.split("\n")
         )
         return [self.line(line) for line in stripped.split("\n")]
 
-    def lines_opt(self, f: Callable, o: Optional[Any]) -> List[Line]:
+    def lines_opt(self, f: Callable[[Any], List[Line]], o: Optional[Any]) -> List[Line]:
         return [] if o is None else f(o)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,8 @@ classifiers = [
 ]
 
 dependencies = [
-  "mypy==1.17.1"
+  "mypy==1.17.1",
+  "pytest"
 ]
 
 [project.urls]

--- a/tests/active_component/active_component_analysis.json
+++ b/tests/active_component/active_component_analysis.json
@@ -1,564 +1,627 @@
 {
-  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
-  "analysis": {
-    "componentInstanceMap": {
-      "165": {
-        "aNode": {
-          "astNodeId": 165
+  "fppVersion" : "v3.1.0a10-54-g11243e778",
+  "analysis" : {
+    "componentInstanceMap" : {
+      "165" : {
+        "aNode" : {
+          "astNodeId" : 165
         },
-        "qualifiedName": {
-          "qualifier": ["FSW"],
-          "base": "dataCompressor"
+        "qualifiedName" : {
+          "qualifier" : [
+            "FSW"
+          ],
+          "base" : "dataCompressor"
         },
-        "component": {
-          "astNodeId": 58
+        "component" : {
+          "astNodeId" : 58
         },
-        "baseId": 256,
-        "maxId": 255,
-        "file": "None",
-        "queueSize": {
-          "Some": 10
+        "baseId" : 256,
+        "maxId" : 255,
+        "file" : "None",
+        "queueSize" : {
+          "Some" : 10
         },
-        "stackSize": {
-          "Some": 10240
+        "stackSize" : {
+          "Some" : 10240
         },
-        "priority": {
-          "Some": 30
+        "priority" : {
+          "Some" : 30
         },
-        "cpu": "None",
-        "initSpecifierMap": {}
+        "cpu" : "None",
+        "initSpecifierMap" : {
+          
+        }
       },
-      "201": {
-        "aNode": {
-          "astNodeId": 201
+      "201" : {
+        "aNode" : {
+          "astNodeId" : 201
         },
-        "qualifiedName": {
-          "qualifier": ["FSW"],
-          "base": "stateMachines"
+        "qualifiedName" : {
+          "qualifier" : [
+            "FSW"
+          ],
+          "base" : "stateMachines"
         },
-        "component": {
-          "astNodeId": 137
+        "component" : {
+          "astNodeId" : 137
         },
-        "baseId": 512,
-        "maxId": 511,
-        "file": "None",
-        "queueSize": {
-          "Some": 10
+        "baseId" : 512,
+        "maxId" : 511,
+        "file" : "None",
+        "queueSize" : {
+          "Some" : 10
         },
-        "stackSize": {
-          "Some": 10240
+        "stackSize" : {
+          "Some" : 10240
         },
-        "priority": {
-          "Some": 40
+        "priority" : {
+          "Some" : 40
         },
-        "cpu": "None",
-        "initSpecifierMap": {}
+        "cpu" : "None",
+        "initSpecifierMap" : {
+          
+        }
       }
     },
-    "componentMap": {
-      "58": {
-        "aNode": {
-          "astNodeId": 58
+    "componentMap" : {
+      "58" : {
+        "aNode" : {
+          "astNodeId" : 58
         },
-        "portMap": {
-          "bufferSendIn": {
-            "General": {
-              "aNode": {
-                "astNodeId": 45
+        "portMap" : {
+          "bufferSendIn" : {
+            "General" : {
+              "aNode" : {
+                "astNodeId" : 45
               },
-              "specifier": {
-                "kind": {
-                  "AsyncInput": {}
-                },
-                "name": "bufferSendIn",
-                "size": "None",
-                "port": {
-                  "Some": {
-                    "astNodeId": 44
+              "specifier" : {
+                "kind" : {
+                  "AsyncInput" : {
+                    
                   }
                 },
-                "priority": "None",
-                "queueFull": "None"
+                "name" : "bufferSendIn",
+                "size" : "None",
+                "port" : {
+                  "Some" : {
+                    "astNodeId" : 44
+                  }
+                },
+                "priority" : "None",
+                "queueFull" : "None"
               },
-              "kind": "AsyncInput",
-              "size": 1,
-              "ty": {
-                "DefPort": {
-                  "symbol": {
-                    "Port": {
-                      "nodeId": 2,
-                      "unqualifiedName": "BufferSend"
+              "kind" : "AsyncInput",
+              "size" : 1,
+              "ty" : {
+                "DefPort" : {
+                  "symbol" : {
+                    "Port" : {
+                      "nodeId" : 2,
+                      "unqualifiedName" : "BufferSend"
                     }
                   }
                 }
               },
-              "importNodeIds": []
+              "importNodeIds" : [
+              ]
             }
           },
-          "bufferSendOut": {
-            "General": {
-              "aNode": {
-                "astNodeId": 57
+          "bufferSendOut" : {
+            "General" : {
+              "aNode" : {
+                "astNodeId" : 57
               },
-              "specifier": {
-                "kind": {
-                  "Output": {}
-                },
-                "name": "bufferSendOut",
-                "size": "None",
-                "port": {
-                  "Some": {
-                    "astNodeId": 56
+              "specifier" : {
+                "kind" : {
+                  "Output" : {
+                    
                   }
                 },
-                "priority": "None",
-                "queueFull": "None"
+                "name" : "bufferSendOut",
+                "size" : "None",
+                "port" : {
+                  "Some" : {
+                    "astNodeId" : 56
+                  }
+                },
+                "priority" : "None",
+                "queueFull" : "None"
               },
-              "kind": "Output",
-              "size": 1,
-              "ty": {
-                "DefPort": {
-                  "symbol": {
-                    "Port": {
-                      "nodeId": 2,
-                      "unqualifiedName": "BufferSend"
+              "kind" : "Output",
+              "size" : 1,
+              "ty" : {
+                "DefPort" : {
+                  "symbol" : {
+                    "Port" : {
+                      "nodeId" : 2,
+                      "unqualifiedName" : "BufferSend"
                     }
                   }
                 }
               },
-              "importNodeIds": []
+              "importNodeIds" : [
+              ]
             }
           }
         },
-        "specialPortMap": {},
-        "commandMap": {},
-        "defaultOpcode": 0,
-        "tlmChannelMap": {},
-        "tlmChannelNameMap": {},
-        "defaultTlmChannelId": 0,
-        "eventMap": {},
-        "defaultEventId": 0,
-        "paramMap": {},
-        "specPortMatchingList": [],
-        "stateMachineInstanceMap": {},
-        "portMatchingList": [],
-        "defaultParamId": 0,
-        "containerMap": {},
-        "defaultContainerId": 0,
-        "recordMap": {},
-        "defaultRecordId": 0
+        "specialPortMap" : {
+          
+        },
+        "commandMap" : {
+          
+        },
+        "defaultOpcode" : 0,
+        "tlmChannelMap" : {
+          
+        },
+        "tlmChannelNameMap" : {
+          
+        },
+        "defaultTlmChannelId" : 0,
+        "eventMap" : {
+          
+        },
+        "defaultEventId" : 0,
+        "paramMap" : {
+          
+        },
+        "specPortMatchingList" : [
+        ],
+        "stateMachineInstanceMap" : {
+          
+        },
+        "portMatchingList" : [
+        ],
+        "defaultParamId" : 0,
+        "containerMap" : {
+          
+        },
+        "defaultContainerId" : 0,
+        "recordMap" : {
+          
+        },
+        "defaultRecordId" : 0
       },
-      "137": {
-        "aNode": {
-          "astNodeId": 137
+      "137" : {
+        "aNode" : {
+          "astNodeId" : 137
         },
-        "portMap": {
-          "schedIn": {
-            "General": {
-              "aNode": {
-                "astNodeId": 115
+        "portMap" : {
+          "schedIn" : {
+            "General" : {
+              "aNode" : {
+                "astNodeId" : 115
               },
-              "specifier": {
-                "kind": {
-                  "AsyncInput": {}
-                },
-                "name": "schedIn",
-                "size": "None",
-                "port": {
-                  "Some": {
-                    "astNodeId": 114
+              "specifier" : {
+                "kind" : {
+                  "AsyncInput" : {
+                    
                   }
                 },
-                "priority": "None",
-                "queueFull": "None"
+                "name" : "schedIn",
+                "size" : "None",
+                "port" : {
+                  "Some" : {
+                    "astNodeId" : 114
+                  }
+                },
+                "priority" : "None",
+                "queueFull" : "None"
               },
-              "kind": "AsyncInput",
-              "size": 1,
-              "ty": {
-                "DefPort": {
-                  "symbol": {
-                    "Port": {
-                      "nodeId": 6,
-                      "unqualifiedName": "Sched"
+              "kind" : "AsyncInput",
+              "size" : 1,
+              "ty" : {
+                "DefPort" : {
+                  "symbol" : {
+                    "Port" : {
+                      "nodeId" : 6,
+                      "unqualifiedName" : "Sched"
                     }
                   }
                 }
               },
-              "importNodeIds": []
+              "importNodeIds" : [
+              ]
             }
           }
         },
-        "specialPortMap": {},
-        "commandMap": {},
-        "defaultOpcode": 0,
-        "tlmChannelMap": {},
-        "tlmChannelNameMap": {},
-        "defaultTlmChannelId": 0,
-        "eventMap": {},
-        "defaultEventId": 0,
-        "paramMap": {},
-        "specPortMatchingList": [],
-        "stateMachineInstanceMap": {
-          "s1": {
-            "aNode": {
-              "astNodeId": 127
+        "specialPortMap" : {
+          
+        },
+        "commandMap" : {
+          
+        },
+        "defaultOpcode" : 0,
+        "tlmChannelMap" : {
+          
+        },
+        "tlmChannelNameMap" : {
+          
+        },
+        "defaultTlmChannelId" : 0,
+        "eventMap" : {
+          
+        },
+        "defaultEventId" : 0,
+        "paramMap" : {
+          
+        },
+        "specPortMatchingList" : [
+        ],
+        "stateMachineInstanceMap" : {
+          "s1" : {
+            "aNode" : {
+              "astNodeId" : 127
             },
-            "symbol": {
-              "node": {
-                "astNodeId": 116
+            "symbol" : {
+              "node" : {
+                "astNodeId" : 116
               }
             },
-            "priority": "None",
-            "queueFull": {
-              "Assert": {}
+            "priority" : "None",
+            "queueFull" : {
+              "Assert" : {
+                
+              }
             }
           },
-          "s2": {
-            "aNode": {
-              "astNodeId": 136
+          "s2" : {
+            "aNode" : {
+              "astNodeId" : 136
             },
-            "symbol": {
-              "node": {
-                "astNodeId": 124
+            "symbol" : {
+              "node" : {
+                "astNodeId" : 124
               }
             },
-            "priority": "None",
-            "queueFull": {
-              "Assert": {}
+            "priority" : "None",
+            "queueFull" : {
+              "Assert" : {
+                
+              }
             }
           }
         },
-        "portMatchingList": [],
-        "defaultParamId": 0,
-        "containerMap": {},
-        "defaultContainerId": 0,
-        "recordMap": {},
-        "defaultRecordId": 0
+        "portMatchingList" : [
+        ],
+        "defaultParamId" : 0,
+        "containerMap" : {
+          
+        },
+        "defaultContainerId" : 0,
+        "recordMap" : {
+          
+        },
+        "defaultRecordId" : 0
       }
     },
-    "includedFileSet": [],
-    "inputFileSet": [
+    "includedFileSet" : [
+    ],
+    "inputFileSet" : [
       "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp"
     ],
-    "locationSpecifierMap": [],
-    "parentSymbolMap": {
-      "153": {
-        "Module": {
-          "nodeId": 202,
-          "unqualifiedName": "FSW"
+    "locationSpecifierMap" : [
+    ],
+    "parentSymbolMap" : {
+      "153" : {
+        "Module" : {
+          "nodeId" : 202,
+          "unqualifiedName" : "FSW"
         }
       },
-      "124": {
-        "Component": {
-          "nodeId": 137,
-          "unqualifiedName": "StateMachines"
+      "124" : {
+        "Component" : {
+          "nodeId" : 137,
+          "unqualifiedName" : "StateMachines"
         }
       },
-      "201": {
-        "Module": {
-          "nodeId": 202,
-          "unqualifiedName": "FSW"
+      "201" : {
+        "Module" : {
+          "nodeId" : 202,
+          "unqualifiedName" : "FSW"
         }
       },
-      "152": {
-        "Module": {
-          "nodeId": 153,
-          "unqualifiedName": "Default"
+      "152" : {
+        "Module" : {
+          "nodeId" : 153,
+          "unqualifiedName" : "Default"
         }
       },
-      "116": {
-        "Component": {
-          "nodeId": 137,
-          "unqualifiedName": "StateMachines"
+      "116" : {
+        "Component" : {
+          "nodeId" : 137,
+          "unqualifiedName" : "StateMachines"
         }
       },
-      "137": {
-        "Module": {
-          "nodeId": 138,
-          "unqualifiedName": "M"
+      "137" : {
+        "Module" : {
+          "nodeId" : 138,
+          "unqualifiedName" : "M"
         }
       },
-      "6": {
-        "Module": {
-          "nodeId": 7,
-          "unqualifiedName": "Svc"
+      "6" : {
+        "Module" : {
+          "nodeId" : 7,
+          "unqualifiedName" : "Svc"
         }
       },
-      "140": {
-        "Module": {
-          "nodeId": 153,
-          "unqualifiedName": "Default"
+      "140" : {
+        "Module" : {
+          "nodeId" : 153,
+          "unqualifiedName" : "Default"
         }
       },
-      "58": {
-        "Module": {
-          "nodeId": 59,
-          "unqualifiedName": "Utils"
+      "58" : {
+        "Module" : {
+          "nodeId" : 59,
+          "unqualifiedName" : "Utils"
         }
       },
-      "2": {
-        "Module": {
-          "nodeId": 3,
-          "unqualifiedName": "Fw"
+      "2" : {
+        "Module" : {
+          "nodeId" : 3,
+          "unqualifiedName" : "Fw"
         }
       },
-      "165": {
-        "Module": {
-          "nodeId": 202,
-          "unqualifiedName": "FSW"
+      "165" : {
+        "Module" : {
+          "nodeId" : 202,
+          "unqualifiedName" : "FSW"
         }
       }
     },
-    "symbolScopeMap": {
-      "153": {
-        "map": {
-          "Value": {
-            "map": {
-              "queueSize": {
-                "Constant": {
-                  "nodeId": 140,
-                  "unqualifiedName": "queueSize"
+    "symbolScopeMap" : {
+      "153" : {
+        "map" : {
+          "Value" : {
+            "map" : {
+              "queueSize" : {
+                "Constant" : {
+                  "nodeId" : 140,
+                  "unqualifiedName" : "queueSize"
                 }
               },
-              "stackSize": {
-                "Constant": {
-                  "nodeId": 152,
-                  "unqualifiedName": "stackSize"
+              "stackSize" : {
+                "Constant" : {
+                  "nodeId" : 152,
+                  "unqualifiedName" : "stackSize"
                 }
               }
             }
           }
         }
       },
-      "59": {
-        "map": {
-          "Component": {
-            "map": {
-              "DataCompressor": {
-                "Component": {
-                  "nodeId": 58,
-                  "unqualifiedName": "DataCompressor"
+      "59" : {
+        "map" : {
+          "Component" : {
+            "map" : {
+              "DataCompressor" : {
+                "Component" : {
+                  "nodeId" : 58,
+                  "unqualifiedName" : "DataCompressor"
                 }
               }
             }
           },
-          "StateMachine": {
-            "map": {
-              "DataCompressor": {
-                "Component": {
-                  "nodeId": 58,
-                  "unqualifiedName": "DataCompressor"
+          "StateMachine" : {
+            "map" : {
+              "DataCompressor" : {
+                "Component" : {
+                  "nodeId" : 58,
+                  "unqualifiedName" : "DataCompressor"
                 }
               }
             }
           },
-          "Type": {
-            "map": {
-              "DataCompressor": {
-                "Component": {
-                  "nodeId": 58,
-                  "unqualifiedName": "DataCompressor"
+          "Type" : {
+            "map" : {
+              "DataCompressor" : {
+                "Component" : {
+                  "nodeId" : 58,
+                  "unqualifiedName" : "DataCompressor"
                 }
               }
             }
           },
-          "Value": {
-            "map": {
-              "DataCompressor": {
-                "Component": {
-                  "nodeId": 58,
-                  "unqualifiedName": "DataCompressor"
+          "Value" : {
+            "map" : {
+              "DataCompressor" : {
+                "Component" : {
+                  "nodeId" : 58,
+                  "unqualifiedName" : "DataCompressor"
                 }
               }
             }
           }
         }
       },
-      "138": {
-        "map": {
-          "Component": {
-            "map": {
-              "StateMachines": {
-                "Component": {
-                  "nodeId": 137,
-                  "unqualifiedName": "StateMachines"
+      "138" : {
+        "map" : {
+          "Component" : {
+            "map" : {
+              "StateMachines" : {
+                "Component" : {
+                  "nodeId" : 137,
+                  "unqualifiedName" : "StateMachines"
                 }
               }
             }
           },
-          "StateMachine": {
-            "map": {
-              "StateMachines": {
-                "Component": {
-                  "nodeId": 137,
-                  "unqualifiedName": "StateMachines"
+          "StateMachine" : {
+            "map" : {
+              "StateMachines" : {
+                "Component" : {
+                  "nodeId" : 137,
+                  "unqualifiedName" : "StateMachines"
                 }
               }
             }
           },
-          "Type": {
-            "map": {
-              "StateMachines": {
-                "Component": {
-                  "nodeId": 137,
-                  "unqualifiedName": "StateMachines"
+          "Type" : {
+            "map" : {
+              "StateMachines" : {
+                "Component" : {
+                  "nodeId" : 137,
+                  "unqualifiedName" : "StateMachines"
                 }
               }
             }
           },
-          "Value": {
-            "map": {
-              "StateMachines": {
-                "Component": {
-                  "nodeId": 137,
-                  "unqualifiedName": "StateMachines"
+          "Value" : {
+            "map" : {
+              "StateMachines" : {
+                "Component" : {
+                  "nodeId" : 137,
+                  "unqualifiedName" : "StateMachines"
                 }
               }
             }
           }
         }
       },
-      "202": {
-        "map": {
-          "ComponentInstance": {
-            "map": {
-              "Default": {
-                "Module": {
-                  "nodeId": 153,
-                  "unqualifiedName": "Default"
+      "202" : {
+        "map" : {
+          "ComponentInstance" : {
+            "map" : {
+              "Default" : {
+                "Module" : {
+                  "nodeId" : 153,
+                  "unqualifiedName" : "Default"
                 }
               },
-              "dataCompressor": {
-                "ComponentInstance": {
-                  "nodeId": 165,
-                  "unqualifiedName": "dataCompressor"
+              "dataCompressor" : {
+                "ComponentInstance" : {
+                  "nodeId" : 165,
+                  "unqualifiedName" : "dataCompressor"
                 }
               },
-              "stateMachines": {
-                "ComponentInstance": {
-                  "nodeId": 201,
-                  "unqualifiedName": "stateMachines"
+              "stateMachines" : {
+                "ComponentInstance" : {
+                  "nodeId" : 201,
+                  "unqualifiedName" : "stateMachines"
                 }
               }
             }
           },
-          "Topology": {
-            "map": {
-              "Default": {
-                "Module": {
-                  "nodeId": 153,
-                  "unqualifiedName": "Default"
+          "Topology" : {
+            "map" : {
+              "Default" : {
+                "Module" : {
+                  "nodeId" : 153,
+                  "unqualifiedName" : "Default"
                 }
               }
             }
           },
-          "Interface": {
-            "map": {
-              "Default": {
-                "Module": {
-                  "nodeId": 153,
-                  "unqualifiedName": "Default"
+          "Interface" : {
+            "map" : {
+              "Default" : {
+                "Module" : {
+                  "nodeId" : 153,
+                  "unqualifiedName" : "Default"
                 }
               }
             }
           },
-          "StateMachine": {
-            "map": {
-              "Default": {
-                "Module": {
-                  "nodeId": 153,
-                  "unqualifiedName": "Default"
+          "StateMachine" : {
+            "map" : {
+              "Default" : {
+                "Module" : {
+                  "nodeId" : 153,
+                  "unqualifiedName" : "Default"
                 }
               }
             }
           },
-          "Value": {
-            "map": {
-              "Default": {
-                "Module": {
-                  "nodeId": 153,
-                  "unqualifiedName": "Default"
+          "Value" : {
+            "map" : {
+              "Default" : {
+                "Module" : {
+                  "nodeId" : 153,
+                  "unqualifiedName" : "Default"
                 }
               }
             }
           },
-          "Port": {
-            "map": {
-              "Default": {
-                "Module": {
-                  "nodeId": 153,
-                  "unqualifiedName": "Default"
+          "Port" : {
+            "map" : {
+              "Default" : {
+                "Module" : {
+                  "nodeId" : 153,
+                  "unqualifiedName" : "Default"
                 }
               }
             }
           },
-          "Component": {
-            "map": {
-              "Default": {
-                "Module": {
-                  "nodeId": 153,
-                  "unqualifiedName": "Default"
+          "Component" : {
+            "map" : {
+              "Default" : {
+                "Module" : {
+                  "nodeId" : 153,
+                  "unqualifiedName" : "Default"
                 }
               }
             }
           },
-          "Type": {
-            "map": {
-              "Default": {
-                "Module": {
-                  "nodeId": 153,
-                  "unqualifiedName": "Default"
+          "Type" : {
+            "map" : {
+              "Default" : {
+                "Module" : {
+                  "nodeId" : 153,
+                  "unqualifiedName" : "Default"
                 }
               }
             }
           }
         }
       },
-      "137": {
-        "map": {
-          "StateMachine": {
-            "map": {
-              "S1": {
-                "StateMachine": {
-                  "nodeId": 116,
-                  "unqualifiedName": "S1"
+      "137" : {
+        "map" : {
+          "StateMachine" : {
+            "map" : {
+              "S1" : {
+                "StateMachine" : {
+                  "nodeId" : 116,
+                  "unqualifiedName" : "S1"
                 }
               },
-              "S2": {
-                "StateMachine": {
-                  "nodeId": 124,
-                  "unqualifiedName": "S2"
+              "S2" : {
+                "StateMachine" : {
+                  "nodeId" : 124,
+                  "unqualifiedName" : "S2"
                 }
               }
             }
           }
         }
       },
-      "58": {
-        "map": {}
+      "58" : {
+        "map" : {
+          
+        }
       },
-      "7": {
-        "map": {
-          "Port": {
-            "map": {
-              "Sched": {
-                "Port": {
-                  "nodeId": 6,
-                  "unqualifiedName": "Sched"
+      "7" : {
+        "map" : {
+          "Port" : {
+            "map" : {
+              "Sched" : {
+                "Port" : {
+                  "nodeId" : 6,
+                  "unqualifiedName" : "Sched"
                 }
               }
             }
           }
         }
       },
-      "3": {
-        "map": {
-          "Port": {
-            "map": {
-              "BufferSend": {
-                "Port": {
-                  "nodeId": 2,
-                  "unqualifiedName": "BufferSend"
+      "3" : {
+        "map" : {
+          "Port" : {
+            "map" : {
+              "BufferSend" : {
+                "Port" : {
+                  "nodeId" : 2,
+                  "unqualifiedName" : "BufferSend"
                 }
               }
             }
@@ -566,367 +629,422 @@
         }
       }
     },
-    "topologyMap": {},
-    "typeMap": {
-      "193": {
-        "Int": {
-          "Integer": {}
+    "topologyMap" : {
+      
+    },
+    "typeMap" : {
+      "193" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "164": {
-        "Int": {
-          "Integer": {}
+      "164" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "139": {
-        "Int": {
-          "Integer": {}
+      "139" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "163": {
-        "Int": {
-          "Integer": {}
+      "163" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "152": {
-        "Int": {
-          "Integer": {}
+      "152" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "199": {
-        "Int": {
-          "Integer": {}
+      "199" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "196": {
-        "Int": {
-          "Integer": {}
+      "196" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "140": {
-        "Int": {
-          "Integer": {}
+      "140" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "151": {
-        "Int": {
-          "Integer": {}
+      "151" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "149": {
-        "Int": {
-          "Integer": {}
+      "149" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "160": {
-        "Int": {
-          "Integer": {}
+      "160" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "150": {
-        "Int": {
-          "Integer": {}
+      "150" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "200": {
-        "Int": {
-          "Integer": {}
+      "200" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "157": {
-        "Int": {
-          "Integer": {}
+      "157" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       }
     },
-    "useDefMap": {
-      "158": {
-        "Module": {
-          "nodeId": 153,
-          "unqualifiedName": "Default"
+    "useDefMap" : {
+      "158" : {
+        "Module" : {
+          "nodeId" : 153,
+          "unqualifiedName" : "Default"
         }
       },
-      "135": {
-        "StateMachine": {
-          "nodeId": 124,
-          "unqualifiedName": "S2"
+      "135" : {
+        "StateMachine" : {
+          "nodeId" : 124,
+          "unqualifiedName" : "S2"
         }
       },
-      "56": {
-        "Port": {
-          "nodeId": 2,
-          "unqualifiedName": "BufferSend"
+      "56" : {
+        "Port" : {
+          "nodeId" : 2,
+          "unqualifiedName" : "BufferSend"
         }
       },
-      "163": {
-        "Constant": {
-          "nodeId": 152,
-          "unqualifiedName": "stackSize"
+      "163" : {
+        "Constant" : {
+          "nodeId" : 152,
+          "unqualifiedName" : "stackSize"
         }
       },
-      "199": {
-        "Constant": {
-          "nodeId": 152,
-          "unqualifiedName": "stackSize"
+      "199" : {
+        "Constant" : {
+          "nodeId" : 152,
+          "unqualifiedName" : "stackSize"
         }
       },
-      "196": {
-        "Constant": {
-          "nodeId": 140,
-          "unqualifiedName": "queueSize"
+      "196" : {
+        "Constant" : {
+          "nodeId" : 140,
+          "unqualifiedName" : "queueSize"
         }
       },
-      "54": {
-        "Module": {
-          "nodeId": 3,
-          "unqualifiedName": "Fw"
+      "54" : {
+        "Module" : {
+          "nodeId" : 3,
+          "unqualifiedName" : "Fw"
         }
       },
-      "126": {
-        "StateMachine": {
-          "nodeId": 116,
-          "unqualifiedName": "S1"
+      "126" : {
+        "StateMachine" : {
+          "nodeId" : 116,
+          "unqualifiedName" : "S1"
         }
       },
-      "190": {
-        "Module": {
-          "nodeId": 138,
-          "unqualifiedName": "M"
+      "190" : {
+        "Module" : {
+          "nodeId" : 138,
+          "unqualifiedName" : "M"
         }
       },
-      "160": {
-        "Constant": {
-          "nodeId": 140,
-          "unqualifiedName": "queueSize"
+      "160" : {
+        "Constant" : {
+          "nodeId" : 140,
+          "unqualifiedName" : "queueSize"
         }
       },
-      "161": {
-        "Module": {
-          "nodeId": 153,
-          "unqualifiedName": "Default"
+      "161" : {
+        "Module" : {
+          "nodeId" : 153,
+          "unqualifiedName" : "Default"
         }
       },
-      "44": {
-        "Port": {
-          "nodeId": 2,
-          "unqualifiedName": "BufferSend"
+      "44" : {
+        "Port" : {
+          "nodeId" : 2,
+          "unqualifiedName" : "BufferSend"
         }
       },
-      "197": {
-        "Module": {
-          "nodeId": 153,
-          "unqualifiedName": "Default"
+      "197" : {
+        "Module" : {
+          "nodeId" : 153,
+          "unqualifiedName" : "Default"
         }
       },
-      "192": {
-        "Component": {
-          "nodeId": 137,
-          "unqualifiedName": "StateMachines"
+      "192" : {
+        "Component" : {
+          "nodeId" : 137,
+          "unqualifiedName" : "StateMachines"
         }
       },
-      "112": {
-        "Module": {
-          "nodeId": 7,
-          "unqualifiedName": "Svc"
+      "112" : {
+        "Module" : {
+          "nodeId" : 7,
+          "unqualifiedName" : "Svc"
         }
       },
-      "42": {
-        "Module": {
-          "nodeId": 3,
-          "unqualifiedName": "Fw"
+      "42" : {
+        "Module" : {
+          "nodeId" : 3,
+          "unqualifiedName" : "Fw"
         }
       },
-      "156": {
-        "Component": {
-          "nodeId": 58,
-          "unqualifiedName": "DataCompressor"
+      "156" : {
+        "Component" : {
+          "nodeId" : 58,
+          "unqualifiedName" : "DataCompressor"
         }
       },
-      "194": {
-        "Module": {
-          "nodeId": 153,
-          "unqualifiedName": "Default"
+      "194" : {
+        "Module" : {
+          "nodeId" : 153,
+          "unqualifiedName" : "Default"
         }
       },
-      "154": {
-        "Module": {
-          "nodeId": 59,
-          "unqualifiedName": "Utils"
+      "154" : {
+        "Module" : {
+          "nodeId" : 59,
+          "unqualifiedName" : "Utils"
         }
       },
-      "114": {
-        "Port": {
-          "nodeId": 6,
-          "unqualifiedName": "Sched"
+      "114" : {
+        "Port" : {
+          "nodeId" : 6,
+          "unqualifiedName" : "Sched"
         }
       }
     },
-    "valueMap": {
-      "193": {
-        "Integer": {
-          "value": 512
+    "valueMap" : {
+      "193" : {
+        "Integer" : {
+          "value" : 512
         }
       },
-      "164": {
-        "Integer": {
-          "value": 30
+      "164" : {
+        "Integer" : {
+          "value" : 30
         }
       },
-      "139": {
-        "Integer": {
-          "value": 10
+      "139" : {
+        "Integer" : {
+          "value" : 10
         }
       },
-      "163": {
-        "Integer": {
-          "value": 10240
+      "163" : {
+        "Integer" : {
+          "value" : 10240
         }
       },
-      "152": {
-        "Integer": {
-          "value": 10240
+      "152" : {
+        "Integer" : {
+          "value" : 10240
         }
       },
-      "199": {
-        "Integer": {
-          "value": 10240
+      "199" : {
+        "Integer" : {
+          "value" : 10240
         }
       },
-      "196": {
-        "Integer": {
-          "value": 10
+      "196" : {
+        "Integer" : {
+          "value" : 10
         }
       },
-      "140": {
-        "Integer": {
-          "value": 10
+      "140" : {
+        "Integer" : {
+          "value" : 10
         }
       },
-      "151": {
-        "Integer": {
-          "value": 10240
+      "151" : {
+        "Integer" : {
+          "value" : 10240
         }
       },
-      "149": {
-        "Integer": {
-          "value": 10
+      "149" : {
+        "Integer" : {
+          "value" : 10
         }
       },
-      "160": {
-        "Integer": {
-          "value": 10
+      "160" : {
+        "Integer" : {
+          "value" : 10
         }
       },
-      "150": {
-        "Integer": {
-          "value": 1024
+      "150" : {
+        "Integer" : {
+          "value" : 1024
         }
       },
-      "200": {
-        "Integer": {
-          "value": 40
+      "200" : {
+        "Integer" : {
+          "value" : 40
         }
       },
-      "157": {
-        "Integer": {
-          "value": 256
+      "157" : {
+        "Integer" : {
+          "value" : 256
         }
       }
     },
-    "stateMachineMap": {
-      "116": {
-        "aNode": {
-          "astNodeId": 116
+    "stateMachineMap" : {
+      "116" : {
+        "aNode" : {
+          "astNodeId" : 116
         },
-        "sma": {
-          "symbol": {
-            "node": {
-              "astNodeId": 116
+        "sma" : {
+          "symbol" : {
+            "node" : {
+              "astNodeId" : 116
             }
           },
-          "symbolScopeMap": {},
-          "useDefMap": {},
-          "transitionGraph": {
-            "initialNode": "None",
-            "arcMap": {}
+          "symbolScopeMap" : {
+            
           },
-          "reverseTransitionGraph": {
-            "initialNode": "None",
-            "arcMap": {}
+          "useDefMap" : {
+            
           },
-          "typeOptionMap": {},
-          "flattenedStateTransitionMap": {},
-          "flattenedChoiceTransitionMap": {}
+          "transitionGraph" : {
+            "initialNode" : "None",
+            "arcMap" : {
+              
+            }
+          },
+          "reverseTransitionGraph" : {
+            "initialNode" : "None",
+            "arcMap" : {
+              
+            }
+          },
+          "typeOptionMap" : {
+            
+          },
+          "flattenedStateTransitionMap" : {
+            
+          },
+          "flattenedChoiceTransitionMap" : {
+            
+          }
         }
       },
-      "124": {
-        "aNode": {
-          "astNodeId": 124
+      "124" : {
+        "aNode" : {
+          "astNodeId" : 124
         },
-        "sma": {
-          "symbol": {
-            "node": {
-              "astNodeId": 124
+        "sma" : {
+          "symbol" : {
+            "node" : {
+              "astNodeId" : 124
             }
           },
-          "symbolScopeMap": {
-            "123": {
-              "map": {}
-            }
-          },
-          "useDefMap": {
-            "118": {
-              "State": {
-                "nodeId": 123,
-                "unqualifiedName": "IDLE"
+          "symbolScopeMap" : {
+            "123" : {
+              "map" : {
+                
               }
             }
           },
-          "transitionGraph": {
-            "initialNode": {
-              "Some": {
-                "soc": {
-                  "State": {
-                    "symbol": {
-                      "node": {
-                        "astNodeId": 123
+          "useDefMap" : {
+            "118" : {
+              "State" : {
+                "nodeId" : 123,
+                "unqualifiedName" : "IDLE"
+              }
+            }
+          },
+          "transitionGraph" : {
+            "initialNode" : {
+              "Some" : {
+                "soc" : {
+                  "State" : {
+                    "symbol" : {
+                      "node" : {
+                        "astNodeId" : 123
                       }
                     }
                   }
                 }
               }
             },
-            "arcMap": {
-              "123": []
+            "arcMap" : {
+              "123" : [
+              ]
             }
           },
-          "reverseTransitionGraph": {
-            "initialNode": {
-              "Some": {
-                "soc": {
-                  "State": {
-                    "symbol": {
-                      "node": {
-                        "astNodeId": 123
+          "reverseTransitionGraph" : {
+            "initialNode" : {
+              "Some" : {
+                "soc" : {
+                  "State" : {
+                    "symbol" : {
+                      "node" : {
+                        "astNodeId" : 123
                       }
                     }
                   }
                 }
               }
             },
-            "arcMap": {
-              "123": []
+            "arcMap" : {
+              "123" : [
+              ]
             }
           },
-          "typeOptionMap": {
-            "120": "None"
+          "typeOptionMap" : {
+            "120" : "None"
           },
-          "flattenedStateTransitionMap": {},
-          "flattenedChoiceTransitionMap": {}
+          "flattenedStateTransitionMap" : {
+            
+          },
+          "flattenedChoiceTransitionMap" : {
+            
+          }
         }
       }
     },
-    "dictionarySymbolSet": [],
-    "interfaceMap": {}
+    "dictionarySymbolSet" : [
+    ],
+    "interfaceMap" : {
+      
+    }
   }
 }

--- a/tests/active_component/active_component_analysis.json
+++ b/tests/active_component/active_component_analysis.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion": "[ fpp version ]",
+  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
   "analysis": {
     "componentInstanceMap": {
       "165": {
@@ -897,7 +897,7 @@
               }
             },
             "arcMap": {
-              "state IDLE": []
+              "123": []
             }
           },
           "reverseTransitionGraph": {
@@ -915,7 +915,7 @@
               }
             },
             "arcMap": {
-              "state IDLE": []
+              "123": []
             }
           },
           "typeOptionMap": {

--- a/tests/active_component/active_component_ast.json
+++ b/tests/active_component/active_component_ast.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion": "[ fpp version ]",
+  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
   "ast": [
     {
       "members": [

--- a/tests/active_component/active_component_ast.json
+++ b/tests/active_component/active_component_ast.json
@@ -1,807 +1,884 @@
 {
-  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
-  "ast": [
+  "fppVersion" : "v3.1.0a10-54-g11243e778",
+  "ast" : [
     {
-      "members": [
+      "members" : [
         [
-          [],
+          [
+          ],
           {
-            "DefModule": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "Fw",
-                    "members": [
+            "DefModule" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "Fw",
+                    "members" : [
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "DefPort": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "name": "BufferSend",
-                                  "params": [],
-                                  "returnType": "None"
+                          "DefPort" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "name" : "BufferSend",
+                                  "params" : [
+                                  ],
+                                  "returnType" : "None"
                                 },
-                                "id": 2
+                                "id" : 2
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ]
                     ]
                   },
-                  "id": 3
+                  "id" : 3
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          [],
+          [
+          ],
           {
-            "DefModule": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "Svc",
-                    "members": [
+            "DefModule" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "Svc",
+                    "members" : [
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "DefPort": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "name": "Sched",
-                                  "params": [],
-                                  "returnType": "None"
+                          "DefPort" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "name" : "Sched",
+                                  "params" : [
+                                  ],
+                                  "returnType" : "None"
                                 },
-                                "id": 6
+                                "id" : 6
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ]
                     ]
                   },
-                  "id": 7
+                  "id" : 7
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          [],
+          [
+          ],
           {
-            "DefModule": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "Utils",
-                    "members": [
+            "DefModule" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "Utils",
+                    "members" : [
                       [
-                        ["A component for compressing data"],
+                        [
+                          "A component for compressing data"
+                        ],
                         {
-                          "DefComponent": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "kind": {
-                                    "Active": {}
+                          "DefComponent" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "kind" : {
+                                    "Active" : {
+                                      
+                                    }
                                   },
-                                  "name": "DataCompressor",
-                                  "members": [
+                                  "name" : "DataCompressor",
+                                  "members" : [
                                     [
-                                      ["Uncompressed input data"],
+                                      [
+                                        "Uncompressed input data"
+                                      ],
                                       {
-                                        "SpecPortInstance": {
-                                          "node": {
-                                            "AstNode": {
-                                              "data": {
-                                                "General": {
-                                                  "kind": {
-                                                    "AsyncInput": {}
+                                        "SpecPortInstance" : {
+                                          "node" : {
+                                            "AstNode" : {
+                                              "data" : {
+                                                "General" : {
+                                                  "kind" : {
+                                                    "AsyncInput" : {
+                                                      
+                                                    }
                                                   },
-                                                  "name": "bufferSendIn",
-                                                  "size": "None",
-                                                  "port": {
-                                                    "Some": {
-                                                      "AstNode": {
-                                                        "data": {
-                                                          "Qualified": {
-                                                            "qualifier": {
-                                                              "AstNode": {
-                                                                "data": {
-                                                                  "Unqualified": {
-                                                                    "name": "Fw"
+                                                  "name" : "bufferSendIn",
+                                                  "size" : "None",
+                                                  "port" : {
+                                                    "Some" : {
+                                                      "AstNode" : {
+                                                        "data" : {
+                                                          "Qualified" : {
+                                                            "qualifier" : {
+                                                              "AstNode" : {
+                                                                "data" : {
+                                                                  "Unqualified" : {
+                                                                    "name" : "Fw"
                                                                   }
                                                                 },
-                                                                "id": 42
+                                                                "id" : 42
                                                               }
                                                             },
-                                                            "name": {
-                                                              "AstNode": {
-                                                                "data": "BufferSend",
-                                                                "id": 43
+                                                            "name" : {
+                                                              "AstNode" : {
+                                                                "data" : "BufferSend",
+                                                                "id" : 43
                                                               }
                                                             }
                                                           }
                                                         },
-                                                        "id": 44
+                                                        "id" : 44
                                                       }
                                                     }
                                                   },
-                                                  "priority": "None",
-                                                  "queueFull": "None"
+                                                  "priority" : "None",
+                                                  "queueFull" : "None"
                                                 }
                                               },
-                                              "id": 45
+                                              "id" : 45
                                             }
                                           }
                                         }
                                       },
-                                      []
+                                      [
+                                      ]
                                     ],
                                     [
-                                      ["Compressed output data"],
+                                      [
+                                        "Compressed output data"
+                                      ],
                                       {
-                                        "SpecPortInstance": {
-                                          "node": {
-                                            "AstNode": {
-                                              "data": {
-                                                "General": {
-                                                  "kind": {
-                                                    "Output": {}
+                                        "SpecPortInstance" : {
+                                          "node" : {
+                                            "AstNode" : {
+                                              "data" : {
+                                                "General" : {
+                                                  "kind" : {
+                                                    "Output" : {
+                                                      
+                                                    }
                                                   },
-                                                  "name": "bufferSendOut",
-                                                  "size": "None",
-                                                  "port": {
-                                                    "Some": {
-                                                      "AstNode": {
-                                                        "data": {
-                                                          "Qualified": {
-                                                            "qualifier": {
-                                                              "AstNode": {
-                                                                "data": {
-                                                                  "Unqualified": {
-                                                                    "name": "Fw"
+                                                  "name" : "bufferSendOut",
+                                                  "size" : "None",
+                                                  "port" : {
+                                                    "Some" : {
+                                                      "AstNode" : {
+                                                        "data" : {
+                                                          "Qualified" : {
+                                                            "qualifier" : {
+                                                              "AstNode" : {
+                                                                "data" : {
+                                                                  "Unqualified" : {
+                                                                    "name" : "Fw"
                                                                   }
                                                                 },
-                                                                "id": 54
+                                                                "id" : 54
                                                               }
                                                             },
-                                                            "name": {
-                                                              "AstNode": {
-                                                                "data": "BufferSend",
-                                                                "id": 55
+                                                            "name" : {
+                                                              "AstNode" : {
+                                                                "data" : "BufferSend",
+                                                                "id" : 55
                                                               }
                                                             }
                                                           }
                                                         },
-                                                        "id": 56
+                                                        "id" : 56
                                                       }
                                                     }
                                                   },
-                                                  "priority": "None",
-                                                  "queueFull": "None"
+                                                  "priority" : "None",
+                                                  "queueFull" : "None"
                                                 }
                                               },
-                                              "id": 57
+                                              "id" : 57
                                             }
                                           }
                                         }
                                       },
-                                      []
+                                      [
+                                      ]
                                     ]
                                   ]
                                 },
-                                "id": 58
+                                "id" : 58
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ]
                     ]
                   },
-                  "id": 59
+                  "id" : 59
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          [],
+          [
+          ],
           {
-            "DefModule": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "M",
-                    "members": [
+            "DefModule" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "M",
+                    "members" : [
                       [
-                        ["A component with state machines"],
+                        [
+                          "A component with state machines"
+                        ],
                         {
-                          "DefComponent": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "kind": {
-                                    "Active": {}
+                          "DefComponent" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "kind" : {
+                                    "Active" : {
+                                      
+                                    }
                                   },
-                                  "name": "StateMachines",
-                                  "members": [
+                                  "name" : "StateMachines",
+                                  "members" : [
                                     [
-                                      ["Sched in port"],
+                                      [
+                                        "Sched in port"
+                                      ],
                                       {
-                                        "SpecPortInstance": {
-                                          "node": {
-                                            "AstNode": {
-                                              "data": {
-                                                "General": {
-                                                  "kind": {
-                                                    "AsyncInput": {}
+                                        "SpecPortInstance" : {
+                                          "node" : {
+                                            "AstNode" : {
+                                              "data" : {
+                                                "General" : {
+                                                  "kind" : {
+                                                    "AsyncInput" : {
+                                                      
+                                                    }
                                                   },
-                                                  "name": "schedIn",
-                                                  "size": "None",
-                                                  "port": {
-                                                    "Some": {
-                                                      "AstNode": {
-                                                        "data": {
-                                                          "Qualified": {
-                                                            "qualifier": {
-                                                              "AstNode": {
-                                                                "data": {
-                                                                  "Unqualified": {
-                                                                    "name": "Svc"
+                                                  "name" : "schedIn",
+                                                  "size" : "None",
+                                                  "port" : {
+                                                    "Some" : {
+                                                      "AstNode" : {
+                                                        "data" : {
+                                                          "Qualified" : {
+                                                            "qualifier" : {
+                                                              "AstNode" : {
+                                                                "data" : {
+                                                                  "Unqualified" : {
+                                                                    "name" : "Svc"
                                                                   }
                                                                 },
-                                                                "id": 112
+                                                                "id" : 112
                                                               }
                                                             },
-                                                            "name": {
-                                                              "AstNode": {
-                                                                "data": "Sched",
-                                                                "id": 113
+                                                            "name" : {
+                                                              "AstNode" : {
+                                                                "data" : "Sched",
+                                                                "id" : 113
                                                               }
                                                             }
                                                           }
                                                         },
-                                                        "id": 114
+                                                        "id" : 114
                                                       }
                                                     }
                                                   },
-                                                  "priority": "None",
-                                                  "queueFull": "None"
+                                                  "priority" : "None",
+                                                  "queueFull" : "None"
                                                 }
                                               },
-                                              "id": 115
+                                              "id" : 115
                                             }
                                           }
                                         }
                                       },
-                                      []
+                                      [
+                                      ]
                                     ],
                                     [
-                                      ["State machine S1"],
+                                      [
+                                        "State machine S1"
+                                      ],
                                       {
-                                        "DefStateMachine": {
-                                          "node": {
-                                            "AstNode": {
-                                              "data": {
-                                                "name": "S1",
-                                                "members": "None"
+                                        "DefStateMachine" : {
+                                          "node" : {
+                                            "AstNode" : {
+                                              "data" : {
+                                                "name" : "S1",
+                                                "members" : "None"
                                               },
-                                              "id": 116
+                                              "id" : 116
                                             }
                                           }
                                         }
                                       },
-                                      []
+                                      [
+                                      ]
                                     ],
                                     [
-                                      ["State machine S2"],
+                                      [
+                                        "State machine S2"
+                                      ],
                                       {
-                                        "DefStateMachine": {
-                                          "node": {
-                                            "AstNode": {
-                                              "data": {
-                                                "name": "S2",
-                                                "members": {
-                                                  "Some": [
+                                        "DefStateMachine" : {
+                                          "node" : {
+                                            "AstNode" : {
+                                              "data" : {
+                                                "name" : "S2",
+                                                "members" : {
+                                                  "Some" : [
                                                     [
-                                                      [],
+                                                      [
+                                                      ],
                                                       {
-                                                        "SpecInitialTransition": {
-                                                          "node": {
-                                                            "AstNode": {
-                                                              "data": {
-                                                                "transition": {
-                                                                  "AstNode": {
-                                                                    "data": {
-                                                                      "actions": [],
-                                                                      "target": {
-                                                                        "AstNode": {
-                                                                          "data": {
-                                                                            "Unqualified": {
-                                                                              "name": "IDLE"
+                                                        "SpecInitialTransition" : {
+                                                          "node" : {
+                                                            "AstNode" : {
+                                                              "data" : {
+                                                                "transition" : {
+                                                                  "AstNode" : {
+                                                                    "data" : {
+                                                                      "actions" : [
+                                                                      ],
+                                                                      "target" : {
+                                                                        "AstNode" : {
+                                                                          "data" : {
+                                                                            "Unqualified" : {
+                                                                              "name" : "IDLE"
                                                                             }
                                                                           },
-                                                                          "id": 118
+                                                                          "id" : 118
                                                                         }
                                                                       }
                                                                     },
-                                                                    "id": 119
+                                                                    "id" : 119
                                                                   }
                                                                 }
                                                               },
-                                                              "id": 120
+                                                              "id" : 120
                                                             }
                                                           }
                                                         }
                                                       },
-                                                      []
+                                                      [
+                                                      ]
                                                     ],
                                                     [
-                                                      [],
+                                                      [
+                                                      ],
                                                       {
-                                                        "DefState": {
-                                                          "node": {
-                                                            "AstNode": {
-                                                              "data": {
-                                                                "name": "IDLE",
-                                                                "members": []
+                                                        "DefState" : {
+                                                          "node" : {
+                                                            "AstNode" : {
+                                                              "data" : {
+                                                                "name" : "IDLE",
+                                                                "members" : [
+                                                                ]
                                                               },
-                                                              "id": 123
+                                                              "id" : 123
                                                             }
                                                           }
                                                         }
                                                       },
-                                                      []
+                                                      [
+                                                      ]
                                                     ]
                                                   ]
                                                 }
                                               },
-                                              "id": 124
+                                              "id" : 124
                                             }
                                           }
                                         }
                                       },
-                                      []
+                                      [
+                                      ]
                                     ],
                                     [
-                                      ["State machine instance s1"],
+                                      [
+                                        "State machine instance s1"
+                                      ],
                                       {
-                                        "SpecStateMachineInstance": {
-                                          "node": {
-                                            "AstNode": {
-                                              "data": {
-                                                "name": "s1",
-                                                "stateMachine": {
-                                                  "AstNode": {
-                                                    "data": {
-                                                      "Unqualified": {
-                                                        "name": "S1"
+                                        "SpecStateMachineInstance" : {
+                                          "node" : {
+                                            "AstNode" : {
+                                              "data" : {
+                                                "name" : "s1",
+                                                "stateMachine" : {
+                                                  "AstNode" : {
+                                                    "data" : {
+                                                      "Unqualified" : {
+                                                        "name" : "S1"
                                                       }
                                                     },
-                                                    "id": 126
+                                                    "id" : 126
                                                   }
                                                 },
-                                                "priority": "None",
-                                                "queueFull": "None"
+                                                "priority" : "None",
+                                                "queueFull" : "None"
                                               },
-                                              "id": 127
+                                              "id" : 127
                                             }
                                           }
                                         }
                                       },
-                                      []
+                                      [
+                                      ]
                                     ],
                                     [
-                                      ["State machine instance s2"],
+                                      [
+                                        "State machine instance s2"
+                                      ],
                                       {
-                                        "SpecStateMachineInstance": {
-                                          "node": {
-                                            "AstNode": {
-                                              "data": {
-                                                "name": "s2",
-                                                "stateMachine": {
-                                                  "AstNode": {
-                                                    "data": {
-                                                      "Unqualified": {
-                                                        "name": "S2"
+                                        "SpecStateMachineInstance" : {
+                                          "node" : {
+                                            "AstNode" : {
+                                              "data" : {
+                                                "name" : "s2",
+                                                "stateMachine" : {
+                                                  "AstNode" : {
+                                                    "data" : {
+                                                      "Unqualified" : {
+                                                        "name" : "S2"
                                                       }
                                                     },
-                                                    "id": 135
+                                                    "id" : 135
                                                   }
                                                 },
-                                                "priority": "None",
-                                                "queueFull": "None"
+                                                "priority" : "None",
+                                                "queueFull" : "None"
                                               },
-                                              "id": 136
+                                              "id" : 136
                                             }
                                           }
                                         }
                                       },
-                                      []
+                                      [
+                                      ]
                                     ]
                                   ]
                                 },
-                                "id": 137
+                                "id" : 137
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ]
                     ]
                   },
-                  "id": 138
+                  "id" : 138
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          [],
+          [
+          ],
           {
-            "DefModule": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "FSW",
-                    "members": [
+            "DefModule" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "FSW",
+                    "members" : [
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "DefModule": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "name": "Default",
-                                  "members": [
+                          "DefModule" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "name" : "Default",
+                                  "members" : [
                                     [
-                                      ["Default queue size"],
+                                      [
+                                        "Default queue size"
+                                      ],
                                       {
-                                        "DefConstant": {
-                                          "node": {
-                                            "AstNode": {
-                                              "data": {
-                                                "name": "queueSize",
-                                                "value": {
-                                                  "AstNode": {
-                                                    "data": {
-                                                      "ExprLiteralInt": {
-                                                        "value": "10"
+                                        "DefConstant" : {
+                                          "node" : {
+                                            "AstNode" : {
+                                              "data" : {
+                                                "name" : "queueSize",
+                                                "value" : {
+                                                  "AstNode" : {
+                                                    "data" : {
+                                                      "ExprLiteralInt" : {
+                                                        "value" : "10"
                                                       }
                                                     },
-                                                    "id": 139
+                                                    "id" : 139
                                                   }
                                                 },
-                                                "isDictionaryDef": false
+                                                "isDictionaryDef" : false
                                               },
-                                              "id": 140
+                                              "id" : 140
                                             }
                                           }
                                         }
                                       },
-                                      []
+                                      [
+                                      ]
                                     ],
                                     [
-                                      ["Default stack size"],
+                                      [
+                                        "Default stack size"
+                                      ],
                                       {
-                                        "DefConstant": {
-                                          "node": {
-                                            "AstNode": {
-                                              "data": {
-                                                "name": "stackSize",
-                                                "value": {
-                                                  "AstNode": {
-                                                    "data": {
-                                                      "ExprBinop": {
-                                                        "e1": {
-                                                          "AstNode": {
-                                                            "data": {
-                                                              "ExprLiteralInt": {
-                                                                "value": "10"
+                                        "DefConstant" : {
+                                          "node" : {
+                                            "AstNode" : {
+                                              "data" : {
+                                                "name" : "stackSize",
+                                                "value" : {
+                                                  "AstNode" : {
+                                                    "data" : {
+                                                      "ExprBinop" : {
+                                                        "e1" : {
+                                                          "AstNode" : {
+                                                            "data" : {
+                                                              "ExprLiteralInt" : {
+                                                                "value" : "10"
                                                               }
                                                             },
-                                                            "id": 149
+                                                            "id" : 149
                                                           }
                                                         },
-                                                        "op": {
-                                                          "Mul": {}
+                                                        "op" : {
+                                                          "Mul" : {
+                                                            
+                                                          }
                                                         },
-                                                        "e2": {
-                                                          "AstNode": {
-                                                            "data": {
-                                                              "ExprLiteralInt": {
-                                                                "value": "1024"
+                                                        "e2" : {
+                                                          "AstNode" : {
+                                                            "data" : {
+                                                              "ExprLiteralInt" : {
+                                                                "value" : "1024"
                                                               }
                                                             },
-                                                            "id": 150
+                                                            "id" : 150
                                                           }
                                                         }
                                                       }
                                                     },
-                                                    "id": 151
+                                                    "id" : 151
                                                   }
                                                 },
-                                                "isDictionaryDef": false
+                                                "isDictionaryDef" : false
                                               },
-                                              "id": 152
+                                              "id" : 152
                                             }
                                           }
                                         }
                                       },
-                                      []
+                                      [
+                                      ]
                                     ]
                                   ]
                                 },
-                                "id": 153
+                                "id" : 153
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        ["Data compressor instance"],
+                        [
+                          "Data compressor instance"
+                        ],
                         {
-                          "DefComponentInstance": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "name": "dataCompressor",
-                                  "component": {
-                                    "AstNode": {
-                                      "data": {
-                                        "Qualified": {
-                                          "qualifier": {
-                                            "AstNode": {
-                                              "data": {
-                                                "Unqualified": {
-                                                  "name": "Utils"
+                          "DefComponentInstance" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "name" : "dataCompressor",
+                                  "component" : {
+                                    "AstNode" : {
+                                      "data" : {
+                                        "Qualified" : {
+                                          "qualifier" : {
+                                            "AstNode" : {
+                                              "data" : {
+                                                "Unqualified" : {
+                                                  "name" : "Utils"
                                                 }
                                               },
-                                              "id": 154
+                                              "id" : 154
                                             }
                                           },
-                                          "name": {
-                                            "AstNode": {
-                                              "data": "DataCompressor",
-                                              "id": 155
+                                          "name" : {
+                                            "AstNode" : {
+                                              "data" : "DataCompressor",
+                                              "id" : 155
                                             }
                                           }
                                         }
                                       },
-                                      "id": 156
+                                      "id" : 156
                                     }
                                   },
-                                  "baseId": {
-                                    "AstNode": {
-                                      "data": {
-                                        "ExprLiteralInt": {
-                                          "value": "0x100"
+                                  "baseId" : {
+                                    "AstNode" : {
+                                      "data" : {
+                                        "ExprLiteralInt" : {
+                                          "value" : "0x100"
                                         }
                                       },
-                                      "id": 157
+                                      "id" : 157
                                     }
                                   },
-                                  "implType": "None",
-                                  "file": "None",
-                                  "queueSize": {
-                                    "Some": {
-                                      "AstNode": {
-                                        "data": {
-                                          "ExprDot": {
-                                            "e": {
-                                              "AstNode": {
-                                                "data": {
-                                                  "ExprIdent": {
-                                                    "value": "Default"
+                                  "implType" : "None",
+                                  "file" : "None",
+                                  "queueSize" : {
+                                    "Some" : {
+                                      "AstNode" : {
+                                        "data" : {
+                                          "ExprDot" : {
+                                            "e" : {
+                                              "AstNode" : {
+                                                "data" : {
+                                                  "ExprIdent" : {
+                                                    "value" : "Default"
                                                   }
                                                 },
-                                                "id": 158
+                                                "id" : 158
                                               }
                                             },
-                                            "id": {
-                                              "AstNode": {
-                                                "data": "queueSize",
-                                                "id": 159
+                                            "id" : {
+                                              "AstNode" : {
+                                                "data" : "queueSize",
+                                                "id" : 159
                                               }
                                             }
                                           }
                                         },
-                                        "id": 160
+                                        "id" : 160
                                       }
                                     }
                                   },
-                                  "stackSize": {
-                                    "Some": {
-                                      "AstNode": {
-                                        "data": {
-                                          "ExprDot": {
-                                            "e": {
-                                              "AstNode": {
-                                                "data": {
-                                                  "ExprIdent": {
-                                                    "value": "Default"
+                                  "stackSize" : {
+                                    "Some" : {
+                                      "AstNode" : {
+                                        "data" : {
+                                          "ExprDot" : {
+                                            "e" : {
+                                              "AstNode" : {
+                                                "data" : {
+                                                  "ExprIdent" : {
+                                                    "value" : "Default"
                                                   }
                                                 },
-                                                "id": 161
+                                                "id" : 161
                                               }
                                             },
-                                            "id": {
-                                              "AstNode": {
-                                                "data": "stackSize",
-                                                "id": 162
+                                            "id" : {
+                                              "AstNode" : {
+                                                "data" : "stackSize",
+                                                "id" : 162
                                               }
                                             }
                                           }
                                         },
-                                        "id": 163
+                                        "id" : 163
                                       }
                                     }
                                   },
-                                  "priority": {
-                                    "Some": {
-                                      "AstNode": {
-                                        "data": {
-                                          "ExprLiteralInt": {
-                                            "value": "30"
+                                  "priority" : {
+                                    "Some" : {
+                                      "AstNode" : {
+                                        "data" : {
+                                          "ExprLiteralInt" : {
+                                            "value" : "30"
                                           }
                                         },
-                                        "id": 164
+                                        "id" : 164
                                       }
                                     }
                                   },
-                                  "cpu": "None",
-                                  "initSpecs": []
+                                  "cpu" : "None",
+                                  "initSpecs" : [
+                                  ]
                                 },
-                                "id": 165
+                                "id" : 165
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        ["State machines instance"],
+                        [
+                          "State machines instance"
+                        ],
                         {
-                          "DefComponentInstance": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "name": "stateMachines",
-                                  "component": {
-                                    "AstNode": {
-                                      "data": {
-                                        "Qualified": {
-                                          "qualifier": {
-                                            "AstNode": {
-                                              "data": {
-                                                "Unqualified": {
-                                                  "name": "M"
+                          "DefComponentInstance" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "name" : "stateMachines",
+                                  "component" : {
+                                    "AstNode" : {
+                                      "data" : {
+                                        "Qualified" : {
+                                          "qualifier" : {
+                                            "AstNode" : {
+                                              "data" : {
+                                                "Unqualified" : {
+                                                  "name" : "M"
                                                 }
                                               },
-                                              "id": 190
+                                              "id" : 190
                                             }
                                           },
-                                          "name": {
-                                            "AstNode": {
-                                              "data": "StateMachines",
-                                              "id": 191
+                                          "name" : {
+                                            "AstNode" : {
+                                              "data" : "StateMachines",
+                                              "id" : 191
                                             }
                                           }
                                         }
                                       },
-                                      "id": 192
+                                      "id" : 192
                                     }
                                   },
-                                  "baseId": {
-                                    "AstNode": {
-                                      "data": {
-                                        "ExprLiteralInt": {
-                                          "value": "0x200"
+                                  "baseId" : {
+                                    "AstNode" : {
+                                      "data" : {
+                                        "ExprLiteralInt" : {
+                                          "value" : "0x200"
                                         }
                                       },
-                                      "id": 193
+                                      "id" : 193
                                     }
                                   },
-                                  "implType": "None",
-                                  "file": "None",
-                                  "queueSize": {
-                                    "Some": {
-                                      "AstNode": {
-                                        "data": {
-                                          "ExprDot": {
-                                            "e": {
-                                              "AstNode": {
-                                                "data": {
-                                                  "ExprIdent": {
-                                                    "value": "Default"
+                                  "implType" : "None",
+                                  "file" : "None",
+                                  "queueSize" : {
+                                    "Some" : {
+                                      "AstNode" : {
+                                        "data" : {
+                                          "ExprDot" : {
+                                            "e" : {
+                                              "AstNode" : {
+                                                "data" : {
+                                                  "ExprIdent" : {
+                                                    "value" : "Default"
                                                   }
                                                 },
-                                                "id": 194
+                                                "id" : 194
                                               }
                                             },
-                                            "id": {
-                                              "AstNode": {
-                                                "data": "queueSize",
-                                                "id": 195
+                                            "id" : {
+                                              "AstNode" : {
+                                                "data" : "queueSize",
+                                                "id" : 195
                                               }
                                             }
                                           }
                                         },
-                                        "id": 196
+                                        "id" : 196
                                       }
                                     }
                                   },
-                                  "stackSize": {
-                                    "Some": {
-                                      "AstNode": {
-                                        "data": {
-                                          "ExprDot": {
-                                            "e": {
-                                              "AstNode": {
-                                                "data": {
-                                                  "ExprIdent": {
-                                                    "value": "Default"
+                                  "stackSize" : {
+                                    "Some" : {
+                                      "AstNode" : {
+                                        "data" : {
+                                          "ExprDot" : {
+                                            "e" : {
+                                              "AstNode" : {
+                                                "data" : {
+                                                  "ExprIdent" : {
+                                                    "value" : "Default"
                                                   }
                                                 },
-                                                "id": 197
+                                                "id" : 197
                                               }
                                             },
-                                            "id": {
-                                              "AstNode": {
-                                                "data": "stackSize",
-                                                "id": 198
+                                            "id" : {
+                                              "AstNode" : {
+                                                "data" : "stackSize",
+                                                "id" : 198
                                               }
                                             }
                                           }
                                         },
-                                        "id": 199
+                                        "id" : 199
                                       }
                                     }
                                   },
-                                  "priority": {
-                                    "Some": {
-                                      "AstNode": {
-                                        "data": {
-                                          "ExprLiteralInt": {
-                                            "value": "40"
+                                  "priority" : {
+                                    "Some" : {
+                                      "AstNode" : {
+                                        "data" : {
+                                          "ExprLiteralInt" : {
+                                            "value" : "40"
                                           }
                                         },
-                                        "id": 200
+                                        "id" : 200
                                       }
                                     }
                                   },
-                                  "cpu": "None",
-                                  "initSpecs": []
+                                  "cpu" : "None",
+                                  "initSpecs" : [
+                                  ]
                                 },
-                                "id": 201
+                                "id" : 201
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ]
                     ]
                   },
-                  "id": 202
+                  "id" : 202
                 }
               }
             }
           },
-          []
+          [
+          ]
         ]
       ]
     }

--- a/tests/active_component/active_component_locations.json
+++ b/tests/active_component/active_component_locations.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion": "[ fpp version ]",
+  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
   "locationMap": {
     "0": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",

--- a/tests/active_component/active_component_locations.json
+++ b/tests/active_component/active_component_locations.json
@@ -1,1020 +1,1020 @@
 {
-  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
-  "locationMap": {
-    "0": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "2.3",
-      "includingLoc": "None"
-    },
-    "1": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "2.3",
-      "includingLoc": "None"
-    },
-    "2": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "2.3",
-      "includingLoc": "None"
-    },
-    "3": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "1.1",
-      "includingLoc": "None"
-    },
-    "4": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "6.3",
-      "includingLoc": "None"
-    },
-    "5": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "6.3",
-      "includingLoc": "None"
-    },
-    "6": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "6.3",
-      "includingLoc": "None"
-    },
-    "7": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "5.1",
-      "includingLoc": "None"
-    },
-    "8": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "15.36",
-      "includingLoc": "None"
-    },
-    "9": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "15.39",
-      "includingLoc": "None"
-    },
-    "10": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "15.36",
-      "includingLoc": "None"
-    },
-    "11": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "15.5",
-      "includingLoc": "None"
-    },
-    "12": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "18.32",
-      "includingLoc": "None"
-    },
-    "13": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "18.35",
-      "includingLoc": "None"
-    },
-    "14": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "18.32",
-      "includingLoc": "None"
-    },
-    "15": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "18.5",
-      "includingLoc": "None"
-    },
-    "16": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "18.32",
-      "includingLoc": "None"
-    },
-    "17": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "18.35",
-      "includingLoc": "None"
-    },
-    "18": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "18.32",
-      "includingLoc": "None"
-    },
-    "19": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "18.5",
-      "includingLoc": "None"
-    },
-    "20": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "18.32",
-      "includingLoc": "None"
-    },
-    "21": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "18.35",
-      "includingLoc": "None"
-    },
-    "22": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "18.32",
-      "includingLoc": "None"
-    },
-    "23": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "18.5",
-      "includingLoc": "None"
-    },
-    "24": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "12.3",
-      "includingLoc": "None"
-    },
-    "25": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "15.36",
-      "includingLoc": "None"
-    },
-    "26": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "15.39",
-      "includingLoc": "None"
-    },
-    "27": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "15.36",
-      "includingLoc": "None"
-    },
-    "28": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "15.5",
-      "includingLoc": "None"
-    },
-    "29": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "18.32",
-      "includingLoc": "None"
-    },
-    "30": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "18.35",
-      "includingLoc": "None"
-    },
-    "31": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "18.32",
-      "includingLoc": "None"
-    },
-    "32": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "18.5",
-      "includingLoc": "None"
-    },
-    "33": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "18.32",
-      "includingLoc": "None"
-    },
-    "34": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "18.35",
-      "includingLoc": "None"
-    },
-    "35": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "18.32",
-      "includingLoc": "None"
-    },
-    "36": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "18.5",
-      "includingLoc": "None"
-    },
-    "37": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "18.32",
-      "includingLoc": "None"
-    },
-    "38": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "18.35",
-      "includingLoc": "None"
-    },
-    "39": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "18.32",
-      "includingLoc": "None"
-    },
-    "40": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "18.5",
-      "includingLoc": "None"
-    },
-    "41": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "12.3",
-      "includingLoc": "None"
-    },
-    "42": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "15.36",
-      "includingLoc": "None"
-    },
-    "43": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "15.39",
-      "includingLoc": "None"
-    },
-    "44": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "15.36",
-      "includingLoc": "None"
-    },
-    "45": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "15.5",
-      "includingLoc": "None"
-    },
-    "46": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "18.32",
-      "includingLoc": "None"
-    },
-    "47": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "18.35",
-      "includingLoc": "None"
-    },
-    "48": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "18.32",
-      "includingLoc": "None"
-    },
-    "49": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "18.5",
-      "includingLoc": "None"
-    },
-    "50": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "18.32",
-      "includingLoc": "None"
-    },
-    "51": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "18.35",
-      "includingLoc": "None"
-    },
-    "52": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "18.32",
-      "includingLoc": "None"
-    },
-    "53": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "18.5",
-      "includingLoc": "None"
-    },
-    "54": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "18.32",
-      "includingLoc": "None"
-    },
-    "55": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "18.35",
-      "includingLoc": "None"
-    },
-    "56": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "18.32",
-      "includingLoc": "None"
-    },
-    "57": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "18.5",
-      "includingLoc": "None"
-    },
-    "58": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "12.3",
-      "includingLoc": "None"
-    },
-    "59": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "9.1",
-      "includingLoc": "None"
-    },
-    "60": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "30.31",
-      "includingLoc": "None"
-    },
-    "61": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "30.35",
-      "includingLoc": "None"
-    },
-    "62": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "30.31",
-      "includingLoc": "None"
-    },
-    "63": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "30.5",
-      "includingLoc": "None"
-    },
-    "64": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "33.5",
-      "includingLoc": "None"
-    },
-    "65": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "37.23",
-      "includingLoc": "None"
-    },
-    "66": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "37.23",
-      "includingLoc": "None"
-    },
-    "67": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "37.17",
-      "includingLoc": "None"
-    },
-    "68": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "37.9",
-      "includingLoc": "None"
-    },
-    "69": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "38.9",
-      "includingLoc": "None"
-    },
-    "70": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "38.9",
-      "includingLoc": "None"
-    },
-    "71": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "38.9",
-      "includingLoc": "None"
-    },
-    "72": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "36.5",
-      "includingLoc": "None"
-    },
-    "73": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "42.32",
-      "includingLoc": "None"
-    },
-    "74": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "42.32",
-      "includingLoc": "None"
-    },
-    "75": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "42.5",
-      "includingLoc": "None"
-    },
-    "76": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "45.32",
-      "includingLoc": "None"
-    },
-    "77": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "45.32",
-      "includingLoc": "None"
-    },
-    "78": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "45.5",
-      "includingLoc": "None"
-    },
-    "79": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "45.32",
-      "includingLoc": "None"
-    },
-    "80": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "45.32",
-      "includingLoc": "None"
-    },
-    "81": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "45.5",
-      "includingLoc": "None"
-    },
-    "82": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "45.32",
-      "includingLoc": "None"
-    },
-    "83": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "45.32",
-      "includingLoc": "None"
-    },
-    "84": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "45.5",
-      "includingLoc": "None"
-    },
-    "85": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "27.3",
-      "includingLoc": "None"
-    },
-    "86": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "30.31",
-      "includingLoc": "None"
-    },
-    "87": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "30.35",
-      "includingLoc": "None"
-    },
-    "88": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "30.31",
-      "includingLoc": "None"
-    },
-    "89": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "30.5",
-      "includingLoc": "None"
-    },
-    "90": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "33.5",
-      "includingLoc": "None"
-    },
-    "91": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "37.23",
-      "includingLoc": "None"
-    },
-    "92": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "37.23",
-      "includingLoc": "None"
-    },
-    "93": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "37.17",
-      "includingLoc": "None"
-    },
-    "94": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "37.9",
-      "includingLoc": "None"
-    },
-    "95": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "38.9",
-      "includingLoc": "None"
-    },
-    "96": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "38.9",
-      "includingLoc": "None"
-    },
-    "97": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "38.9",
-      "includingLoc": "None"
-    },
-    "98": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "36.5",
-      "includingLoc": "None"
-    },
-    "99": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "42.32",
-      "includingLoc": "None"
-    },
-    "100": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "42.32",
-      "includingLoc": "None"
-    },
-    "101": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "42.5",
-      "includingLoc": "None"
-    },
-    "102": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "45.32",
-      "includingLoc": "None"
-    },
-    "103": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "45.32",
-      "includingLoc": "None"
-    },
-    "104": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "45.5",
-      "includingLoc": "None"
-    },
-    "105": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "45.32",
-      "includingLoc": "None"
-    },
-    "106": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "45.32",
-      "includingLoc": "None"
-    },
-    "107": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "45.5",
-      "includingLoc": "None"
-    },
-    "108": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "45.32",
-      "includingLoc": "None"
-    },
-    "109": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "45.32",
-      "includingLoc": "None"
-    },
-    "110": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "45.5",
-      "includingLoc": "None"
-    },
-    "111": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "27.3",
-      "includingLoc": "None"
-    },
-    "112": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "30.31",
-      "includingLoc": "None"
-    },
-    "113": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "30.35",
-      "includingLoc": "None"
-    },
-    "114": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "30.31",
-      "includingLoc": "None"
-    },
-    "115": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "30.5",
-      "includingLoc": "None"
-    },
-    "116": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "33.5",
-      "includingLoc": "None"
-    },
-    "117": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "37.23",
-      "includingLoc": "None"
-    },
-    "118": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "37.23",
-      "includingLoc": "None"
-    },
-    "119": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "37.17",
-      "includingLoc": "None"
-    },
-    "120": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "37.9",
-      "includingLoc": "None"
-    },
-    "121": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "38.9",
-      "includingLoc": "None"
-    },
-    "122": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "38.9",
-      "includingLoc": "None"
-    },
-    "123": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "38.9",
-      "includingLoc": "None"
-    },
-    "124": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "36.5",
-      "includingLoc": "None"
-    },
-    "125": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "42.32",
-      "includingLoc": "None"
-    },
-    "126": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "42.32",
-      "includingLoc": "None"
-    },
-    "127": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "42.5",
-      "includingLoc": "None"
-    },
-    "128": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "45.32",
-      "includingLoc": "None"
-    },
-    "129": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "45.32",
-      "includingLoc": "None"
-    },
-    "130": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "45.5",
-      "includingLoc": "None"
-    },
-    "131": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "45.32",
-      "includingLoc": "None"
-    },
-    "132": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "45.32",
-      "includingLoc": "None"
-    },
-    "133": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "45.5",
-      "includingLoc": "None"
-    },
-    "134": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "45.32",
-      "includingLoc": "None"
-    },
-    "135": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "45.32",
-      "includingLoc": "None"
-    },
-    "136": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "45.5",
-      "includingLoc": "None"
-    },
-    "137": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "27.3",
-      "includingLoc": "None"
-    },
-    "138": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "24.1",
-      "includingLoc": "None"
-    },
-    "139": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "55.26",
-      "includingLoc": "None"
-    },
-    "140": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "55.5",
-      "includingLoc": "None"
-    },
-    "141": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "57.26",
-      "includingLoc": "None"
-    },
-    "142": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "57.31",
-      "includingLoc": "None"
-    },
-    "143": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "57.29",
-      "includingLoc": "None"
-    },
-    "144": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "57.5",
-      "includingLoc": "None"
-    },
-    "145": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "57.26",
-      "includingLoc": "None"
-    },
-    "146": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "57.31",
-      "includingLoc": "None"
-    },
-    "147": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "57.29",
-      "includingLoc": "None"
-    },
-    "148": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "57.5",
-      "includingLoc": "None"
-    },
-    "149": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "57.26",
-      "includingLoc": "None"
-    },
-    "150": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "57.31",
-      "includingLoc": "None"
-    },
-    "151": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "57.29",
-      "includingLoc": "None"
-    },
-    "152": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "57.5",
-      "includingLoc": "None"
-    },
-    "153": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "53.3",
-      "includingLoc": "None"
-    },
-    "154": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "61.28",
-      "includingLoc": "None"
-    },
-    "155": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "61.34",
-      "includingLoc": "None"
-    },
-    "156": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "61.28",
-      "includingLoc": "None"
-    },
-    "157": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "61.57",
-      "includingLoc": "None"
-    },
-    "158": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "62.16",
-      "includingLoc": "None"
-    },
-    "159": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "62.24",
-      "includingLoc": "None"
-    },
-    "160": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "62.16",
-      "includingLoc": "None"
-    },
-    "161": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "63.16",
-      "includingLoc": "None"
-    },
-    "162": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "63.24",
-      "includingLoc": "None"
-    },
-    "163": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "63.16",
-      "includingLoc": "None"
-    },
-    "164": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "64.14",
-      "includingLoc": "None"
-    },
-    "165": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "61.3",
-      "includingLoc": "None"
-    },
-    "166": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "67.27",
-      "includingLoc": "None"
-    },
-    "167": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "67.29",
-      "includingLoc": "None"
-    },
-    "168": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "67.27",
-      "includingLoc": "None"
-    },
-    "169": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "67.51",
-      "includingLoc": "None"
-    },
-    "170": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "68.16",
-      "includingLoc": "None"
-    },
-    "171": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "68.24",
-      "includingLoc": "None"
-    },
-    "172": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "68.16",
-      "includingLoc": "None"
-    },
-    "173": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "69.16",
-      "includingLoc": "None"
-    },
-    "174": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "69.24",
-      "includingLoc": "None"
-    },
-    "175": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "69.16",
-      "includingLoc": "None"
-    },
-    "176": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "70.14",
-      "includingLoc": "None"
-    },
-    "177": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "67.3",
-      "includingLoc": "None"
-    },
-    "178": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "67.27",
-      "includingLoc": "None"
-    },
-    "179": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "67.29",
-      "includingLoc": "None"
-    },
-    "180": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "67.27",
-      "includingLoc": "None"
-    },
-    "181": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "67.51",
-      "includingLoc": "None"
-    },
-    "182": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "68.16",
-      "includingLoc": "None"
-    },
-    "183": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "68.24",
-      "includingLoc": "None"
-    },
-    "184": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "68.16",
-      "includingLoc": "None"
-    },
-    "185": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "69.16",
-      "includingLoc": "None"
-    },
-    "186": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "69.24",
-      "includingLoc": "None"
-    },
-    "187": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "69.16",
-      "includingLoc": "None"
-    },
-    "188": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "70.14",
-      "includingLoc": "None"
-    },
-    "189": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "67.3",
-      "includingLoc": "None"
-    },
-    "190": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "67.27",
-      "includingLoc": "None"
-    },
-    "191": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "67.29",
-      "includingLoc": "None"
-    },
-    "192": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "67.27",
-      "includingLoc": "None"
-    },
-    "193": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "67.51",
-      "includingLoc": "None"
-    },
-    "194": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "68.16",
-      "includingLoc": "None"
-    },
-    "195": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "68.24",
-      "includingLoc": "None"
-    },
-    "196": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "68.16",
-      "includingLoc": "None"
-    },
-    "197": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "69.16",
-      "includingLoc": "None"
-    },
-    "198": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "69.24",
-      "includingLoc": "None"
-    },
-    "199": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "69.16",
-      "includingLoc": "None"
-    },
-    "200": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "70.14",
-      "includingLoc": "None"
-    },
-    "201": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "67.3",
-      "includingLoc": "None"
-    },
-    "202": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
-      "pos": "51.1",
-      "includingLoc": "None"
+  "fppVersion" : "v3.1.0a10-54-g11243e778",
+  "locationMap" : {
+    "0" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "2.3",
+      "includingLoc" : "None"
+    },
+    "1" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "2.3",
+      "includingLoc" : "None"
+    },
+    "2" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "2.3",
+      "includingLoc" : "None"
+    },
+    "3" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "1.1",
+      "includingLoc" : "None"
+    },
+    "4" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "6.3",
+      "includingLoc" : "None"
+    },
+    "5" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "6.3",
+      "includingLoc" : "None"
+    },
+    "6" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "6.3",
+      "includingLoc" : "None"
+    },
+    "7" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "5.1",
+      "includingLoc" : "None"
+    },
+    "8" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "15.36",
+      "includingLoc" : "None"
+    },
+    "9" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "15.39",
+      "includingLoc" : "None"
+    },
+    "10" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "15.36",
+      "includingLoc" : "None"
+    },
+    "11" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "15.5",
+      "includingLoc" : "None"
+    },
+    "12" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "18.32",
+      "includingLoc" : "None"
+    },
+    "13" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "18.35",
+      "includingLoc" : "None"
+    },
+    "14" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "18.32",
+      "includingLoc" : "None"
+    },
+    "15" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "18.5",
+      "includingLoc" : "None"
+    },
+    "16" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "18.32",
+      "includingLoc" : "None"
+    },
+    "17" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "18.35",
+      "includingLoc" : "None"
+    },
+    "18" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "18.32",
+      "includingLoc" : "None"
+    },
+    "19" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "18.5",
+      "includingLoc" : "None"
+    },
+    "20" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "18.32",
+      "includingLoc" : "None"
+    },
+    "21" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "18.35",
+      "includingLoc" : "None"
+    },
+    "22" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "18.32",
+      "includingLoc" : "None"
+    },
+    "23" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "18.5",
+      "includingLoc" : "None"
+    },
+    "24" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "12.3",
+      "includingLoc" : "None"
+    },
+    "25" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "15.36",
+      "includingLoc" : "None"
+    },
+    "26" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "15.39",
+      "includingLoc" : "None"
+    },
+    "27" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "15.36",
+      "includingLoc" : "None"
+    },
+    "28" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "15.5",
+      "includingLoc" : "None"
+    },
+    "29" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "18.32",
+      "includingLoc" : "None"
+    },
+    "30" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "18.35",
+      "includingLoc" : "None"
+    },
+    "31" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "18.32",
+      "includingLoc" : "None"
+    },
+    "32" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "18.5",
+      "includingLoc" : "None"
+    },
+    "33" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "18.32",
+      "includingLoc" : "None"
+    },
+    "34" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "18.35",
+      "includingLoc" : "None"
+    },
+    "35" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "18.32",
+      "includingLoc" : "None"
+    },
+    "36" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "18.5",
+      "includingLoc" : "None"
+    },
+    "37" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "18.32",
+      "includingLoc" : "None"
+    },
+    "38" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "18.35",
+      "includingLoc" : "None"
+    },
+    "39" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "18.32",
+      "includingLoc" : "None"
+    },
+    "40" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "18.5",
+      "includingLoc" : "None"
+    },
+    "41" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "12.3",
+      "includingLoc" : "None"
+    },
+    "42" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "15.36",
+      "includingLoc" : "None"
+    },
+    "43" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "15.39",
+      "includingLoc" : "None"
+    },
+    "44" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "15.36",
+      "includingLoc" : "None"
+    },
+    "45" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "15.5",
+      "includingLoc" : "None"
+    },
+    "46" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "18.32",
+      "includingLoc" : "None"
+    },
+    "47" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "18.35",
+      "includingLoc" : "None"
+    },
+    "48" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "18.32",
+      "includingLoc" : "None"
+    },
+    "49" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "18.5",
+      "includingLoc" : "None"
+    },
+    "50" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "18.32",
+      "includingLoc" : "None"
+    },
+    "51" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "18.35",
+      "includingLoc" : "None"
+    },
+    "52" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "18.32",
+      "includingLoc" : "None"
+    },
+    "53" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "18.5",
+      "includingLoc" : "None"
+    },
+    "54" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "18.32",
+      "includingLoc" : "None"
+    },
+    "55" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "18.35",
+      "includingLoc" : "None"
+    },
+    "56" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "18.32",
+      "includingLoc" : "None"
+    },
+    "57" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "18.5",
+      "includingLoc" : "None"
+    },
+    "58" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "12.3",
+      "includingLoc" : "None"
+    },
+    "59" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "9.1",
+      "includingLoc" : "None"
+    },
+    "60" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "30.31",
+      "includingLoc" : "None"
+    },
+    "61" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "30.35",
+      "includingLoc" : "None"
+    },
+    "62" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "30.31",
+      "includingLoc" : "None"
+    },
+    "63" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "30.5",
+      "includingLoc" : "None"
+    },
+    "64" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "33.5",
+      "includingLoc" : "None"
+    },
+    "65" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "37.23",
+      "includingLoc" : "None"
+    },
+    "66" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "37.23",
+      "includingLoc" : "None"
+    },
+    "67" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "37.17",
+      "includingLoc" : "None"
+    },
+    "68" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "37.9",
+      "includingLoc" : "None"
+    },
+    "69" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "38.9",
+      "includingLoc" : "None"
+    },
+    "70" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "38.9",
+      "includingLoc" : "None"
+    },
+    "71" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "38.9",
+      "includingLoc" : "None"
+    },
+    "72" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "36.5",
+      "includingLoc" : "None"
+    },
+    "73" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "42.32",
+      "includingLoc" : "None"
+    },
+    "74" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "42.32",
+      "includingLoc" : "None"
+    },
+    "75" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "42.5",
+      "includingLoc" : "None"
+    },
+    "76" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "45.32",
+      "includingLoc" : "None"
+    },
+    "77" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "45.32",
+      "includingLoc" : "None"
+    },
+    "78" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "45.5",
+      "includingLoc" : "None"
+    },
+    "79" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "45.32",
+      "includingLoc" : "None"
+    },
+    "80" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "45.32",
+      "includingLoc" : "None"
+    },
+    "81" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "45.5",
+      "includingLoc" : "None"
+    },
+    "82" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "45.32",
+      "includingLoc" : "None"
+    },
+    "83" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "45.32",
+      "includingLoc" : "None"
+    },
+    "84" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "45.5",
+      "includingLoc" : "None"
+    },
+    "85" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "27.3",
+      "includingLoc" : "None"
+    },
+    "86" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "30.31",
+      "includingLoc" : "None"
+    },
+    "87" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "30.35",
+      "includingLoc" : "None"
+    },
+    "88" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "30.31",
+      "includingLoc" : "None"
+    },
+    "89" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "30.5",
+      "includingLoc" : "None"
+    },
+    "90" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "33.5",
+      "includingLoc" : "None"
+    },
+    "91" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "37.23",
+      "includingLoc" : "None"
+    },
+    "92" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "37.23",
+      "includingLoc" : "None"
+    },
+    "93" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "37.17",
+      "includingLoc" : "None"
+    },
+    "94" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "37.9",
+      "includingLoc" : "None"
+    },
+    "95" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "38.9",
+      "includingLoc" : "None"
+    },
+    "96" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "38.9",
+      "includingLoc" : "None"
+    },
+    "97" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "38.9",
+      "includingLoc" : "None"
+    },
+    "98" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "36.5",
+      "includingLoc" : "None"
+    },
+    "99" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "42.32",
+      "includingLoc" : "None"
+    },
+    "100" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "42.32",
+      "includingLoc" : "None"
+    },
+    "101" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "42.5",
+      "includingLoc" : "None"
+    },
+    "102" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "45.32",
+      "includingLoc" : "None"
+    },
+    "103" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "45.32",
+      "includingLoc" : "None"
+    },
+    "104" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "45.5",
+      "includingLoc" : "None"
+    },
+    "105" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "45.32",
+      "includingLoc" : "None"
+    },
+    "106" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "45.32",
+      "includingLoc" : "None"
+    },
+    "107" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "45.5",
+      "includingLoc" : "None"
+    },
+    "108" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "45.32",
+      "includingLoc" : "None"
+    },
+    "109" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "45.32",
+      "includingLoc" : "None"
+    },
+    "110" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "45.5",
+      "includingLoc" : "None"
+    },
+    "111" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "27.3",
+      "includingLoc" : "None"
+    },
+    "112" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "30.31",
+      "includingLoc" : "None"
+    },
+    "113" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "30.35",
+      "includingLoc" : "None"
+    },
+    "114" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "30.31",
+      "includingLoc" : "None"
+    },
+    "115" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "30.5",
+      "includingLoc" : "None"
+    },
+    "116" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "33.5",
+      "includingLoc" : "None"
+    },
+    "117" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "37.23",
+      "includingLoc" : "None"
+    },
+    "118" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "37.23",
+      "includingLoc" : "None"
+    },
+    "119" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "37.17",
+      "includingLoc" : "None"
+    },
+    "120" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "37.9",
+      "includingLoc" : "None"
+    },
+    "121" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "38.9",
+      "includingLoc" : "None"
+    },
+    "122" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "38.9",
+      "includingLoc" : "None"
+    },
+    "123" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "38.9",
+      "includingLoc" : "None"
+    },
+    "124" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "36.5",
+      "includingLoc" : "None"
+    },
+    "125" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "42.32",
+      "includingLoc" : "None"
+    },
+    "126" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "42.32",
+      "includingLoc" : "None"
+    },
+    "127" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "42.5",
+      "includingLoc" : "None"
+    },
+    "128" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "45.32",
+      "includingLoc" : "None"
+    },
+    "129" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "45.32",
+      "includingLoc" : "None"
+    },
+    "130" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "45.5",
+      "includingLoc" : "None"
+    },
+    "131" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "45.32",
+      "includingLoc" : "None"
+    },
+    "132" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "45.32",
+      "includingLoc" : "None"
+    },
+    "133" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "45.5",
+      "includingLoc" : "None"
+    },
+    "134" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "45.32",
+      "includingLoc" : "None"
+    },
+    "135" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "45.32",
+      "includingLoc" : "None"
+    },
+    "136" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "45.5",
+      "includingLoc" : "None"
+    },
+    "137" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "27.3",
+      "includingLoc" : "None"
+    },
+    "138" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "24.1",
+      "includingLoc" : "None"
+    },
+    "139" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "55.26",
+      "includingLoc" : "None"
+    },
+    "140" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "55.5",
+      "includingLoc" : "None"
+    },
+    "141" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "57.26",
+      "includingLoc" : "None"
+    },
+    "142" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "57.31",
+      "includingLoc" : "None"
+    },
+    "143" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "57.29",
+      "includingLoc" : "None"
+    },
+    "144" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "57.5",
+      "includingLoc" : "None"
+    },
+    "145" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "57.26",
+      "includingLoc" : "None"
+    },
+    "146" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "57.31",
+      "includingLoc" : "None"
+    },
+    "147" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "57.29",
+      "includingLoc" : "None"
+    },
+    "148" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "57.5",
+      "includingLoc" : "None"
+    },
+    "149" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "57.26",
+      "includingLoc" : "None"
+    },
+    "150" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "57.31",
+      "includingLoc" : "None"
+    },
+    "151" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "57.29",
+      "includingLoc" : "None"
+    },
+    "152" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "57.5",
+      "includingLoc" : "None"
+    },
+    "153" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "53.3",
+      "includingLoc" : "None"
+    },
+    "154" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "61.28",
+      "includingLoc" : "None"
+    },
+    "155" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "61.34",
+      "includingLoc" : "None"
+    },
+    "156" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "61.28",
+      "includingLoc" : "None"
+    },
+    "157" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "61.57",
+      "includingLoc" : "None"
+    },
+    "158" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "62.16",
+      "includingLoc" : "None"
+    },
+    "159" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "62.24",
+      "includingLoc" : "None"
+    },
+    "160" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "62.16",
+      "includingLoc" : "None"
+    },
+    "161" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "63.16",
+      "includingLoc" : "None"
+    },
+    "162" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "63.24",
+      "includingLoc" : "None"
+    },
+    "163" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "63.16",
+      "includingLoc" : "None"
+    },
+    "164" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "64.14",
+      "includingLoc" : "None"
+    },
+    "165" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "61.3",
+      "includingLoc" : "None"
+    },
+    "166" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "67.27",
+      "includingLoc" : "None"
+    },
+    "167" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "67.29",
+      "includingLoc" : "None"
+    },
+    "168" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "67.27",
+      "includingLoc" : "None"
+    },
+    "169" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "67.51",
+      "includingLoc" : "None"
+    },
+    "170" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "68.16",
+      "includingLoc" : "None"
+    },
+    "171" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "68.24",
+      "includingLoc" : "None"
+    },
+    "172" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "68.16",
+      "includingLoc" : "None"
+    },
+    "173" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "69.16",
+      "includingLoc" : "None"
+    },
+    "174" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "69.24",
+      "includingLoc" : "None"
+    },
+    "175" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "69.16",
+      "includingLoc" : "None"
+    },
+    "176" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "70.14",
+      "includingLoc" : "None"
+    },
+    "177" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "67.3",
+      "includingLoc" : "None"
+    },
+    "178" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "67.27",
+      "includingLoc" : "None"
+    },
+    "179" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "67.29",
+      "includingLoc" : "None"
+    },
+    "180" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "67.27",
+      "includingLoc" : "None"
+    },
+    "181" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "67.51",
+      "includingLoc" : "None"
+    },
+    "182" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "68.16",
+      "includingLoc" : "None"
+    },
+    "183" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "68.24",
+      "includingLoc" : "None"
+    },
+    "184" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "68.16",
+      "includingLoc" : "None"
+    },
+    "185" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "69.16",
+      "includingLoc" : "None"
+    },
+    "186" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "69.24",
+      "includingLoc" : "None"
+    },
+    "187" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "69.16",
+      "includingLoc" : "None"
+    },
+    "188" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "70.14",
+      "includingLoc" : "None"
+    },
+    "189" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "67.3",
+      "includingLoc" : "None"
+    },
+    "190" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "67.27",
+      "includingLoc" : "None"
+    },
+    "191" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "67.29",
+      "includingLoc" : "None"
+    },
+    "192" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "67.27",
+      "includingLoc" : "None"
+    },
+    "193" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "67.51",
+      "includingLoc" : "None"
+    },
+    "194" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "68.16",
+      "includingLoc" : "None"
+    },
+    "195" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "68.24",
+      "includingLoc" : "None"
+    },
+    "196" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "68.16",
+      "includingLoc" : "None"
+    },
+    "197" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "69.16",
+      "includingLoc" : "None"
+    },
+    "198" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "69.24",
+      "includingLoc" : "None"
+    },
+    "199" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "69.16",
+      "includingLoc" : "None"
+    },
+    "200" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "70.14",
+      "includingLoc" : "None"
+    },
+    "201" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "67.3",
+      "includingLoc" : "None"
+    },
+    "202" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",
+      "pos" : "51.1",
+      "includingLoc" : "None"
     }
   }
 }

--- a/tests/command_patterned_connections/command_patterned_connections.fpp
+++ b/tests/command_patterned_connections/command_patterned_connections.fpp
@@ -1,0 +1,49 @@
+module Fw {
+
+  port Cmd
+
+  port CmdReg
+
+  port CmdResponse
+
+}
+
+module M {
+
+  passive component Commands {
+
+    sync input port cmdRegIn: Fw.CmdReg
+
+    output port cmdOut: Fw.Cmd
+
+    sync input port cmdResponseIn: Fw.CmdResponse
+
+  }
+
+  passive component C {
+
+    command reg port cmdRegOut
+
+    command recv port cmdIn
+
+    command resp port cmdResponseOut
+
+  }
+
+  instance commands: Commands base id 0x100
+
+  instance c: C base id 0x100
+
+  topology T {
+
+    instance commands
+
+    instance c
+
+    command connections instance commands {
+      c
+    }
+
+  }
+
+}

--- a/tests/command_patterned_connections/command_patterned_connections_analysis.json
+++ b/tests/command_patterned_connections/command_patterned_connections_analysis.json
@@ -1,0 +1,3777 @@
+{
+  "fppVersion" : "v3.1.0a10-54-g11243e778",
+  "analysis" : {
+    "componentInstanceMap" : {
+      "36" : {
+        "aNode" : {
+          "astNodeId" : 36
+        },
+        "qualifiedName" : {
+          "qualifier" : [
+            "M"
+          ],
+          "base" : "commands"
+        },
+        "component" : {
+          "astNodeId" : 26
+        },
+        "baseId" : 256,
+        "maxId" : 255,
+        "file" : "None",
+        "queueSize" : "None",
+        "stackSize" : "None",
+        "priority" : "None",
+        "cpu" : "None",
+        "initSpecifierMap" : {
+          
+        }
+      },
+      "40" : {
+        "aNode" : {
+          "astNodeId" : 40
+        },
+        "qualifiedName" : {
+          "qualifier" : [
+            "M"
+          ],
+          "base" : "c"
+        },
+        "component" : {
+          "astNodeId" : 32
+        },
+        "baseId" : 256,
+        "maxId" : 255,
+        "file" : "None",
+        "queueSize" : "None",
+        "stackSize" : "None",
+        "priority" : "None",
+        "cpu" : "None",
+        "initSpecifierMap" : {
+          
+        }
+      }
+    },
+    "componentMap" : {
+      "26" : {
+        "aNode" : {
+          "astNodeId" : 26
+        },
+        "portMap" : {
+          "cmdRegIn" : {
+            "General" : {
+              "aNode" : {
+                "astNodeId" : 9
+              },
+              "specifier" : {
+                "kind" : {
+                  "SyncInput" : {
+                    
+                  }
+                },
+                "name" : "cmdRegIn",
+                "size" : "None",
+                "port" : {
+                  "Some" : {
+                    "astNodeId" : 8
+                  }
+                },
+                "priority" : "None",
+                "queueFull" : "None"
+              },
+              "kind" : "SyncInput",
+              "size" : 1,
+              "ty" : {
+                "DefPort" : {
+                  "symbol" : {
+                    "Port" : {
+                      "nodeId" : 1,
+                      "unqualifiedName" : "CmdReg"
+                    }
+                  }
+                }
+              },
+              "importNodeIds" : [
+              ]
+            }
+          },
+          "cmdOut" : {
+            "General" : {
+              "aNode" : {
+                "astNodeId" : 13
+              },
+              "specifier" : {
+                "kind" : {
+                  "Output" : {
+                    
+                  }
+                },
+                "name" : "cmdOut",
+                "size" : "None",
+                "port" : {
+                  "Some" : {
+                    "astNodeId" : 12
+                  }
+                },
+                "priority" : "None",
+                "queueFull" : "None"
+              },
+              "kind" : "Output",
+              "size" : 1,
+              "ty" : {
+                "DefPort" : {
+                  "symbol" : {
+                    "Port" : {
+                      "nodeId" : 0,
+                      "unqualifiedName" : "Cmd"
+                    }
+                  }
+                }
+              },
+              "importNodeIds" : [
+              ]
+            }
+          },
+          "cmdResponseIn" : {
+            "General" : {
+              "aNode" : {
+                "astNodeId" : 25
+              },
+              "specifier" : {
+                "kind" : {
+                  "SyncInput" : {
+                    
+                  }
+                },
+                "name" : "cmdResponseIn",
+                "size" : "None",
+                "port" : {
+                  "Some" : {
+                    "astNodeId" : 24
+                  }
+                },
+                "priority" : "None",
+                "queueFull" : "None"
+              },
+              "kind" : "SyncInput",
+              "size" : 1,
+              "ty" : {
+                "DefPort" : {
+                  "symbol" : {
+                    "Port" : {
+                      "nodeId" : 4,
+                      "unqualifiedName" : "CmdResponse"
+                    }
+                  }
+                }
+              },
+              "importNodeIds" : [
+              ]
+            }
+          }
+        },
+        "specialPortMap" : {
+          
+        },
+        "commandMap" : {
+          
+        },
+        "defaultOpcode" : 0,
+        "tlmChannelMap" : {
+          
+        },
+        "tlmChannelNameMap" : {
+          
+        },
+        "defaultTlmChannelId" : 0,
+        "eventMap" : {
+          
+        },
+        "defaultEventId" : 0,
+        "paramMap" : {
+          
+        },
+        "specPortMatchingList" : [
+        ],
+        "stateMachineInstanceMap" : {
+          
+        },
+        "portMatchingList" : [
+        ],
+        "defaultParamId" : 0,
+        "containerMap" : {
+          
+        },
+        "defaultContainerId" : 0,
+        "recordMap" : {
+          
+        },
+        "defaultRecordId" : 0
+      },
+      "32" : {
+        "aNode" : {
+          "astNodeId" : 32
+        },
+        "portMap" : {
+          "cmdRegOut" : {
+            "Special" : {
+              "aNode" : {
+                "astNodeId" : 27
+              },
+              "specifier" : {
+                "inputKind" : "None",
+                "kind" : {
+                  "CommandReg" : {
+                    
+                  }
+                },
+                "name" : "cmdRegOut",
+                "priority" : "None",
+                "queueFull" : "None"
+              },
+              "symbol" : {
+                "Port" : {
+                  "nodeId" : 1,
+                  "unqualifiedName" : "CmdReg"
+                }
+              },
+              "priority" : "None",
+              "queueFull" : "None",
+              "importNodeIds" : [
+              ]
+            }
+          },
+          "cmdIn" : {
+            "Special" : {
+              "aNode" : {
+                "astNodeId" : 28
+              },
+              "specifier" : {
+                "inputKind" : "None",
+                "kind" : {
+                  "CommandRecv" : {
+                    
+                  }
+                },
+                "name" : "cmdIn",
+                "priority" : "None",
+                "queueFull" : "None"
+              },
+              "symbol" : {
+                "Port" : {
+                  "nodeId" : 0,
+                  "unqualifiedName" : "Cmd"
+                }
+              },
+              "priority" : "None",
+              "queueFull" : "None",
+              "importNodeIds" : [
+              ]
+            }
+          },
+          "cmdResponseOut" : {
+            "Special" : {
+              "aNode" : {
+                "astNodeId" : 31
+              },
+              "specifier" : {
+                "inputKind" : "None",
+                "kind" : {
+                  "CommandResp" : {
+                    
+                  }
+                },
+                "name" : "cmdResponseOut",
+                "priority" : "None",
+                "queueFull" : "None"
+              },
+              "symbol" : {
+                "Port" : {
+                  "nodeId" : 4,
+                  "unqualifiedName" : "CmdResponse"
+                }
+              },
+              "priority" : "None",
+              "queueFull" : "None",
+              "importNodeIds" : [
+              ]
+            }
+          }
+        },
+        "specialPortMap" : {
+          "command reg" : {
+            "aNode" : {
+              "astNodeId" : 27
+            },
+            "specifier" : {
+              "inputKind" : "None",
+              "kind" : {
+                "CommandReg" : {
+                  
+                }
+              },
+              "name" : "cmdRegOut",
+              "priority" : "None",
+              "queueFull" : "None"
+            },
+            "symbol" : {
+              "Port" : {
+                "nodeId" : 1,
+                "unqualifiedName" : "CmdReg"
+              }
+            },
+            "priority" : "None",
+            "queueFull" : "None",
+            "importNodeIds" : [
+            ]
+          },
+          "command recv" : {
+            "aNode" : {
+              "astNodeId" : 28
+            },
+            "specifier" : {
+              "inputKind" : "None",
+              "kind" : {
+                "CommandRecv" : {
+                  
+                }
+              },
+              "name" : "cmdIn",
+              "priority" : "None",
+              "queueFull" : "None"
+            },
+            "symbol" : {
+              "Port" : {
+                "nodeId" : 0,
+                "unqualifiedName" : "Cmd"
+              }
+            },
+            "priority" : "None",
+            "queueFull" : "None",
+            "importNodeIds" : [
+            ]
+          },
+          "command resp" : {
+            "aNode" : {
+              "astNodeId" : 31
+            },
+            "specifier" : {
+              "inputKind" : "None",
+              "kind" : {
+                "CommandResp" : {
+                  
+                }
+              },
+              "name" : "cmdResponseOut",
+              "priority" : "None",
+              "queueFull" : "None"
+            },
+            "symbol" : {
+              "Port" : {
+                "nodeId" : 4,
+                "unqualifiedName" : "CmdResponse"
+              }
+            },
+            "priority" : "None",
+            "queueFull" : "None",
+            "importNodeIds" : [
+            ]
+          }
+        },
+        "commandMap" : {
+          
+        },
+        "defaultOpcode" : 0,
+        "tlmChannelMap" : {
+          
+        },
+        "tlmChannelNameMap" : {
+          
+        },
+        "defaultTlmChannelId" : 0,
+        "eventMap" : {
+          
+        },
+        "defaultEventId" : 0,
+        "paramMap" : {
+          
+        },
+        "specPortMatchingList" : [
+        ],
+        "stateMachineInstanceMap" : {
+          
+        },
+        "portMatchingList" : [
+        ],
+        "defaultParamId" : 0,
+        "containerMap" : {
+          
+        },
+        "defaultContainerId" : 0,
+        "recordMap" : {
+          
+        },
+        "defaultRecordId" : 0
+      }
+    },
+    "includedFileSet" : [
+    ],
+    "inputFileSet" : [
+      "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp"
+    ],
+    "locationSpecifierMap" : [
+    ],
+    "parentSymbolMap" : {
+      "26" : {
+        "Module" : {
+          "nodeId" : 107,
+          "unqualifiedName" : "M"
+        }
+      },
+      "32" : {
+        "Module" : {
+          "nodeId" : 107,
+          "unqualifiedName" : "M"
+        }
+      },
+      "106" : {
+        "Module" : {
+          "nodeId" : 107,
+          "unqualifiedName" : "M"
+        }
+      },
+      "0" : {
+        "Module" : {
+          "nodeId" : 5,
+          "unqualifiedName" : "Fw"
+        }
+      },
+      "4" : {
+        "Module" : {
+          "nodeId" : 5,
+          "unqualifiedName" : "Fw"
+        }
+      },
+      "40" : {
+        "Module" : {
+          "nodeId" : 107,
+          "unqualifiedName" : "M"
+        }
+      },
+      "36" : {
+        "Module" : {
+          "nodeId" : 107,
+          "unqualifiedName" : "M"
+        }
+      },
+      "1" : {
+        "Module" : {
+          "nodeId" : 5,
+          "unqualifiedName" : "Fw"
+        }
+      }
+    },
+    "symbolScopeMap" : {
+      "5" : {
+        "map" : {
+          "Port" : {
+            "map" : {
+              "Cmd" : {
+                "Port" : {
+                  "nodeId" : 0,
+                  "unqualifiedName" : "Cmd"
+                }
+              },
+              "CmdReg" : {
+                "Port" : {
+                  "nodeId" : 1,
+                  "unqualifiedName" : "CmdReg"
+                }
+              },
+              "CmdResponse" : {
+                "Port" : {
+                  "nodeId" : 4,
+                  "unqualifiedName" : "CmdResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "26" : {
+        "map" : {
+          
+        }
+      },
+      "32" : {
+        "map" : {
+          
+        }
+      },
+      "107" : {
+        "map" : {
+          "ComponentInstance" : {
+            "map" : {
+              "commands" : {
+                "ComponentInstance" : {
+                  "nodeId" : 36,
+                  "unqualifiedName" : "commands"
+                }
+              },
+              "c" : {
+                "ComponentInstance" : {
+                  "nodeId" : 40,
+                  "unqualifiedName" : "c"
+                }
+              }
+            }
+          },
+          "Topology" : {
+            "map" : {
+              "T" : {
+                "Topology" : {
+                  "nodeId" : 106,
+                  "unqualifiedName" : "T"
+                }
+              }
+            }
+          },
+          "StateMachine" : {
+            "map" : {
+              "Commands" : {
+                "Component" : {
+                  "nodeId" : 26,
+                  "unqualifiedName" : "Commands"
+                }
+              },
+              "C" : {
+                "Component" : {
+                  "nodeId" : 32,
+                  "unqualifiedName" : "C"
+                }
+              }
+            }
+          },
+          "Value" : {
+            "map" : {
+              "Commands" : {
+                "Component" : {
+                  "nodeId" : 26,
+                  "unqualifiedName" : "Commands"
+                }
+              },
+              "C" : {
+                "Component" : {
+                  "nodeId" : 32,
+                  "unqualifiedName" : "C"
+                }
+              }
+            }
+          },
+          "Component" : {
+            "map" : {
+              "Commands" : {
+                "Component" : {
+                  "nodeId" : 26,
+                  "unqualifiedName" : "Commands"
+                }
+              },
+              "C" : {
+                "Component" : {
+                  "nodeId" : 32,
+                  "unqualifiedName" : "C"
+                }
+              }
+            }
+          },
+          "Type" : {
+            "map" : {
+              "Commands" : {
+                "Component" : {
+                  "nodeId" : 26,
+                  "unqualifiedName" : "Commands"
+                }
+              },
+              "C" : {
+                "Component" : {
+                  "nodeId" : 32,
+                  "unqualifiedName" : "C"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "topologyMap" : {
+      "106" : {
+        "aNode" : {
+          "astNodeId" : 106
+        },
+        "directImportMap" : {
+          
+        },
+        "transitiveImportSet" : [
+        ],
+        "instanceMap" : [
+          [
+            {
+              "aNode" : {
+                "astNodeId" : 36
+              },
+              "qualifiedName" : {
+                "qualifier" : [
+                  "M"
+                ],
+                "base" : "commands"
+              },
+              "component" : {
+                "astNodeId" : 26
+              },
+              "baseId" : 256,
+              "maxId" : 255,
+              "file" : "None",
+              "queueSize" : "None",
+              "stackSize" : "None",
+              "priority" : "None",
+              "cpu" : "None",
+              "initSpecifierMap" : {
+                
+              }
+            },
+            [
+              {
+                "Public" : {
+                  
+                }
+              },
+              {
+                "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+                "pos" : "20.5",
+                "includingLoc" : "None"
+              }
+            ]
+          ],
+          [
+            {
+              "aNode" : {
+                "astNodeId" : 40
+              },
+              "qualifiedName" : {
+                "qualifier" : [
+                  "M"
+                ],
+                "base" : "c"
+              },
+              "component" : {
+                "astNodeId" : 32
+              },
+              "baseId" : 256,
+              "maxId" : 255,
+              "file" : "None",
+              "queueSize" : "None",
+              "stackSize" : "None",
+              "priority" : "None",
+              "cpu" : "None",
+              "initSpecifierMap" : {
+                
+              }
+            },
+            [
+              {
+                "Public" : {
+                  
+                }
+              },
+              {
+                "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+                "pos" : "21.5",
+                "includingLoc" : "None"
+              }
+            ]
+          ]
+        ],
+        "patternMap" : {
+          "Command" : {
+            "aNode" : {
+              "astNodeId" : 105
+            },
+            "ast" : {
+              "kind" : {
+                "Command" : {
+                  
+                }
+              },
+              "source" : {
+                "astNodeId" : 102
+              },
+              "targets" : [
+                {
+                  "astNodeId" : 104
+                }
+              ]
+            },
+            "source" : [
+              {
+                "aNode" : {
+                  "astNodeId" : 36
+                },
+                "qualifiedName" : {
+                  "qualifier" : [
+                    "M"
+                  ],
+                  "base" : "commands"
+                },
+                "component" : {
+                  "astNodeId" : 26
+                },
+                "baseId" : 256,
+                "maxId" : 255,
+                "file" : "None",
+                "queueSize" : "None",
+                "stackSize" : "None",
+                "priority" : "None",
+                "cpu" : "None",
+                "initSpecifierMap" : {
+                  
+                }
+              },
+              {
+                "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+                "pos" : "22.34",
+                "includingLoc" : "None"
+              }
+            ],
+            "targets" : [
+              [
+                {
+                  "aNode" : {
+                    "astNodeId" : 40
+                  },
+                  "qualifiedName" : {
+                    "qualifier" : [
+                      "M"
+                    ],
+                    "base" : "c"
+                  },
+                  "component" : {
+                    "astNodeId" : 32
+                  },
+                  "baseId" : 256,
+                  "maxId" : 255,
+                  "file" : "None",
+                  "queueSize" : "None",
+                  "stackSize" : "None",
+                  "priority" : "None",
+                  "cpu" : "None",
+                  "initSpecifierMap" : {
+                    
+                  }
+                },
+                {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+                  "pos" : "22.45",
+                  "includingLoc" : "None"
+                }
+              ]
+            ]
+          }
+        },
+        "connectionMap" : {
+          "CommandRegistration" : [
+            {
+              "from" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+                  "pos" : "22.5",
+                  "includingLoc" : "None"
+                },
+                "port" : {
+                  "componentInstance" : {
+                    "aNode" : {
+                      "astNodeId" : 40
+                    },
+                    "qualifiedName" : {
+                      "qualifier" : [
+                        "M"
+                      ],
+                      "base" : "c"
+                    },
+                    "component" : {
+                      "astNodeId" : 32
+                    },
+                    "baseId" : 256,
+                    "maxId" : 255,
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecifierMap" : {
+                      
+                    }
+                  },
+                  "portInstance" : {
+                    "Special" : {
+                      "aNode" : {
+                        "astNodeId" : 27
+                      },
+                      "specifier" : {
+                        "inputKind" : "None",
+                        "kind" : {
+                          "CommandReg" : {
+                            
+                          }
+                        },
+                        "name" : "cmdRegOut",
+                        "priority" : "None",
+                        "queueFull" : "None"
+                      },
+                      "symbol" : {
+                        "Port" : {
+                          "nodeId" : 1,
+                          "unqualifiedName" : "CmdReg"
+                        }
+                      },
+                      "priority" : "None",
+                      "queueFull" : "None",
+                      "importNodeIds" : [
+                      ]
+                    }
+                  }
+                },
+                "portNumber" : "None"
+              },
+              "to" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+                  "pos" : "22.5",
+                  "includingLoc" : "None"
+                },
+                "port" : {
+                  "componentInstance" : {
+                    "aNode" : {
+                      "astNodeId" : 36
+                    },
+                    "qualifiedName" : {
+                      "qualifier" : [
+                        "M"
+                      ],
+                      "base" : "commands"
+                    },
+                    "component" : {
+                      "astNodeId" : 26
+                    },
+                    "baseId" : 256,
+                    "maxId" : 255,
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecifierMap" : {
+                      
+                    }
+                  },
+                  "portInstance" : {
+                    "General" : {
+                      "aNode" : {
+                        "astNodeId" : 9
+                      },
+                      "specifier" : {
+                        "kind" : {
+                          "SyncInput" : {
+                            
+                          }
+                        },
+                        "name" : "cmdRegIn",
+                        "size" : "None",
+                        "port" : {
+                          "Some" : {
+                            "astNodeId" : 8
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None"
+                      },
+                      "kind" : "SyncInput",
+                      "size" : 1,
+                      "ty" : {
+                        "DefPort" : {
+                          "symbol" : {
+                            "Port" : {
+                              "nodeId" : 1,
+                              "unqualifiedName" : "CmdReg"
+                            }
+                          }
+                        }
+                      },
+                      "importNodeIds" : [
+                      ]
+                    }
+                  }
+                },
+                "portNumber" : "None"
+              },
+              "isUnmatched" : false
+            }
+          ],
+          "Command" : [
+            {
+              "from" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+                  "pos" : "22.5",
+                  "includingLoc" : "None"
+                },
+                "port" : {
+                  "componentInstance" : {
+                    "aNode" : {
+                      "astNodeId" : 36
+                    },
+                    "qualifiedName" : {
+                      "qualifier" : [
+                        "M"
+                      ],
+                      "base" : "commands"
+                    },
+                    "component" : {
+                      "astNodeId" : 26
+                    },
+                    "baseId" : 256,
+                    "maxId" : 255,
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecifierMap" : {
+                      
+                    }
+                  },
+                  "portInstance" : {
+                    "General" : {
+                      "aNode" : {
+                        "astNodeId" : 13
+                      },
+                      "specifier" : {
+                        "kind" : {
+                          "Output" : {
+                            
+                          }
+                        },
+                        "name" : "cmdOut",
+                        "size" : "None",
+                        "port" : {
+                          "Some" : {
+                            "astNodeId" : 12
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None"
+                      },
+                      "kind" : "Output",
+                      "size" : 1,
+                      "ty" : {
+                        "DefPort" : {
+                          "symbol" : {
+                            "Port" : {
+                              "nodeId" : 0,
+                              "unqualifiedName" : "Cmd"
+                            }
+                          }
+                        }
+                      },
+                      "importNodeIds" : [
+                      ]
+                    }
+                  }
+                },
+                "portNumber" : "None"
+              },
+              "to" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+                  "pos" : "22.5",
+                  "includingLoc" : "None"
+                },
+                "port" : {
+                  "componentInstance" : {
+                    "aNode" : {
+                      "astNodeId" : 40
+                    },
+                    "qualifiedName" : {
+                      "qualifier" : [
+                        "M"
+                      ],
+                      "base" : "c"
+                    },
+                    "component" : {
+                      "astNodeId" : 32
+                    },
+                    "baseId" : 256,
+                    "maxId" : 255,
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecifierMap" : {
+                      
+                    }
+                  },
+                  "portInstance" : {
+                    "Special" : {
+                      "aNode" : {
+                        "astNodeId" : 28
+                      },
+                      "specifier" : {
+                        "inputKind" : "None",
+                        "kind" : {
+                          "CommandRecv" : {
+                            
+                          }
+                        },
+                        "name" : "cmdIn",
+                        "priority" : "None",
+                        "queueFull" : "None"
+                      },
+                      "symbol" : {
+                        "Port" : {
+                          "nodeId" : 0,
+                          "unqualifiedName" : "Cmd"
+                        }
+                      },
+                      "priority" : "None",
+                      "queueFull" : "None",
+                      "importNodeIds" : [
+                      ]
+                    }
+                  }
+                },
+                "portNumber" : "None"
+              },
+              "isUnmatched" : false
+            }
+          ],
+          "CommandResponse" : [
+            {
+              "from" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+                  "pos" : "22.5",
+                  "includingLoc" : "None"
+                },
+                "port" : {
+                  "componentInstance" : {
+                    "aNode" : {
+                      "astNodeId" : 40
+                    },
+                    "qualifiedName" : {
+                      "qualifier" : [
+                        "M"
+                      ],
+                      "base" : "c"
+                    },
+                    "component" : {
+                      "astNodeId" : 32
+                    },
+                    "baseId" : 256,
+                    "maxId" : 255,
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecifierMap" : {
+                      
+                    }
+                  },
+                  "portInstance" : {
+                    "Special" : {
+                      "aNode" : {
+                        "astNodeId" : 31
+                      },
+                      "specifier" : {
+                        "inputKind" : "None",
+                        "kind" : {
+                          "CommandResp" : {
+                            
+                          }
+                        },
+                        "name" : "cmdResponseOut",
+                        "priority" : "None",
+                        "queueFull" : "None"
+                      },
+                      "symbol" : {
+                        "Port" : {
+                          "nodeId" : 4,
+                          "unqualifiedName" : "CmdResponse"
+                        }
+                      },
+                      "priority" : "None",
+                      "queueFull" : "None",
+                      "importNodeIds" : [
+                      ]
+                    }
+                  }
+                },
+                "portNumber" : "None"
+              },
+              "to" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+                  "pos" : "22.5",
+                  "includingLoc" : "None"
+                },
+                "port" : {
+                  "componentInstance" : {
+                    "aNode" : {
+                      "astNodeId" : 36
+                    },
+                    "qualifiedName" : {
+                      "qualifier" : [
+                        "M"
+                      ],
+                      "base" : "commands"
+                    },
+                    "component" : {
+                      "astNodeId" : 26
+                    },
+                    "baseId" : 256,
+                    "maxId" : 255,
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecifierMap" : {
+                      
+                    }
+                  },
+                  "portInstance" : {
+                    "General" : {
+                      "aNode" : {
+                        "astNodeId" : 25
+                      },
+                      "specifier" : {
+                        "kind" : {
+                          "SyncInput" : {
+                            
+                          }
+                        },
+                        "name" : "cmdResponseIn",
+                        "size" : "None",
+                        "port" : {
+                          "Some" : {
+                            "astNodeId" : 24
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None"
+                      },
+                      "kind" : "SyncInput",
+                      "size" : 1,
+                      "ty" : {
+                        "DefPort" : {
+                          "symbol" : {
+                            "Port" : {
+                              "nodeId" : 4,
+                              "unqualifiedName" : "CmdResponse"
+                            }
+                          }
+                        }
+                      },
+                      "importNodeIds" : [
+                      ]
+                    }
+                  }
+                },
+                "portNumber" : "None"
+              },
+              "isUnmatched" : false
+            }
+          ]
+        },
+        "localConnectionMap" : {
+          "CommandRegistration" : [
+            {
+              "from" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+                  "pos" : "22.5",
+                  "includingLoc" : "None"
+                },
+                "port" : {
+                  "componentInstance" : {
+                    "aNode" : {
+                      "astNodeId" : 40
+                    },
+                    "qualifiedName" : {
+                      "qualifier" : [
+                        "M"
+                      ],
+                      "base" : "c"
+                    },
+                    "component" : {
+                      "astNodeId" : 32
+                    },
+                    "baseId" : 256,
+                    "maxId" : 255,
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecifierMap" : {
+                      
+                    }
+                  },
+                  "portInstance" : {
+                    "Special" : {
+                      "aNode" : {
+                        "astNodeId" : 27
+                      },
+                      "specifier" : {
+                        "inputKind" : "None",
+                        "kind" : {
+                          "CommandReg" : {
+                            
+                          }
+                        },
+                        "name" : "cmdRegOut",
+                        "priority" : "None",
+                        "queueFull" : "None"
+                      },
+                      "symbol" : {
+                        "Port" : {
+                          "nodeId" : 1,
+                          "unqualifiedName" : "CmdReg"
+                        }
+                      },
+                      "priority" : "None",
+                      "queueFull" : "None",
+                      "importNodeIds" : [
+                      ]
+                    }
+                  }
+                },
+                "portNumber" : "None"
+              },
+              "to" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+                  "pos" : "22.5",
+                  "includingLoc" : "None"
+                },
+                "port" : {
+                  "componentInstance" : {
+                    "aNode" : {
+                      "astNodeId" : 36
+                    },
+                    "qualifiedName" : {
+                      "qualifier" : [
+                        "M"
+                      ],
+                      "base" : "commands"
+                    },
+                    "component" : {
+                      "astNodeId" : 26
+                    },
+                    "baseId" : 256,
+                    "maxId" : 255,
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecifierMap" : {
+                      
+                    }
+                  },
+                  "portInstance" : {
+                    "General" : {
+                      "aNode" : {
+                        "astNodeId" : 9
+                      },
+                      "specifier" : {
+                        "kind" : {
+                          "SyncInput" : {
+                            
+                          }
+                        },
+                        "name" : "cmdRegIn",
+                        "size" : "None",
+                        "port" : {
+                          "Some" : {
+                            "astNodeId" : 8
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None"
+                      },
+                      "kind" : "SyncInput",
+                      "size" : 1,
+                      "ty" : {
+                        "DefPort" : {
+                          "symbol" : {
+                            "Port" : {
+                              "nodeId" : 1,
+                              "unqualifiedName" : "CmdReg"
+                            }
+                          }
+                        }
+                      },
+                      "importNodeIds" : [
+                      ]
+                    }
+                  }
+                },
+                "portNumber" : "None"
+              },
+              "isUnmatched" : false
+            }
+          ],
+          "Command" : [
+            {
+              "from" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+                  "pos" : "22.5",
+                  "includingLoc" : "None"
+                },
+                "port" : {
+                  "componentInstance" : {
+                    "aNode" : {
+                      "astNodeId" : 36
+                    },
+                    "qualifiedName" : {
+                      "qualifier" : [
+                        "M"
+                      ],
+                      "base" : "commands"
+                    },
+                    "component" : {
+                      "astNodeId" : 26
+                    },
+                    "baseId" : 256,
+                    "maxId" : 255,
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecifierMap" : {
+                      
+                    }
+                  },
+                  "portInstance" : {
+                    "General" : {
+                      "aNode" : {
+                        "astNodeId" : 13
+                      },
+                      "specifier" : {
+                        "kind" : {
+                          "Output" : {
+                            
+                          }
+                        },
+                        "name" : "cmdOut",
+                        "size" : "None",
+                        "port" : {
+                          "Some" : {
+                            "astNodeId" : 12
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None"
+                      },
+                      "kind" : "Output",
+                      "size" : 1,
+                      "ty" : {
+                        "DefPort" : {
+                          "symbol" : {
+                            "Port" : {
+                              "nodeId" : 0,
+                              "unqualifiedName" : "Cmd"
+                            }
+                          }
+                        }
+                      },
+                      "importNodeIds" : [
+                      ]
+                    }
+                  }
+                },
+                "portNumber" : "None"
+              },
+              "to" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+                  "pos" : "22.5",
+                  "includingLoc" : "None"
+                },
+                "port" : {
+                  "componentInstance" : {
+                    "aNode" : {
+                      "astNodeId" : 40
+                    },
+                    "qualifiedName" : {
+                      "qualifier" : [
+                        "M"
+                      ],
+                      "base" : "c"
+                    },
+                    "component" : {
+                      "astNodeId" : 32
+                    },
+                    "baseId" : 256,
+                    "maxId" : 255,
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecifierMap" : {
+                      
+                    }
+                  },
+                  "portInstance" : {
+                    "Special" : {
+                      "aNode" : {
+                        "astNodeId" : 28
+                      },
+                      "specifier" : {
+                        "inputKind" : "None",
+                        "kind" : {
+                          "CommandRecv" : {
+                            
+                          }
+                        },
+                        "name" : "cmdIn",
+                        "priority" : "None",
+                        "queueFull" : "None"
+                      },
+                      "symbol" : {
+                        "Port" : {
+                          "nodeId" : 0,
+                          "unqualifiedName" : "Cmd"
+                        }
+                      },
+                      "priority" : "None",
+                      "queueFull" : "None",
+                      "importNodeIds" : [
+                      ]
+                    }
+                  }
+                },
+                "portNumber" : "None"
+              },
+              "isUnmatched" : false
+            }
+          ],
+          "CommandResponse" : [
+            {
+              "from" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+                  "pos" : "22.5",
+                  "includingLoc" : "None"
+                },
+                "port" : {
+                  "componentInstance" : {
+                    "aNode" : {
+                      "astNodeId" : 40
+                    },
+                    "qualifiedName" : {
+                      "qualifier" : [
+                        "M"
+                      ],
+                      "base" : "c"
+                    },
+                    "component" : {
+                      "astNodeId" : 32
+                    },
+                    "baseId" : 256,
+                    "maxId" : 255,
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecifierMap" : {
+                      
+                    }
+                  },
+                  "portInstance" : {
+                    "Special" : {
+                      "aNode" : {
+                        "astNodeId" : 31
+                      },
+                      "specifier" : {
+                        "inputKind" : "None",
+                        "kind" : {
+                          "CommandResp" : {
+                            
+                          }
+                        },
+                        "name" : "cmdResponseOut",
+                        "priority" : "None",
+                        "queueFull" : "None"
+                      },
+                      "symbol" : {
+                        "Port" : {
+                          "nodeId" : 4,
+                          "unqualifiedName" : "CmdResponse"
+                        }
+                      },
+                      "priority" : "None",
+                      "queueFull" : "None",
+                      "importNodeIds" : [
+                      ]
+                    }
+                  }
+                },
+                "portNumber" : "None"
+              },
+              "to" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+                  "pos" : "22.5",
+                  "includingLoc" : "None"
+                },
+                "port" : {
+                  "componentInstance" : {
+                    "aNode" : {
+                      "astNodeId" : 36
+                    },
+                    "qualifiedName" : {
+                      "qualifier" : [
+                        "M"
+                      ],
+                      "base" : "commands"
+                    },
+                    "component" : {
+                      "astNodeId" : 26
+                    },
+                    "baseId" : 256,
+                    "maxId" : 255,
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecifierMap" : {
+                      
+                    }
+                  },
+                  "portInstance" : {
+                    "General" : {
+                      "aNode" : {
+                        "astNodeId" : 25
+                      },
+                      "specifier" : {
+                        "kind" : {
+                          "SyncInput" : {
+                            
+                          }
+                        },
+                        "name" : "cmdResponseIn",
+                        "size" : "None",
+                        "port" : {
+                          "Some" : {
+                            "astNodeId" : 24
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None"
+                      },
+                      "kind" : "SyncInput",
+                      "size" : 1,
+                      "ty" : {
+                        "DefPort" : {
+                          "symbol" : {
+                            "Port" : {
+                              "nodeId" : 4,
+                              "unqualifiedName" : "CmdResponse"
+                            }
+                          }
+                        }
+                      },
+                      "importNodeIds" : [
+                      ]
+                    }
+                  }
+                },
+                "portNumber" : "None"
+              },
+              "isUnmatched" : false
+            }
+          ]
+        },
+        "outputConnectionMap" : [
+          [
+            {
+              "componentInstance" : {
+                "aNode" : {
+                  "astNodeId" : 40
+                },
+                "qualifiedName" : {
+                  "qualifier" : [
+                    "M"
+                  ],
+                  "base" : "c"
+                },
+                "component" : {
+                  "astNodeId" : 32
+                },
+                "baseId" : 256,
+                "maxId" : 255,
+                "file" : "None",
+                "queueSize" : "None",
+                "stackSize" : "None",
+                "priority" : "None",
+                "cpu" : "None",
+                "initSpecifierMap" : {
+                  
+                }
+              },
+              "portInstance" : {
+                "Special" : {
+                  "aNode" : {
+                    "astNodeId" : 27
+                  },
+                  "specifier" : {
+                    "inputKind" : "None",
+                    "kind" : {
+                      "CommandReg" : {
+                        
+                      }
+                    },
+                    "name" : "cmdRegOut",
+                    "priority" : "None",
+                    "queueFull" : "None"
+                  },
+                  "symbol" : {
+                    "Port" : {
+                      "nodeId" : 1,
+                      "unqualifiedName" : "CmdReg"
+                    }
+                  },
+                  "priority" : "None",
+                  "queueFull" : "None",
+                  "importNodeIds" : [
+                  ]
+                }
+              }
+            },
+            [
+              {
+                "from" : {
+                  "loc" : {
+                    "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+                    "pos" : "22.5",
+                    "includingLoc" : "None"
+                  },
+                  "port" : {
+                    "componentInstance" : {
+                      "aNode" : {
+                        "astNodeId" : 40
+                      },
+                      "qualifiedName" : {
+                        "qualifier" : [
+                          "M"
+                        ],
+                        "base" : "c"
+                      },
+                      "component" : {
+                        "astNodeId" : 32
+                      },
+                      "baseId" : 256,
+                      "maxId" : 255,
+                      "file" : "None",
+                      "queueSize" : "None",
+                      "stackSize" : "None",
+                      "priority" : "None",
+                      "cpu" : "None",
+                      "initSpecifierMap" : {
+                        
+                      }
+                    },
+                    "portInstance" : {
+                      "Special" : {
+                        "aNode" : {
+                          "astNodeId" : 27
+                        },
+                        "specifier" : {
+                          "inputKind" : "None",
+                          "kind" : {
+                            "CommandReg" : {
+                              
+                            }
+                          },
+                          "name" : "cmdRegOut",
+                          "priority" : "None",
+                          "queueFull" : "None"
+                        },
+                        "symbol" : {
+                          "Port" : {
+                            "nodeId" : 1,
+                            "unqualifiedName" : "CmdReg"
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None",
+                        "importNodeIds" : [
+                        ]
+                      }
+                    }
+                  },
+                  "portNumber" : "None"
+                },
+                "to" : {
+                  "loc" : {
+                    "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+                    "pos" : "22.5",
+                    "includingLoc" : "None"
+                  },
+                  "port" : {
+                    "componentInstance" : {
+                      "aNode" : {
+                        "astNodeId" : 36
+                      },
+                      "qualifiedName" : {
+                        "qualifier" : [
+                          "M"
+                        ],
+                        "base" : "commands"
+                      },
+                      "component" : {
+                        "astNodeId" : 26
+                      },
+                      "baseId" : 256,
+                      "maxId" : 255,
+                      "file" : "None",
+                      "queueSize" : "None",
+                      "stackSize" : "None",
+                      "priority" : "None",
+                      "cpu" : "None",
+                      "initSpecifierMap" : {
+                        
+                      }
+                    },
+                    "portInstance" : {
+                      "General" : {
+                        "aNode" : {
+                          "astNodeId" : 9
+                        },
+                        "specifier" : {
+                          "kind" : {
+                            "SyncInput" : {
+                              
+                            }
+                          },
+                          "name" : "cmdRegIn",
+                          "size" : "None",
+                          "port" : {
+                            "Some" : {
+                              "astNodeId" : 8
+                            }
+                          },
+                          "priority" : "None",
+                          "queueFull" : "None"
+                        },
+                        "kind" : "SyncInput",
+                        "size" : 1,
+                        "ty" : {
+                          "DefPort" : {
+                            "symbol" : {
+                              "Port" : {
+                                "nodeId" : 1,
+                                "unqualifiedName" : "CmdReg"
+                              }
+                            }
+                          }
+                        },
+                        "importNodeIds" : [
+                        ]
+                      }
+                    }
+                  },
+                  "portNumber" : "None"
+                },
+                "isUnmatched" : false
+              }
+            ]
+          ],
+          [
+            {
+              "componentInstance" : {
+                "aNode" : {
+                  "astNodeId" : 36
+                },
+                "qualifiedName" : {
+                  "qualifier" : [
+                    "M"
+                  ],
+                  "base" : "commands"
+                },
+                "component" : {
+                  "astNodeId" : 26
+                },
+                "baseId" : 256,
+                "maxId" : 255,
+                "file" : "None",
+                "queueSize" : "None",
+                "stackSize" : "None",
+                "priority" : "None",
+                "cpu" : "None",
+                "initSpecifierMap" : {
+                  
+                }
+              },
+              "portInstance" : {
+                "General" : {
+                  "aNode" : {
+                    "astNodeId" : 13
+                  },
+                  "specifier" : {
+                    "kind" : {
+                      "Output" : {
+                        
+                      }
+                    },
+                    "name" : "cmdOut",
+                    "size" : "None",
+                    "port" : {
+                      "Some" : {
+                        "astNodeId" : 12
+                      }
+                    },
+                    "priority" : "None",
+                    "queueFull" : "None"
+                  },
+                  "kind" : "Output",
+                  "size" : 1,
+                  "ty" : {
+                    "DefPort" : {
+                      "symbol" : {
+                        "Port" : {
+                          "nodeId" : 0,
+                          "unqualifiedName" : "Cmd"
+                        }
+                      }
+                    }
+                  },
+                  "importNodeIds" : [
+                  ]
+                }
+              }
+            },
+            [
+              {
+                "from" : {
+                  "loc" : {
+                    "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+                    "pos" : "22.5",
+                    "includingLoc" : "None"
+                  },
+                  "port" : {
+                    "componentInstance" : {
+                      "aNode" : {
+                        "astNodeId" : 36
+                      },
+                      "qualifiedName" : {
+                        "qualifier" : [
+                          "M"
+                        ],
+                        "base" : "commands"
+                      },
+                      "component" : {
+                        "astNodeId" : 26
+                      },
+                      "baseId" : 256,
+                      "maxId" : 255,
+                      "file" : "None",
+                      "queueSize" : "None",
+                      "stackSize" : "None",
+                      "priority" : "None",
+                      "cpu" : "None",
+                      "initSpecifierMap" : {
+                        
+                      }
+                    },
+                    "portInstance" : {
+                      "General" : {
+                        "aNode" : {
+                          "astNodeId" : 13
+                        },
+                        "specifier" : {
+                          "kind" : {
+                            "Output" : {
+                              
+                            }
+                          },
+                          "name" : "cmdOut",
+                          "size" : "None",
+                          "port" : {
+                            "Some" : {
+                              "astNodeId" : 12
+                            }
+                          },
+                          "priority" : "None",
+                          "queueFull" : "None"
+                        },
+                        "kind" : "Output",
+                        "size" : 1,
+                        "ty" : {
+                          "DefPort" : {
+                            "symbol" : {
+                              "Port" : {
+                                "nodeId" : 0,
+                                "unqualifiedName" : "Cmd"
+                              }
+                            }
+                          }
+                        },
+                        "importNodeIds" : [
+                        ]
+                      }
+                    }
+                  },
+                  "portNumber" : "None"
+                },
+                "to" : {
+                  "loc" : {
+                    "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+                    "pos" : "22.5",
+                    "includingLoc" : "None"
+                  },
+                  "port" : {
+                    "componentInstance" : {
+                      "aNode" : {
+                        "astNodeId" : 40
+                      },
+                      "qualifiedName" : {
+                        "qualifier" : [
+                          "M"
+                        ],
+                        "base" : "c"
+                      },
+                      "component" : {
+                        "astNodeId" : 32
+                      },
+                      "baseId" : 256,
+                      "maxId" : 255,
+                      "file" : "None",
+                      "queueSize" : "None",
+                      "stackSize" : "None",
+                      "priority" : "None",
+                      "cpu" : "None",
+                      "initSpecifierMap" : {
+                        
+                      }
+                    },
+                    "portInstance" : {
+                      "Special" : {
+                        "aNode" : {
+                          "astNodeId" : 28
+                        },
+                        "specifier" : {
+                          "inputKind" : "None",
+                          "kind" : {
+                            "CommandRecv" : {
+                              
+                            }
+                          },
+                          "name" : "cmdIn",
+                          "priority" : "None",
+                          "queueFull" : "None"
+                        },
+                        "symbol" : {
+                          "Port" : {
+                            "nodeId" : 0,
+                            "unqualifiedName" : "Cmd"
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None",
+                        "importNodeIds" : [
+                        ]
+                      }
+                    }
+                  },
+                  "portNumber" : "None"
+                },
+                "isUnmatched" : false
+              }
+            ]
+          ],
+          [
+            {
+              "componentInstance" : {
+                "aNode" : {
+                  "astNodeId" : 40
+                },
+                "qualifiedName" : {
+                  "qualifier" : [
+                    "M"
+                  ],
+                  "base" : "c"
+                },
+                "component" : {
+                  "astNodeId" : 32
+                },
+                "baseId" : 256,
+                "maxId" : 255,
+                "file" : "None",
+                "queueSize" : "None",
+                "stackSize" : "None",
+                "priority" : "None",
+                "cpu" : "None",
+                "initSpecifierMap" : {
+                  
+                }
+              },
+              "portInstance" : {
+                "Special" : {
+                  "aNode" : {
+                    "astNodeId" : 31
+                  },
+                  "specifier" : {
+                    "inputKind" : "None",
+                    "kind" : {
+                      "CommandResp" : {
+                        
+                      }
+                    },
+                    "name" : "cmdResponseOut",
+                    "priority" : "None",
+                    "queueFull" : "None"
+                  },
+                  "symbol" : {
+                    "Port" : {
+                      "nodeId" : 4,
+                      "unqualifiedName" : "CmdResponse"
+                    }
+                  },
+                  "priority" : "None",
+                  "queueFull" : "None",
+                  "importNodeIds" : [
+                  ]
+                }
+              }
+            },
+            [
+              {
+                "from" : {
+                  "loc" : {
+                    "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+                    "pos" : "22.5",
+                    "includingLoc" : "None"
+                  },
+                  "port" : {
+                    "componentInstance" : {
+                      "aNode" : {
+                        "astNodeId" : 40
+                      },
+                      "qualifiedName" : {
+                        "qualifier" : [
+                          "M"
+                        ],
+                        "base" : "c"
+                      },
+                      "component" : {
+                        "astNodeId" : 32
+                      },
+                      "baseId" : 256,
+                      "maxId" : 255,
+                      "file" : "None",
+                      "queueSize" : "None",
+                      "stackSize" : "None",
+                      "priority" : "None",
+                      "cpu" : "None",
+                      "initSpecifierMap" : {
+                        
+                      }
+                    },
+                    "portInstance" : {
+                      "Special" : {
+                        "aNode" : {
+                          "astNodeId" : 31
+                        },
+                        "specifier" : {
+                          "inputKind" : "None",
+                          "kind" : {
+                            "CommandResp" : {
+                              
+                            }
+                          },
+                          "name" : "cmdResponseOut",
+                          "priority" : "None",
+                          "queueFull" : "None"
+                        },
+                        "symbol" : {
+                          "Port" : {
+                            "nodeId" : 4,
+                            "unqualifiedName" : "CmdResponse"
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None",
+                        "importNodeIds" : [
+                        ]
+                      }
+                    }
+                  },
+                  "portNumber" : "None"
+                },
+                "to" : {
+                  "loc" : {
+                    "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+                    "pos" : "22.5",
+                    "includingLoc" : "None"
+                  },
+                  "port" : {
+                    "componentInstance" : {
+                      "aNode" : {
+                        "astNodeId" : 36
+                      },
+                      "qualifiedName" : {
+                        "qualifier" : [
+                          "M"
+                        ],
+                        "base" : "commands"
+                      },
+                      "component" : {
+                        "astNodeId" : 26
+                      },
+                      "baseId" : 256,
+                      "maxId" : 255,
+                      "file" : "None",
+                      "queueSize" : "None",
+                      "stackSize" : "None",
+                      "priority" : "None",
+                      "cpu" : "None",
+                      "initSpecifierMap" : {
+                        
+                      }
+                    },
+                    "portInstance" : {
+                      "General" : {
+                        "aNode" : {
+                          "astNodeId" : 25
+                        },
+                        "specifier" : {
+                          "kind" : {
+                            "SyncInput" : {
+                              
+                            }
+                          },
+                          "name" : "cmdResponseIn",
+                          "size" : "None",
+                          "port" : {
+                            "Some" : {
+                              "astNodeId" : 24
+                            }
+                          },
+                          "priority" : "None",
+                          "queueFull" : "None"
+                        },
+                        "kind" : "SyncInput",
+                        "size" : 1,
+                        "ty" : {
+                          "DefPort" : {
+                            "symbol" : {
+                              "Port" : {
+                                "nodeId" : 4,
+                                "unqualifiedName" : "CmdResponse"
+                              }
+                            }
+                          }
+                        },
+                        "importNodeIds" : [
+                        ]
+                      }
+                    }
+                  },
+                  "portNumber" : "None"
+                },
+                "isUnmatched" : false
+              }
+            ]
+          ]
+        ],
+        "inputConnectionMap" : [
+          [
+            {
+              "componentInstance" : {
+                "aNode" : {
+                  "astNodeId" : 36
+                },
+                "qualifiedName" : {
+                  "qualifier" : [
+                    "M"
+                  ],
+                  "base" : "commands"
+                },
+                "component" : {
+                  "astNodeId" : 26
+                },
+                "baseId" : 256,
+                "maxId" : 255,
+                "file" : "None",
+                "queueSize" : "None",
+                "stackSize" : "None",
+                "priority" : "None",
+                "cpu" : "None",
+                "initSpecifierMap" : {
+                  
+                }
+              },
+              "portInstance" : {
+                "General" : {
+                  "aNode" : {
+                    "astNodeId" : 9
+                  },
+                  "specifier" : {
+                    "kind" : {
+                      "SyncInput" : {
+                        
+                      }
+                    },
+                    "name" : "cmdRegIn",
+                    "size" : "None",
+                    "port" : {
+                      "Some" : {
+                        "astNodeId" : 8
+                      }
+                    },
+                    "priority" : "None",
+                    "queueFull" : "None"
+                  },
+                  "kind" : "SyncInput",
+                  "size" : 1,
+                  "ty" : {
+                    "DefPort" : {
+                      "symbol" : {
+                        "Port" : {
+                          "nodeId" : 1,
+                          "unqualifiedName" : "CmdReg"
+                        }
+                      }
+                    }
+                  },
+                  "importNodeIds" : [
+                  ]
+                }
+              }
+            },
+            [
+              {
+                "from" : {
+                  "loc" : {
+                    "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+                    "pos" : "22.5",
+                    "includingLoc" : "None"
+                  },
+                  "port" : {
+                    "componentInstance" : {
+                      "aNode" : {
+                        "astNodeId" : 40
+                      },
+                      "qualifiedName" : {
+                        "qualifier" : [
+                          "M"
+                        ],
+                        "base" : "c"
+                      },
+                      "component" : {
+                        "astNodeId" : 32
+                      },
+                      "baseId" : 256,
+                      "maxId" : 255,
+                      "file" : "None",
+                      "queueSize" : "None",
+                      "stackSize" : "None",
+                      "priority" : "None",
+                      "cpu" : "None",
+                      "initSpecifierMap" : {
+                        
+                      }
+                    },
+                    "portInstance" : {
+                      "Special" : {
+                        "aNode" : {
+                          "astNodeId" : 27
+                        },
+                        "specifier" : {
+                          "inputKind" : "None",
+                          "kind" : {
+                            "CommandReg" : {
+                              
+                            }
+                          },
+                          "name" : "cmdRegOut",
+                          "priority" : "None",
+                          "queueFull" : "None"
+                        },
+                        "symbol" : {
+                          "Port" : {
+                            "nodeId" : 1,
+                            "unqualifiedName" : "CmdReg"
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None",
+                        "importNodeIds" : [
+                        ]
+                      }
+                    }
+                  },
+                  "portNumber" : "None"
+                },
+                "to" : {
+                  "loc" : {
+                    "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+                    "pos" : "22.5",
+                    "includingLoc" : "None"
+                  },
+                  "port" : {
+                    "componentInstance" : {
+                      "aNode" : {
+                        "astNodeId" : 36
+                      },
+                      "qualifiedName" : {
+                        "qualifier" : [
+                          "M"
+                        ],
+                        "base" : "commands"
+                      },
+                      "component" : {
+                        "astNodeId" : 26
+                      },
+                      "baseId" : 256,
+                      "maxId" : 255,
+                      "file" : "None",
+                      "queueSize" : "None",
+                      "stackSize" : "None",
+                      "priority" : "None",
+                      "cpu" : "None",
+                      "initSpecifierMap" : {
+                        
+                      }
+                    },
+                    "portInstance" : {
+                      "General" : {
+                        "aNode" : {
+                          "astNodeId" : 9
+                        },
+                        "specifier" : {
+                          "kind" : {
+                            "SyncInput" : {
+                              
+                            }
+                          },
+                          "name" : "cmdRegIn",
+                          "size" : "None",
+                          "port" : {
+                            "Some" : {
+                              "astNodeId" : 8
+                            }
+                          },
+                          "priority" : "None",
+                          "queueFull" : "None"
+                        },
+                        "kind" : "SyncInput",
+                        "size" : 1,
+                        "ty" : {
+                          "DefPort" : {
+                            "symbol" : {
+                              "Port" : {
+                                "nodeId" : 1,
+                                "unqualifiedName" : "CmdReg"
+                              }
+                            }
+                          }
+                        },
+                        "importNodeIds" : [
+                        ]
+                      }
+                    }
+                  },
+                  "portNumber" : "None"
+                },
+                "isUnmatched" : false
+              }
+            ]
+          ],
+          [
+            {
+              "componentInstance" : {
+                "aNode" : {
+                  "astNodeId" : 40
+                },
+                "qualifiedName" : {
+                  "qualifier" : [
+                    "M"
+                  ],
+                  "base" : "c"
+                },
+                "component" : {
+                  "astNodeId" : 32
+                },
+                "baseId" : 256,
+                "maxId" : 255,
+                "file" : "None",
+                "queueSize" : "None",
+                "stackSize" : "None",
+                "priority" : "None",
+                "cpu" : "None",
+                "initSpecifierMap" : {
+                  
+                }
+              },
+              "portInstance" : {
+                "Special" : {
+                  "aNode" : {
+                    "astNodeId" : 28
+                  },
+                  "specifier" : {
+                    "inputKind" : "None",
+                    "kind" : {
+                      "CommandRecv" : {
+                        
+                      }
+                    },
+                    "name" : "cmdIn",
+                    "priority" : "None",
+                    "queueFull" : "None"
+                  },
+                  "symbol" : {
+                    "Port" : {
+                      "nodeId" : 0,
+                      "unqualifiedName" : "Cmd"
+                    }
+                  },
+                  "priority" : "None",
+                  "queueFull" : "None",
+                  "importNodeIds" : [
+                  ]
+                }
+              }
+            },
+            [
+              {
+                "from" : {
+                  "loc" : {
+                    "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+                    "pos" : "22.5",
+                    "includingLoc" : "None"
+                  },
+                  "port" : {
+                    "componentInstance" : {
+                      "aNode" : {
+                        "astNodeId" : 36
+                      },
+                      "qualifiedName" : {
+                        "qualifier" : [
+                          "M"
+                        ],
+                        "base" : "commands"
+                      },
+                      "component" : {
+                        "astNodeId" : 26
+                      },
+                      "baseId" : 256,
+                      "maxId" : 255,
+                      "file" : "None",
+                      "queueSize" : "None",
+                      "stackSize" : "None",
+                      "priority" : "None",
+                      "cpu" : "None",
+                      "initSpecifierMap" : {
+                        
+                      }
+                    },
+                    "portInstance" : {
+                      "General" : {
+                        "aNode" : {
+                          "astNodeId" : 13
+                        },
+                        "specifier" : {
+                          "kind" : {
+                            "Output" : {
+                              
+                            }
+                          },
+                          "name" : "cmdOut",
+                          "size" : "None",
+                          "port" : {
+                            "Some" : {
+                              "astNodeId" : 12
+                            }
+                          },
+                          "priority" : "None",
+                          "queueFull" : "None"
+                        },
+                        "kind" : "Output",
+                        "size" : 1,
+                        "ty" : {
+                          "DefPort" : {
+                            "symbol" : {
+                              "Port" : {
+                                "nodeId" : 0,
+                                "unqualifiedName" : "Cmd"
+                              }
+                            }
+                          }
+                        },
+                        "importNodeIds" : [
+                        ]
+                      }
+                    }
+                  },
+                  "portNumber" : "None"
+                },
+                "to" : {
+                  "loc" : {
+                    "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+                    "pos" : "22.5",
+                    "includingLoc" : "None"
+                  },
+                  "port" : {
+                    "componentInstance" : {
+                      "aNode" : {
+                        "astNodeId" : 40
+                      },
+                      "qualifiedName" : {
+                        "qualifier" : [
+                          "M"
+                        ],
+                        "base" : "c"
+                      },
+                      "component" : {
+                        "astNodeId" : 32
+                      },
+                      "baseId" : 256,
+                      "maxId" : 255,
+                      "file" : "None",
+                      "queueSize" : "None",
+                      "stackSize" : "None",
+                      "priority" : "None",
+                      "cpu" : "None",
+                      "initSpecifierMap" : {
+                        
+                      }
+                    },
+                    "portInstance" : {
+                      "Special" : {
+                        "aNode" : {
+                          "astNodeId" : 28
+                        },
+                        "specifier" : {
+                          "inputKind" : "None",
+                          "kind" : {
+                            "CommandRecv" : {
+                              
+                            }
+                          },
+                          "name" : "cmdIn",
+                          "priority" : "None",
+                          "queueFull" : "None"
+                        },
+                        "symbol" : {
+                          "Port" : {
+                            "nodeId" : 0,
+                            "unqualifiedName" : "Cmd"
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None",
+                        "importNodeIds" : [
+                        ]
+                      }
+                    }
+                  },
+                  "portNumber" : "None"
+                },
+                "isUnmatched" : false
+              }
+            ]
+          ],
+          [
+            {
+              "componentInstance" : {
+                "aNode" : {
+                  "astNodeId" : 36
+                },
+                "qualifiedName" : {
+                  "qualifier" : [
+                    "M"
+                  ],
+                  "base" : "commands"
+                },
+                "component" : {
+                  "astNodeId" : 26
+                },
+                "baseId" : 256,
+                "maxId" : 255,
+                "file" : "None",
+                "queueSize" : "None",
+                "stackSize" : "None",
+                "priority" : "None",
+                "cpu" : "None",
+                "initSpecifierMap" : {
+                  
+                }
+              },
+              "portInstance" : {
+                "General" : {
+                  "aNode" : {
+                    "astNodeId" : 25
+                  },
+                  "specifier" : {
+                    "kind" : {
+                      "SyncInput" : {
+                        
+                      }
+                    },
+                    "name" : "cmdResponseIn",
+                    "size" : "None",
+                    "port" : {
+                      "Some" : {
+                        "astNodeId" : 24
+                      }
+                    },
+                    "priority" : "None",
+                    "queueFull" : "None"
+                  },
+                  "kind" : "SyncInput",
+                  "size" : 1,
+                  "ty" : {
+                    "DefPort" : {
+                      "symbol" : {
+                        "Port" : {
+                          "nodeId" : 4,
+                          "unqualifiedName" : "CmdResponse"
+                        }
+                      }
+                    }
+                  },
+                  "importNodeIds" : [
+                  ]
+                }
+              }
+            },
+            [
+              {
+                "from" : {
+                  "loc" : {
+                    "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+                    "pos" : "22.5",
+                    "includingLoc" : "None"
+                  },
+                  "port" : {
+                    "componentInstance" : {
+                      "aNode" : {
+                        "astNodeId" : 40
+                      },
+                      "qualifiedName" : {
+                        "qualifier" : [
+                          "M"
+                        ],
+                        "base" : "c"
+                      },
+                      "component" : {
+                        "astNodeId" : 32
+                      },
+                      "baseId" : 256,
+                      "maxId" : 255,
+                      "file" : "None",
+                      "queueSize" : "None",
+                      "stackSize" : "None",
+                      "priority" : "None",
+                      "cpu" : "None",
+                      "initSpecifierMap" : {
+                        
+                      }
+                    },
+                    "portInstance" : {
+                      "Special" : {
+                        "aNode" : {
+                          "astNodeId" : 31
+                        },
+                        "specifier" : {
+                          "inputKind" : "None",
+                          "kind" : {
+                            "CommandResp" : {
+                              
+                            }
+                          },
+                          "name" : "cmdResponseOut",
+                          "priority" : "None",
+                          "queueFull" : "None"
+                        },
+                        "symbol" : {
+                          "Port" : {
+                            "nodeId" : 4,
+                            "unqualifiedName" : "CmdResponse"
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None",
+                        "importNodeIds" : [
+                        ]
+                      }
+                    }
+                  },
+                  "portNumber" : "None"
+                },
+                "to" : {
+                  "loc" : {
+                    "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+                    "pos" : "22.5",
+                    "includingLoc" : "None"
+                  },
+                  "port" : {
+                    "componentInstance" : {
+                      "aNode" : {
+                        "astNodeId" : 36
+                      },
+                      "qualifiedName" : {
+                        "qualifier" : [
+                          "M"
+                        ],
+                        "base" : "commands"
+                      },
+                      "component" : {
+                        "astNodeId" : 26
+                      },
+                      "baseId" : 256,
+                      "maxId" : 255,
+                      "file" : "None",
+                      "queueSize" : "None",
+                      "stackSize" : "None",
+                      "priority" : "None",
+                      "cpu" : "None",
+                      "initSpecifierMap" : {
+                        
+                      }
+                    },
+                    "portInstance" : {
+                      "General" : {
+                        "aNode" : {
+                          "astNodeId" : 25
+                        },
+                        "specifier" : {
+                          "kind" : {
+                            "SyncInput" : {
+                              
+                            }
+                          },
+                          "name" : "cmdResponseIn",
+                          "size" : "None",
+                          "port" : {
+                            "Some" : {
+                              "astNodeId" : 24
+                            }
+                          },
+                          "priority" : "None",
+                          "queueFull" : "None"
+                        },
+                        "kind" : "SyncInput",
+                        "size" : 1,
+                        "ty" : {
+                          "DefPort" : {
+                            "symbol" : {
+                              "Port" : {
+                                "nodeId" : 4,
+                                "unqualifiedName" : "CmdResponse"
+                              }
+                            }
+                          }
+                        },
+                        "importNodeIds" : [
+                        ]
+                      }
+                    }
+                  },
+                  "portNumber" : "None"
+                },
+                "isUnmatched" : false
+              }
+            ]
+          ]
+        ],
+        "fromPortNumberMap" : [
+          [
+            {
+              "from" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+                  "pos" : "22.5",
+                  "includingLoc" : "None"
+                },
+                "port" : {
+                  "componentInstance" : {
+                    "aNode" : {
+                      "astNodeId" : 36
+                    },
+                    "qualifiedName" : {
+                      "qualifier" : [
+                        "M"
+                      ],
+                      "base" : "commands"
+                    },
+                    "component" : {
+                      "astNodeId" : 26
+                    },
+                    "baseId" : 256,
+                    "maxId" : 255,
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecifierMap" : {
+                      
+                    }
+                  },
+                  "portInstance" : {
+                    "General" : {
+                      "aNode" : {
+                        "astNodeId" : 13
+                      },
+                      "specifier" : {
+                        "kind" : {
+                          "Output" : {
+                            
+                          }
+                        },
+                        "name" : "cmdOut",
+                        "size" : "None",
+                        "port" : {
+                          "Some" : {
+                            "astNodeId" : 12
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None"
+                      },
+                      "kind" : "Output",
+                      "size" : 1,
+                      "ty" : {
+                        "DefPort" : {
+                          "symbol" : {
+                            "Port" : {
+                              "nodeId" : 0,
+                              "unqualifiedName" : "Cmd"
+                            }
+                          }
+                        }
+                      },
+                      "importNodeIds" : [
+                      ]
+                    }
+                  }
+                },
+                "portNumber" : "None"
+              },
+              "to" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+                  "pos" : "22.5",
+                  "includingLoc" : "None"
+                },
+                "port" : {
+                  "componentInstance" : {
+                    "aNode" : {
+                      "astNodeId" : 40
+                    },
+                    "qualifiedName" : {
+                      "qualifier" : [
+                        "M"
+                      ],
+                      "base" : "c"
+                    },
+                    "component" : {
+                      "astNodeId" : 32
+                    },
+                    "baseId" : 256,
+                    "maxId" : 255,
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecifierMap" : {
+                      
+                    }
+                  },
+                  "portInstance" : {
+                    "Special" : {
+                      "aNode" : {
+                        "astNodeId" : 28
+                      },
+                      "specifier" : {
+                        "inputKind" : "None",
+                        "kind" : {
+                          "CommandRecv" : {
+                            
+                          }
+                        },
+                        "name" : "cmdIn",
+                        "priority" : "None",
+                        "queueFull" : "None"
+                      },
+                      "symbol" : {
+                        "Port" : {
+                          "nodeId" : 0,
+                          "unqualifiedName" : "Cmd"
+                        }
+                      },
+                      "priority" : "None",
+                      "queueFull" : "None",
+                      "importNodeIds" : [
+                      ]
+                    }
+                  }
+                },
+                "portNumber" : "None"
+              },
+              "isUnmatched" : false
+            },
+            0
+          ],
+          [
+            {
+              "from" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+                  "pos" : "22.5",
+                  "includingLoc" : "None"
+                },
+                "port" : {
+                  "componentInstance" : {
+                    "aNode" : {
+                      "astNodeId" : 40
+                    },
+                    "qualifiedName" : {
+                      "qualifier" : [
+                        "M"
+                      ],
+                      "base" : "c"
+                    },
+                    "component" : {
+                      "astNodeId" : 32
+                    },
+                    "baseId" : 256,
+                    "maxId" : 255,
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecifierMap" : {
+                      
+                    }
+                  },
+                  "portInstance" : {
+                    "Special" : {
+                      "aNode" : {
+                        "astNodeId" : 27
+                      },
+                      "specifier" : {
+                        "inputKind" : "None",
+                        "kind" : {
+                          "CommandReg" : {
+                            
+                          }
+                        },
+                        "name" : "cmdRegOut",
+                        "priority" : "None",
+                        "queueFull" : "None"
+                      },
+                      "symbol" : {
+                        "Port" : {
+                          "nodeId" : 1,
+                          "unqualifiedName" : "CmdReg"
+                        }
+                      },
+                      "priority" : "None",
+                      "queueFull" : "None",
+                      "importNodeIds" : [
+                      ]
+                    }
+                  }
+                },
+                "portNumber" : "None"
+              },
+              "to" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+                  "pos" : "22.5",
+                  "includingLoc" : "None"
+                },
+                "port" : {
+                  "componentInstance" : {
+                    "aNode" : {
+                      "astNodeId" : 36
+                    },
+                    "qualifiedName" : {
+                      "qualifier" : [
+                        "M"
+                      ],
+                      "base" : "commands"
+                    },
+                    "component" : {
+                      "astNodeId" : 26
+                    },
+                    "baseId" : 256,
+                    "maxId" : 255,
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecifierMap" : {
+                      
+                    }
+                  },
+                  "portInstance" : {
+                    "General" : {
+                      "aNode" : {
+                        "astNodeId" : 9
+                      },
+                      "specifier" : {
+                        "kind" : {
+                          "SyncInput" : {
+                            
+                          }
+                        },
+                        "name" : "cmdRegIn",
+                        "size" : "None",
+                        "port" : {
+                          "Some" : {
+                            "astNodeId" : 8
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None"
+                      },
+                      "kind" : "SyncInput",
+                      "size" : 1,
+                      "ty" : {
+                        "DefPort" : {
+                          "symbol" : {
+                            "Port" : {
+                              "nodeId" : 1,
+                              "unqualifiedName" : "CmdReg"
+                            }
+                          }
+                        }
+                      },
+                      "importNodeIds" : [
+                      ]
+                    }
+                  }
+                },
+                "portNumber" : "None"
+              },
+              "isUnmatched" : false
+            },
+            0
+          ],
+          [
+            {
+              "from" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+                  "pos" : "22.5",
+                  "includingLoc" : "None"
+                },
+                "port" : {
+                  "componentInstance" : {
+                    "aNode" : {
+                      "astNodeId" : 40
+                    },
+                    "qualifiedName" : {
+                      "qualifier" : [
+                        "M"
+                      ],
+                      "base" : "c"
+                    },
+                    "component" : {
+                      "astNodeId" : 32
+                    },
+                    "baseId" : 256,
+                    "maxId" : 255,
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecifierMap" : {
+                      
+                    }
+                  },
+                  "portInstance" : {
+                    "Special" : {
+                      "aNode" : {
+                        "astNodeId" : 31
+                      },
+                      "specifier" : {
+                        "inputKind" : "None",
+                        "kind" : {
+                          "CommandResp" : {
+                            
+                          }
+                        },
+                        "name" : "cmdResponseOut",
+                        "priority" : "None",
+                        "queueFull" : "None"
+                      },
+                      "symbol" : {
+                        "Port" : {
+                          "nodeId" : 4,
+                          "unqualifiedName" : "CmdResponse"
+                        }
+                      },
+                      "priority" : "None",
+                      "queueFull" : "None",
+                      "importNodeIds" : [
+                      ]
+                    }
+                  }
+                },
+                "portNumber" : "None"
+              },
+              "to" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+                  "pos" : "22.5",
+                  "includingLoc" : "None"
+                },
+                "port" : {
+                  "componentInstance" : {
+                    "aNode" : {
+                      "astNodeId" : 36
+                    },
+                    "qualifiedName" : {
+                      "qualifier" : [
+                        "M"
+                      ],
+                      "base" : "commands"
+                    },
+                    "component" : {
+                      "astNodeId" : 26
+                    },
+                    "baseId" : 256,
+                    "maxId" : 255,
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecifierMap" : {
+                      
+                    }
+                  },
+                  "portInstance" : {
+                    "General" : {
+                      "aNode" : {
+                        "astNodeId" : 25
+                      },
+                      "specifier" : {
+                        "kind" : {
+                          "SyncInput" : {
+                            
+                          }
+                        },
+                        "name" : "cmdResponseIn",
+                        "size" : "None",
+                        "port" : {
+                          "Some" : {
+                            "astNodeId" : 24
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None"
+                      },
+                      "kind" : "SyncInput",
+                      "size" : 1,
+                      "ty" : {
+                        "DefPort" : {
+                          "symbol" : {
+                            "Port" : {
+                              "nodeId" : 4,
+                              "unqualifiedName" : "CmdResponse"
+                            }
+                          }
+                        }
+                      },
+                      "importNodeIds" : [
+                      ]
+                    }
+                  }
+                },
+                "portNumber" : "None"
+              },
+              "isUnmatched" : false
+            },
+            0
+          ]
+        ],
+        "toPortNumberMap" : [
+          [
+            {
+              "from" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+                  "pos" : "22.5",
+                  "includingLoc" : "None"
+                },
+                "port" : {
+                  "componentInstance" : {
+                    "aNode" : {
+                      "astNodeId" : 40
+                    },
+                    "qualifiedName" : {
+                      "qualifier" : [
+                        "M"
+                      ],
+                      "base" : "c"
+                    },
+                    "component" : {
+                      "astNodeId" : 32
+                    },
+                    "baseId" : 256,
+                    "maxId" : 255,
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecifierMap" : {
+                      
+                    }
+                  },
+                  "portInstance" : {
+                    "Special" : {
+                      "aNode" : {
+                        "astNodeId" : 27
+                      },
+                      "specifier" : {
+                        "inputKind" : "None",
+                        "kind" : {
+                          "CommandReg" : {
+                            
+                          }
+                        },
+                        "name" : "cmdRegOut",
+                        "priority" : "None",
+                        "queueFull" : "None"
+                      },
+                      "symbol" : {
+                        "Port" : {
+                          "nodeId" : 1,
+                          "unqualifiedName" : "CmdReg"
+                        }
+                      },
+                      "priority" : "None",
+                      "queueFull" : "None",
+                      "importNodeIds" : [
+                      ]
+                    }
+                  }
+                },
+                "portNumber" : "None"
+              },
+              "to" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+                  "pos" : "22.5",
+                  "includingLoc" : "None"
+                },
+                "port" : {
+                  "componentInstance" : {
+                    "aNode" : {
+                      "astNodeId" : 36
+                    },
+                    "qualifiedName" : {
+                      "qualifier" : [
+                        "M"
+                      ],
+                      "base" : "commands"
+                    },
+                    "component" : {
+                      "astNodeId" : 26
+                    },
+                    "baseId" : 256,
+                    "maxId" : 255,
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecifierMap" : {
+                      
+                    }
+                  },
+                  "portInstance" : {
+                    "General" : {
+                      "aNode" : {
+                        "astNodeId" : 9
+                      },
+                      "specifier" : {
+                        "kind" : {
+                          "SyncInput" : {
+                            
+                          }
+                        },
+                        "name" : "cmdRegIn",
+                        "size" : "None",
+                        "port" : {
+                          "Some" : {
+                            "astNodeId" : 8
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None"
+                      },
+                      "kind" : "SyncInput",
+                      "size" : 1,
+                      "ty" : {
+                        "DefPort" : {
+                          "symbol" : {
+                            "Port" : {
+                              "nodeId" : 1,
+                              "unqualifiedName" : "CmdReg"
+                            }
+                          }
+                        }
+                      },
+                      "importNodeIds" : [
+                      ]
+                    }
+                  }
+                },
+                "portNumber" : "None"
+              },
+              "isUnmatched" : false
+            },
+            0
+          ],
+          [
+            {
+              "from" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+                  "pos" : "22.5",
+                  "includingLoc" : "None"
+                },
+                "port" : {
+                  "componentInstance" : {
+                    "aNode" : {
+                      "astNodeId" : 40
+                    },
+                    "qualifiedName" : {
+                      "qualifier" : [
+                        "M"
+                      ],
+                      "base" : "c"
+                    },
+                    "component" : {
+                      "astNodeId" : 32
+                    },
+                    "baseId" : 256,
+                    "maxId" : 255,
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecifierMap" : {
+                      
+                    }
+                  },
+                  "portInstance" : {
+                    "Special" : {
+                      "aNode" : {
+                        "astNodeId" : 31
+                      },
+                      "specifier" : {
+                        "inputKind" : "None",
+                        "kind" : {
+                          "CommandResp" : {
+                            
+                          }
+                        },
+                        "name" : "cmdResponseOut",
+                        "priority" : "None",
+                        "queueFull" : "None"
+                      },
+                      "symbol" : {
+                        "Port" : {
+                          "nodeId" : 4,
+                          "unqualifiedName" : "CmdResponse"
+                        }
+                      },
+                      "priority" : "None",
+                      "queueFull" : "None",
+                      "importNodeIds" : [
+                      ]
+                    }
+                  }
+                },
+                "portNumber" : "None"
+              },
+              "to" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+                  "pos" : "22.5",
+                  "includingLoc" : "None"
+                },
+                "port" : {
+                  "componentInstance" : {
+                    "aNode" : {
+                      "astNodeId" : 36
+                    },
+                    "qualifiedName" : {
+                      "qualifier" : [
+                        "M"
+                      ],
+                      "base" : "commands"
+                    },
+                    "component" : {
+                      "astNodeId" : 26
+                    },
+                    "baseId" : 256,
+                    "maxId" : 255,
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecifierMap" : {
+                      
+                    }
+                  },
+                  "portInstance" : {
+                    "General" : {
+                      "aNode" : {
+                        "astNodeId" : 25
+                      },
+                      "specifier" : {
+                        "kind" : {
+                          "SyncInput" : {
+                            
+                          }
+                        },
+                        "name" : "cmdResponseIn",
+                        "size" : "None",
+                        "port" : {
+                          "Some" : {
+                            "astNodeId" : 24
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None"
+                      },
+                      "kind" : "SyncInput",
+                      "size" : 1,
+                      "ty" : {
+                        "DefPort" : {
+                          "symbol" : {
+                            "Port" : {
+                              "nodeId" : 4,
+                              "unqualifiedName" : "CmdResponse"
+                            }
+                          }
+                        }
+                      },
+                      "importNodeIds" : [
+                      ]
+                    }
+                  }
+                },
+                "portNumber" : "None"
+              },
+              "isUnmatched" : false
+            },
+            0
+          ],
+          [
+            {
+              "from" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+                  "pos" : "22.5",
+                  "includingLoc" : "None"
+                },
+                "port" : {
+                  "componentInstance" : {
+                    "aNode" : {
+                      "astNodeId" : 36
+                    },
+                    "qualifiedName" : {
+                      "qualifier" : [
+                        "M"
+                      ],
+                      "base" : "commands"
+                    },
+                    "component" : {
+                      "astNodeId" : 26
+                    },
+                    "baseId" : 256,
+                    "maxId" : 255,
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecifierMap" : {
+                      
+                    }
+                  },
+                  "portInstance" : {
+                    "General" : {
+                      "aNode" : {
+                        "astNodeId" : 13
+                      },
+                      "specifier" : {
+                        "kind" : {
+                          "Output" : {
+                            
+                          }
+                        },
+                        "name" : "cmdOut",
+                        "size" : "None",
+                        "port" : {
+                          "Some" : {
+                            "astNodeId" : 12
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None"
+                      },
+                      "kind" : "Output",
+                      "size" : 1,
+                      "ty" : {
+                        "DefPort" : {
+                          "symbol" : {
+                            "Port" : {
+                              "nodeId" : 0,
+                              "unqualifiedName" : "Cmd"
+                            }
+                          }
+                        }
+                      },
+                      "importNodeIds" : [
+                      ]
+                    }
+                  }
+                },
+                "portNumber" : "None"
+              },
+              "to" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+                  "pos" : "22.5",
+                  "includingLoc" : "None"
+                },
+                "port" : {
+                  "componentInstance" : {
+                    "aNode" : {
+                      "astNodeId" : 40
+                    },
+                    "qualifiedName" : {
+                      "qualifier" : [
+                        "M"
+                      ],
+                      "base" : "c"
+                    },
+                    "component" : {
+                      "astNodeId" : 32
+                    },
+                    "baseId" : 256,
+                    "maxId" : 255,
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecifierMap" : {
+                      
+                    }
+                  },
+                  "portInstance" : {
+                    "Special" : {
+                      "aNode" : {
+                        "astNodeId" : 28
+                      },
+                      "specifier" : {
+                        "inputKind" : "None",
+                        "kind" : {
+                          "CommandRecv" : {
+                            
+                          }
+                        },
+                        "name" : "cmdIn",
+                        "priority" : "None",
+                        "queueFull" : "None"
+                      },
+                      "symbol" : {
+                        "Port" : {
+                          "nodeId" : 0,
+                          "unqualifiedName" : "Cmd"
+                        }
+                      },
+                      "priority" : "None",
+                      "queueFull" : "None",
+                      "importNodeIds" : [
+                      ]
+                    }
+                  }
+                },
+                "portNumber" : "None"
+              },
+              "isUnmatched" : false
+            },
+            0
+          ]
+        ],
+        "unconnectedPortSet" : [
+        ]
+      }
+    },
+    "typeMap" : {
+      "35" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
+        }
+      },
+      "39" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
+        }
+      }
+    },
+    "useDefMap" : {
+      "34" : {
+        "Component" : {
+          "nodeId" : 26,
+          "unqualifiedName" : "Commands"
+        }
+      },
+      "8" : {
+        "Port" : {
+          "nodeId" : 1,
+          "unqualifiedName" : "CmdReg"
+        }
+      },
+      "104" : {
+        "ComponentInstance" : {
+          "nodeId" : 40,
+          "unqualifiedName" : "c"
+        }
+      },
+      "22" : {
+        "Module" : {
+          "nodeId" : 5,
+          "unqualifiedName" : "Fw"
+        }
+      },
+      "24" : {
+        "Port" : {
+          "nodeId" : 4,
+          "unqualifiedName" : "CmdResponse"
+        }
+      },
+      "10" : {
+        "Module" : {
+          "nodeId" : 5,
+          "unqualifiedName" : "Fw"
+        }
+      },
+      "6" : {
+        "Module" : {
+          "nodeId" : 5,
+          "unqualifiedName" : "Fw"
+        }
+      },
+      "27" : {
+        "Port" : {
+          "nodeId" : 1,
+          "unqualifiedName" : "CmdReg"
+        }
+      },
+      "28" : {
+        "Port" : {
+          "nodeId" : 0,
+          "unqualifiedName" : "Cmd"
+        }
+      },
+      "12" : {
+        "Port" : {
+          "nodeId" : 0,
+          "unqualifiedName" : "Cmd"
+        }
+      },
+      "89" : {
+        "ComponentInstance" : {
+          "nodeId" : 40,
+          "unqualifiedName" : "c"
+        }
+      },
+      "102" : {
+        "ComponentInstance" : {
+          "nodeId" : 36,
+          "unqualifiedName" : "commands"
+        }
+      },
+      "31" : {
+        "Port" : {
+          "nodeId" : 4,
+          "unqualifiedName" : "CmdResponse"
+        }
+      },
+      "86" : {
+        "ComponentInstance" : {
+          "nodeId" : 36,
+          "unqualifiedName" : "commands"
+        }
+      },
+      "38" : {
+        "Component" : {
+          "nodeId" : 32,
+          "unqualifiedName" : "C"
+        }
+      }
+    },
+    "valueMap" : {
+      "35" : {
+        "Integer" : {
+          "value" : 256
+        }
+      },
+      "39" : {
+        "Integer" : {
+          "value" : 256
+        }
+      }
+    },
+    "stateMachineMap" : {
+      
+    },
+    "dictionarySymbolSet" : [
+    ],
+    "interfaceMap" : {
+      
+    }
+  }
+}

--- a/tests/command_patterned_connections/command_patterned_connections_ast.json
+++ b/tests/command_patterned_connections/command_patterned_connections_ast.json
@@ -1,0 +1,633 @@
+{
+  "fppVersion" : "v3.1.0a10-54-g11243e778",
+  "ast" : [
+    {
+      "members" : [
+        [
+          [
+          ],
+          {
+            "DefModule" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "Fw",
+                    "members" : [
+                      [
+                        [
+                        ],
+                        {
+                          "DefPort" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "name" : "Cmd",
+                                  "params" : [
+                                  ],
+                                  "returnType" : "None"
+                                },
+                                "id" : 0
+                              }
+                            }
+                          }
+                        },
+                        [
+                        ]
+                      ],
+                      [
+                        [
+                        ],
+                        {
+                          "DefPort" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "name" : "CmdReg",
+                                  "params" : [
+                                  ],
+                                  "returnType" : "None"
+                                },
+                                "id" : 1
+                              }
+                            }
+                          }
+                        },
+                        [
+                        ]
+                      ],
+                      [
+                        [
+                        ],
+                        {
+                          "DefPort" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "name" : "CmdResponse",
+                                  "params" : [
+                                  ],
+                                  "returnType" : "None"
+                                },
+                                "id" : 4
+                              }
+                            }
+                          }
+                        },
+                        [
+                        ]
+                      ]
+                    ]
+                  },
+                  "id" : 5
+                }
+              }
+            }
+          },
+          [
+          ]
+        ],
+        [
+          [
+          ],
+          {
+            "DefModule" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "M",
+                    "members" : [
+                      [
+                        [
+                        ],
+                        {
+                          "DefComponent" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "kind" : {
+                                    "Passive" : {
+                                      
+                                    }
+                                  },
+                                  "name" : "Commands",
+                                  "members" : [
+                                    [
+                                      [
+                                      ],
+                                      {
+                                        "SpecPortInstance" : {
+                                          "node" : {
+                                            "AstNode" : {
+                                              "data" : {
+                                                "General" : {
+                                                  "kind" : {
+                                                    "SyncInput" : {
+                                                      
+                                                    }
+                                                  },
+                                                  "name" : "cmdRegIn",
+                                                  "size" : "None",
+                                                  "port" : {
+                                                    "Some" : {
+                                                      "AstNode" : {
+                                                        "data" : {
+                                                          "Qualified" : {
+                                                            "qualifier" : {
+                                                              "AstNode" : {
+                                                                "data" : {
+                                                                  "Unqualified" : {
+                                                                    "name" : "Fw"
+                                                                  }
+                                                                },
+                                                                "id" : 6
+                                                              }
+                                                            },
+                                                            "name" : {
+                                                              "AstNode" : {
+                                                                "data" : "CmdReg",
+                                                                "id" : 7
+                                                              }
+                                                            }
+                                                          }
+                                                        },
+                                                        "id" : 8
+                                                      }
+                                                    }
+                                                  },
+                                                  "priority" : "None",
+                                                  "queueFull" : "None"
+                                                }
+                                              },
+                                              "id" : 9
+                                            }
+                                          }
+                                        }
+                                      },
+                                      [
+                                      ]
+                                    ],
+                                    [
+                                      [
+                                      ],
+                                      {
+                                        "SpecPortInstance" : {
+                                          "node" : {
+                                            "AstNode" : {
+                                              "data" : {
+                                                "General" : {
+                                                  "kind" : {
+                                                    "Output" : {
+                                                      
+                                                    }
+                                                  },
+                                                  "name" : "cmdOut",
+                                                  "size" : "None",
+                                                  "port" : {
+                                                    "Some" : {
+                                                      "AstNode" : {
+                                                        "data" : {
+                                                          "Qualified" : {
+                                                            "qualifier" : {
+                                                              "AstNode" : {
+                                                                "data" : {
+                                                                  "Unqualified" : {
+                                                                    "name" : "Fw"
+                                                                  }
+                                                                },
+                                                                "id" : 10
+                                                              }
+                                                            },
+                                                            "name" : {
+                                                              "AstNode" : {
+                                                                "data" : "Cmd",
+                                                                "id" : 11
+                                                              }
+                                                            }
+                                                          }
+                                                        },
+                                                        "id" : 12
+                                                      }
+                                                    }
+                                                  },
+                                                  "priority" : "None",
+                                                  "queueFull" : "None"
+                                                }
+                                              },
+                                              "id" : 13
+                                            }
+                                          }
+                                        }
+                                      },
+                                      [
+                                      ]
+                                    ],
+                                    [
+                                      [
+                                      ],
+                                      {
+                                        "SpecPortInstance" : {
+                                          "node" : {
+                                            "AstNode" : {
+                                              "data" : {
+                                                "General" : {
+                                                  "kind" : {
+                                                    "SyncInput" : {
+                                                      
+                                                    }
+                                                  },
+                                                  "name" : "cmdResponseIn",
+                                                  "size" : "None",
+                                                  "port" : {
+                                                    "Some" : {
+                                                      "AstNode" : {
+                                                        "data" : {
+                                                          "Qualified" : {
+                                                            "qualifier" : {
+                                                              "AstNode" : {
+                                                                "data" : {
+                                                                  "Unqualified" : {
+                                                                    "name" : "Fw"
+                                                                  }
+                                                                },
+                                                                "id" : 22
+                                                              }
+                                                            },
+                                                            "name" : {
+                                                              "AstNode" : {
+                                                                "data" : "CmdResponse",
+                                                                "id" : 23
+                                                              }
+                                                            }
+                                                          }
+                                                        },
+                                                        "id" : 24
+                                                      }
+                                                    }
+                                                  },
+                                                  "priority" : "None",
+                                                  "queueFull" : "None"
+                                                }
+                                              },
+                                              "id" : 25
+                                            }
+                                          }
+                                        }
+                                      },
+                                      [
+                                      ]
+                                    ]
+                                  ]
+                                },
+                                "id" : 26
+                              }
+                            }
+                          }
+                        },
+                        [
+                        ]
+                      ],
+                      [
+                        [
+                        ],
+                        {
+                          "DefComponent" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "kind" : {
+                                    "Passive" : {
+                                      
+                                    }
+                                  },
+                                  "name" : "C",
+                                  "members" : [
+                                    [
+                                      [
+                                      ],
+                                      {
+                                        "SpecPortInstance" : {
+                                          "node" : {
+                                            "AstNode" : {
+                                              "data" : {
+                                                "Special" : {
+                                                  "inputKind" : "None",
+                                                  "kind" : {
+                                                    "CommandReg" : {
+                                                      
+                                                    }
+                                                  },
+                                                  "name" : "cmdRegOut",
+                                                  "priority" : "None",
+                                                  "queueFull" : "None"
+                                                }
+                                              },
+                                              "id" : 27
+                                            }
+                                          }
+                                        }
+                                      },
+                                      [
+                                      ]
+                                    ],
+                                    [
+                                      [
+                                      ],
+                                      {
+                                        "SpecPortInstance" : {
+                                          "node" : {
+                                            "AstNode" : {
+                                              "data" : {
+                                                "Special" : {
+                                                  "inputKind" : "None",
+                                                  "kind" : {
+                                                    "CommandRecv" : {
+                                                      
+                                                    }
+                                                  },
+                                                  "name" : "cmdIn",
+                                                  "priority" : "None",
+                                                  "queueFull" : "None"
+                                                }
+                                              },
+                                              "id" : 28
+                                            }
+                                          }
+                                        }
+                                      },
+                                      [
+                                      ]
+                                    ],
+                                    [
+                                      [
+                                      ],
+                                      {
+                                        "SpecPortInstance" : {
+                                          "node" : {
+                                            "AstNode" : {
+                                              "data" : {
+                                                "Special" : {
+                                                  "inputKind" : "None",
+                                                  "kind" : {
+                                                    "CommandResp" : {
+                                                      
+                                                    }
+                                                  },
+                                                  "name" : "cmdResponseOut",
+                                                  "priority" : "None",
+                                                  "queueFull" : "None"
+                                                }
+                                              },
+                                              "id" : 31
+                                            }
+                                          }
+                                        }
+                                      },
+                                      [
+                                      ]
+                                    ]
+                                  ]
+                                },
+                                "id" : 32
+                              }
+                            }
+                          }
+                        },
+                        [
+                        ]
+                      ],
+                      [
+                        [
+                        ],
+                        {
+                          "DefComponentInstance" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "name" : "commands",
+                                  "component" : {
+                                    "AstNode" : {
+                                      "data" : {
+                                        "Unqualified" : {
+                                          "name" : "Commands"
+                                        }
+                                      },
+                                      "id" : 34
+                                    }
+                                  },
+                                  "baseId" : {
+                                    "AstNode" : {
+                                      "data" : {
+                                        "ExprLiteralInt" : {
+                                          "value" : "0x100"
+                                        }
+                                      },
+                                      "id" : 35
+                                    }
+                                  },
+                                  "implType" : "None",
+                                  "file" : "None",
+                                  "queueSize" : "None",
+                                  "stackSize" : "None",
+                                  "priority" : "None",
+                                  "cpu" : "None",
+                                  "initSpecs" : [
+                                  ]
+                                },
+                                "id" : 36
+                              }
+                            }
+                          }
+                        },
+                        [
+                        ]
+                      ],
+                      [
+                        [
+                        ],
+                        {
+                          "DefComponentInstance" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "name" : "c",
+                                  "component" : {
+                                    "AstNode" : {
+                                      "data" : {
+                                        "Unqualified" : {
+                                          "name" : "C"
+                                        }
+                                      },
+                                      "id" : 38
+                                    }
+                                  },
+                                  "baseId" : {
+                                    "AstNode" : {
+                                      "data" : {
+                                        "ExprLiteralInt" : {
+                                          "value" : "0x100"
+                                        }
+                                      },
+                                      "id" : 39
+                                    }
+                                  },
+                                  "implType" : "None",
+                                  "file" : "None",
+                                  "queueSize" : "None",
+                                  "stackSize" : "None",
+                                  "priority" : "None",
+                                  "cpu" : "None",
+                                  "initSpecs" : [
+                                  ]
+                                },
+                                "id" : 40
+                              }
+                            }
+                          }
+                        },
+                        [
+                        ]
+                      ],
+                      [
+                        [
+                        ],
+                        {
+                          "DefTopology" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "name" : "T",
+                                  "members" : [
+                                    [
+                                      [
+                                      ],
+                                      {
+                                        "SpecCompInstance" : {
+                                          "node" : {
+                                            "AstNode" : {
+                                              "data" : {
+                                                "visibility" : {
+                                                  "Public" : {
+                                                    
+                                                  }
+                                                },
+                                                "instance" : {
+                                                  "AstNode" : {
+                                                    "data" : {
+                                                      "Unqualified" : {
+                                                        "name" : "commands"
+                                                      }
+                                                    },
+                                                    "id" : 86
+                                                  }
+                                                }
+                                              },
+                                              "id" : 87
+                                            }
+                                          }
+                                        }
+                                      },
+                                      [
+                                      ]
+                                    ],
+                                    [
+                                      [
+                                      ],
+                                      {
+                                        "SpecCompInstance" : {
+                                          "node" : {
+                                            "AstNode" : {
+                                              "data" : {
+                                                "visibility" : {
+                                                  "Public" : {
+                                                    
+                                                  }
+                                                },
+                                                "instance" : {
+                                                  "AstNode" : {
+                                                    "data" : {
+                                                      "Unqualified" : {
+                                                        "name" : "c"
+                                                      }
+                                                    },
+                                                    "id" : 89
+                                                  }
+                                                }
+                                              },
+                                              "id" : 90
+                                            }
+                                          }
+                                        }
+                                      },
+                                      [
+                                      ]
+                                    ],
+                                    [
+                                      [
+                                      ],
+                                      {
+                                        "SpecConnectionGraph" : {
+                                          "node" : {
+                                            "AstNode" : {
+                                              "data" : {
+                                                "Pattern" : {
+                                                  "kind" : {
+                                                    "Command" : {
+                                                      
+                                                    }
+                                                  },
+                                                  "source" : {
+                                                    "AstNode" : {
+                                                      "data" : {
+                                                        "Unqualified" : {
+                                                          "name" : "commands"
+                                                        }
+                                                      },
+                                                      "id" : 102
+                                                    }
+                                                  },
+                                                  "targets" : [
+                                                    {
+                                                      "AstNode" : {
+                                                        "data" : {
+                                                          "Unqualified" : {
+                                                            "name" : "c"
+                                                          }
+                                                        },
+                                                        "id" : 104
+                                                      }
+                                                    }
+                                                  ]
+                                                }
+                                              },
+                                              "id" : 105
+                                            }
+                                          }
+                                        }
+                                      },
+                                      [
+                                      ]
+                                    ]
+                                  ]
+                                },
+                                "id" : 106
+                              }
+                            }
+                          }
+                        },
+                        [
+                        ]
+                      ]
+                    ]
+                  },
+                  "id" : 107
+                }
+              }
+            }
+          },
+          [
+          ]
+        ]
+      ]
+    }
+  ]
+}

--- a/tests/command_patterned_connections/command_patterned_connections_locations.json
+++ b/tests/command_patterned_connections/command_patterned_connections_locations.json
@@ -1,0 +1,545 @@
+{
+  "fppVersion" : "v3.1.0a10-54-g11243e778",
+  "locationMap" : {
+    "0" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "2.3",
+      "includingLoc" : "None"
+    },
+    "1" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "3.3",
+      "includingLoc" : "None"
+    },
+    "2" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "4.3",
+      "includingLoc" : "None"
+    },
+    "3" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "4.3",
+      "includingLoc" : "None"
+    },
+    "4" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "4.3",
+      "includingLoc" : "None"
+    },
+    "5" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "1.1",
+      "includingLoc" : "None"
+    },
+    "6" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "8.31",
+      "includingLoc" : "None"
+    },
+    "7" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "8.34",
+      "includingLoc" : "None"
+    },
+    "8" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "8.31",
+      "includingLoc" : "None"
+    },
+    "9" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "8.5",
+      "includingLoc" : "None"
+    },
+    "10" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "9.25",
+      "includingLoc" : "None"
+    },
+    "11" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "9.28",
+      "includingLoc" : "None"
+    },
+    "12" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "9.25",
+      "includingLoc" : "None"
+    },
+    "13" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "9.5",
+      "includingLoc" : "None"
+    },
+    "14" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "10.36",
+      "includingLoc" : "None"
+    },
+    "15" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "10.39",
+      "includingLoc" : "None"
+    },
+    "16" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "10.36",
+      "includingLoc" : "None"
+    },
+    "17" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "10.5",
+      "includingLoc" : "None"
+    },
+    "18" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "10.36",
+      "includingLoc" : "None"
+    },
+    "19" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "10.39",
+      "includingLoc" : "None"
+    },
+    "20" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "10.36",
+      "includingLoc" : "None"
+    },
+    "21" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "10.5",
+      "includingLoc" : "None"
+    },
+    "22" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "10.36",
+      "includingLoc" : "None"
+    },
+    "23" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "10.39",
+      "includingLoc" : "None"
+    },
+    "24" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "10.36",
+      "includingLoc" : "None"
+    },
+    "25" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "10.5",
+      "includingLoc" : "None"
+    },
+    "26" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "7.3",
+      "includingLoc" : "None"
+    },
+    "27" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "13.5",
+      "includingLoc" : "None"
+    },
+    "28" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "14.5",
+      "includingLoc" : "None"
+    },
+    "29" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "15.5",
+      "includingLoc" : "None"
+    },
+    "30" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "15.5",
+      "includingLoc" : "None"
+    },
+    "31" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "15.5",
+      "includingLoc" : "None"
+    },
+    "32" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "12.3",
+      "includingLoc" : "None"
+    },
+    "33" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "17.22",
+      "includingLoc" : "None"
+    },
+    "34" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "17.22",
+      "includingLoc" : "None"
+    },
+    "35" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "17.39",
+      "includingLoc" : "None"
+    },
+    "36" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "17.3",
+      "includingLoc" : "None"
+    },
+    "37" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "18.15",
+      "includingLoc" : "None"
+    },
+    "38" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "18.15",
+      "includingLoc" : "None"
+    },
+    "39" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "18.25",
+      "includingLoc" : "None"
+    },
+    "40" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "18.3",
+      "includingLoc" : "None"
+    },
+    "41" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "20.14",
+      "includingLoc" : "None"
+    },
+    "42" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "20.14",
+      "includingLoc" : "None"
+    },
+    "43" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "20.5",
+      "includingLoc" : "None"
+    },
+    "44" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "21.14",
+      "includingLoc" : "None"
+    },
+    "45" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "21.14",
+      "includingLoc" : "None"
+    },
+    "46" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "21.5",
+      "includingLoc" : "None"
+    },
+    "47" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "22.34",
+      "includingLoc" : "None"
+    },
+    "48" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "22.34",
+      "includingLoc" : "None"
+    },
+    "49" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "22.45",
+      "includingLoc" : "None"
+    },
+    "50" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "22.45",
+      "includingLoc" : "None"
+    },
+    "51" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "22.5",
+      "includingLoc" : "None"
+    },
+    "52" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "22.34",
+      "includingLoc" : "None"
+    },
+    "53" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "22.34",
+      "includingLoc" : "None"
+    },
+    "54" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "22.45",
+      "includingLoc" : "None"
+    },
+    "55" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "22.45",
+      "includingLoc" : "None"
+    },
+    "56" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "22.5",
+      "includingLoc" : "None"
+    },
+    "57" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "22.34",
+      "includingLoc" : "None"
+    },
+    "58" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "22.34",
+      "includingLoc" : "None"
+    },
+    "59" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "22.45",
+      "includingLoc" : "None"
+    },
+    "60" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "22.45",
+      "includingLoc" : "None"
+    },
+    "61" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "22.5",
+      "includingLoc" : "None"
+    },
+    "62" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "19.3",
+      "includingLoc" : "None"
+    },
+    "63" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "20.14",
+      "includingLoc" : "None"
+    },
+    "64" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "20.14",
+      "includingLoc" : "None"
+    },
+    "65" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "20.5",
+      "includingLoc" : "None"
+    },
+    "66" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "21.14",
+      "includingLoc" : "None"
+    },
+    "67" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "21.14",
+      "includingLoc" : "None"
+    },
+    "68" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "21.5",
+      "includingLoc" : "None"
+    },
+    "69" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "22.34",
+      "includingLoc" : "None"
+    },
+    "70" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "22.34",
+      "includingLoc" : "None"
+    },
+    "71" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "22.45",
+      "includingLoc" : "None"
+    },
+    "72" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "22.45",
+      "includingLoc" : "None"
+    },
+    "73" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "22.5",
+      "includingLoc" : "None"
+    },
+    "74" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "22.34",
+      "includingLoc" : "None"
+    },
+    "75" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "22.34",
+      "includingLoc" : "None"
+    },
+    "76" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "22.45",
+      "includingLoc" : "None"
+    },
+    "77" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "22.45",
+      "includingLoc" : "None"
+    },
+    "78" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "22.5",
+      "includingLoc" : "None"
+    },
+    "79" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "22.34",
+      "includingLoc" : "None"
+    },
+    "80" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "22.34",
+      "includingLoc" : "None"
+    },
+    "81" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "22.45",
+      "includingLoc" : "None"
+    },
+    "82" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "22.45",
+      "includingLoc" : "None"
+    },
+    "83" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "22.5",
+      "includingLoc" : "None"
+    },
+    "84" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "19.3",
+      "includingLoc" : "None"
+    },
+    "85" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "20.14",
+      "includingLoc" : "None"
+    },
+    "86" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "20.14",
+      "includingLoc" : "None"
+    },
+    "87" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "20.5",
+      "includingLoc" : "None"
+    },
+    "88" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "21.14",
+      "includingLoc" : "None"
+    },
+    "89" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "21.14",
+      "includingLoc" : "None"
+    },
+    "90" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "21.5",
+      "includingLoc" : "None"
+    },
+    "91" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "22.34",
+      "includingLoc" : "None"
+    },
+    "92" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "22.34",
+      "includingLoc" : "None"
+    },
+    "93" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "22.45",
+      "includingLoc" : "None"
+    },
+    "94" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "22.45",
+      "includingLoc" : "None"
+    },
+    "95" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "22.5",
+      "includingLoc" : "None"
+    },
+    "96" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "22.34",
+      "includingLoc" : "None"
+    },
+    "97" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "22.34",
+      "includingLoc" : "None"
+    },
+    "98" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "22.45",
+      "includingLoc" : "None"
+    },
+    "99" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "22.45",
+      "includingLoc" : "None"
+    },
+    "100" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "22.5",
+      "includingLoc" : "None"
+    },
+    "101" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "22.34",
+      "includingLoc" : "None"
+    },
+    "102" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "22.34",
+      "includingLoc" : "None"
+    },
+    "103" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "22.45",
+      "includingLoc" : "None"
+    },
+    "104" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "22.45",
+      "includingLoc" : "None"
+    },
+    "105" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "22.5",
+      "includingLoc" : "None"
+    },
+    "106" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "19.3",
+      "includingLoc" : "None"
+    },
+    "107" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+      "pos" : "6.1",
+      "includingLoc" : "None"
+    }
+  }
+}

--- a/tests/commands/commands_analysis.json
+++ b/tests/commands/commands_analysis.json
@@ -1,279 +1,325 @@
 {
-  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
-  "analysis": {
-    "componentInstanceMap": {},
-    "componentMap": {
-      "45": {
-        "aNode": {
-          "astNodeId": 45
+  "fppVersion" : "v3.1.0a10-54-g11243e778",
+  "analysis" : {
+    "componentInstanceMap" : {
+      
+    },
+    "componentMap" : {
+      "45" : {
+        "aNode" : {
+          "astNodeId" : 45
         },
-        "portMap": {
-          "cmdRegOut": {
-            "Special": {
-              "aNode": {
-                "astNodeId": 0
+        "portMap" : {
+          "cmdRegOut" : {
+            "Special" : {
+              "aNode" : {
+                "astNodeId" : 0
               },
-              "specifier": {
-                "inputKind": "None",
-                "kind": {
-                  "CommandReg": {}
+              "specifier" : {
+                "inputKind" : "None",
+                "kind" : {
+                  "CommandReg" : {
+                    
+                  }
                 },
-                "name": "cmdRegOut",
-                "priority": "None",
-                "queueFull": "None"
+                "name" : "cmdRegOut",
+                "priority" : "None",
+                "queueFull" : "None"
               },
-              "symbol": {
-                "Port": {
-                  "nodeId": 47,
-                  "unqualifiedName": "CmdReg"
+              "symbol" : {
+                "Port" : {
+                  "nodeId" : 47,
+                  "unqualifiedName" : "CmdReg"
                 }
               },
-              "priority": "None",
-              "queueFull": "None",
-              "importNodeIds": []
+              "priority" : "None",
+              "queueFull" : "None",
+              "importNodeIds" : [
+              ]
             }
           },
-          "cmdIn": {
-            "Special": {
-              "aNode": {
-                "astNodeId": 1
+          "cmdIn" : {
+            "Special" : {
+              "aNode" : {
+                "astNodeId" : 1
               },
-              "specifier": {
-                "inputKind": "None",
-                "kind": {
-                  "CommandRecv": {}
+              "specifier" : {
+                "inputKind" : "None",
+                "kind" : {
+                  "CommandRecv" : {
+                    
+                  }
                 },
-                "name": "cmdIn",
-                "priority": "None",
-                "queueFull": "None"
+                "name" : "cmdIn",
+                "priority" : "None",
+                "queueFull" : "None"
               },
-              "symbol": {
-                "Port": {
-                  "nodeId": 46,
-                  "unqualifiedName": "Cmd"
+              "symbol" : {
+                "Port" : {
+                  "nodeId" : 46,
+                  "unqualifiedName" : "Cmd"
                 }
               },
-              "priority": "None",
-              "queueFull": "None",
-              "importNodeIds": []
+              "priority" : "None",
+              "queueFull" : "None",
+              "importNodeIds" : [
+              ]
             }
           },
-          "cmdResponseOut": {
-            "Special": {
-              "aNode": {
-                "astNodeId": 2
+          "cmdResponseOut" : {
+            "Special" : {
+              "aNode" : {
+                "astNodeId" : 2
               },
-              "specifier": {
-                "inputKind": "None",
-                "kind": {
-                  "CommandResp": {}
+              "specifier" : {
+                "inputKind" : "None",
+                "kind" : {
+                  "CommandResp" : {
+                    
+                  }
                 },
-                "name": "cmdResponseOut",
-                "priority": "None",
-                "queueFull": "None"
+                "name" : "cmdResponseOut",
+                "priority" : "None",
+                "queueFull" : "None"
               },
-              "symbol": {
-                "Port": {
-                  "nodeId": 50,
-                  "unqualifiedName": "CmdResponse"
+              "symbol" : {
+                "Port" : {
+                  "nodeId" : 50,
+                  "unqualifiedName" : "CmdResponse"
                 }
               },
-              "priority": "None",
-              "queueFull": "None",
-              "importNodeIds": []
+              "priority" : "None",
+              "queueFull" : "None",
+              "importNodeIds" : [
+              ]
             }
           }
         },
-        "specialPortMap": {
-          "command reg": {
-            "aNode": {
-              "astNodeId": 0
+        "specialPortMap" : {
+          "command reg" : {
+            "aNode" : {
+              "astNodeId" : 0
             },
-            "specifier": {
-              "inputKind": "None",
-              "kind": {
-                "CommandReg": {}
+            "specifier" : {
+              "inputKind" : "None",
+              "kind" : {
+                "CommandReg" : {
+                  
+                }
               },
-              "name": "cmdRegOut",
-              "priority": "None",
-              "queueFull": "None"
+              "name" : "cmdRegOut",
+              "priority" : "None",
+              "queueFull" : "None"
             },
-            "symbol": {
-              "Port": {
-                "nodeId": 47,
-                "unqualifiedName": "CmdReg"
+            "symbol" : {
+              "Port" : {
+                "nodeId" : 47,
+                "unqualifiedName" : "CmdReg"
               }
             },
-            "priority": "None",
-            "queueFull": "None",
-            "importNodeIds": []
+            "priority" : "None",
+            "queueFull" : "None",
+            "importNodeIds" : [
+            ]
           },
-          "command recv": {
-            "aNode": {
-              "astNodeId": 1
+          "command recv" : {
+            "aNode" : {
+              "astNodeId" : 1
             },
-            "specifier": {
-              "inputKind": "None",
-              "kind": {
-                "CommandRecv": {}
+            "specifier" : {
+              "inputKind" : "None",
+              "kind" : {
+                "CommandRecv" : {
+                  
+                }
               },
-              "name": "cmdIn",
-              "priority": "None",
-              "queueFull": "None"
+              "name" : "cmdIn",
+              "priority" : "None",
+              "queueFull" : "None"
             },
-            "symbol": {
-              "Port": {
-                "nodeId": 46,
-                "unqualifiedName": "Cmd"
+            "symbol" : {
+              "Port" : {
+                "nodeId" : 46,
+                "unqualifiedName" : "Cmd"
               }
             },
-            "priority": "None",
-            "queueFull": "None",
-            "importNodeIds": []
+            "priority" : "None",
+            "queueFull" : "None",
+            "importNodeIds" : [
+            ]
           },
-          "command resp": {
-            "aNode": {
-              "astNodeId": 2
+          "command resp" : {
+            "aNode" : {
+              "astNodeId" : 2
             },
-            "specifier": {
-              "inputKind": "None",
-              "kind": {
-                "CommandResp": {}
+            "specifier" : {
+              "inputKind" : "None",
+              "kind" : {
+                "CommandResp" : {
+                  
+                }
               },
-              "name": "cmdResponseOut",
-              "priority": "None",
-              "queueFull": "None"
+              "name" : "cmdResponseOut",
+              "priority" : "None",
+              "queueFull" : "None"
             },
-            "symbol": {
-              "Port": {
-                "nodeId": 50,
-                "unqualifiedName": "CmdResponse"
+            "symbol" : {
+              "Port" : {
+                "nodeId" : 50,
+                "unqualifiedName" : "CmdResponse"
               }
             },
-            "priority": "None",
-            "queueFull": "None",
-            "importNodeIds": []
+            "priority" : "None",
+            "queueFull" : "None",
+            "importNodeIds" : [
+            ]
           }
         },
-        "commandMap": {
-          "0": {
-            "NonParam": {
-              "aNode": {
-                "astNodeId": 4
+        "commandMap" : {
+          "0" : {
+            "NonParam" : {
+              "aNode" : {
+                "astNodeId" : 4
               },
-              "kind": {
-                "Async": {
-                  "priority": {
-                    "Some": 10
+              "kind" : {
+                "Async" : {
+                  "priority" : {
+                    "Some" : 10
                   },
-                  "queueFull": {
-                    "Assert": {}
+                  "queueFull" : {
+                    "Assert" : {
+                      
+                    }
                   }
                 }
               }
             }
           },
-          "1": {
-            "NonParam": {
-              "aNode": {
-                "astNodeId": 14
+          "1" : {
+            "NonParam" : {
+              "aNode" : {
+                "astNodeId" : 14
               },
-              "kind": {
-                "Async": {
-                  "priority": {
-                    "Some": 20
+              "kind" : {
+                "Async" : {
+                  "priority" : {
+                    "Some" : 20
                   },
-                  "queueFull": {
-                    "Assert": {}
+                  "queueFull" : {
+                    "Assert" : {
+                      
+                    }
                   }
                 }
               }
             }
           },
-          "16": {
-            "NonParam": {
-              "aNode": {
-                "astNodeId": 44
+          "16" : {
+            "NonParam" : {
+              "aNode" : {
+                "astNodeId" : 44
               },
-              "kind": {
-                "Async": {
-                  "priority": {
-                    "Some": 30
+              "kind" : {
+                "Async" : {
+                  "priority" : {
+                    "Some" : 30
                   },
-                  "queueFull": {
-                    "Drop": {}
+                  "queueFull" : {
+                    "Drop" : {
+                      
+                    }
                   }
                 }
               }
             }
           }
         },
-        "defaultOpcode": 17,
-        "tlmChannelMap": {},
-        "tlmChannelNameMap": {},
-        "defaultTlmChannelId": 0,
-        "eventMap": {},
-        "defaultEventId": 0,
-        "paramMap": {},
-        "specPortMatchingList": [],
-        "stateMachineInstanceMap": {},
-        "portMatchingList": [],
-        "defaultParamId": 0,
-        "containerMap": {},
-        "defaultContainerId": 0,
-        "recordMap": {},
-        "defaultRecordId": 0
+        "defaultOpcode" : 17,
+        "tlmChannelMap" : {
+          
+        },
+        "tlmChannelNameMap" : {
+          
+        },
+        "defaultTlmChannelId" : 0,
+        "eventMap" : {
+          
+        },
+        "defaultEventId" : 0,
+        "paramMap" : {
+          
+        },
+        "specPortMatchingList" : [
+        ],
+        "stateMachineInstanceMap" : {
+          
+        },
+        "portMatchingList" : [
+        ],
+        "defaultParamId" : 0,
+        "containerMap" : {
+          
+        },
+        "defaultContainerId" : 0,
+        "recordMap" : {
+          
+        },
+        "defaultRecordId" : 0
       }
     },
-    "includedFileSet": [],
-    "inputFileSet": [
+    "includedFileSet" : [
+    ],
+    "inputFileSet" : [
       "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp"
     ],
-    "locationSpecifierMap": [],
-    "parentSymbolMap": {
-      "46": {
-        "Module": {
-          "nodeId": 51,
-          "unqualifiedName": "Fw"
+    "locationSpecifierMap" : [
+    ],
+    "parentSymbolMap" : {
+      "46" : {
+        "Module" : {
+          "nodeId" : 51,
+          "unqualifiedName" : "Fw"
         }
       },
-      "47": {
-        "Module": {
-          "nodeId": 51,
-          "unqualifiedName": "Fw"
+      "47" : {
+        "Module" : {
+          "nodeId" : 51,
+          "unqualifiedName" : "Fw"
         }
       },
-      "50": {
-        "Module": {
-          "nodeId": 51,
-          "unqualifiedName": "Fw"
+      "50" : {
+        "Module" : {
+          "nodeId" : 51,
+          "unqualifiedName" : "Fw"
         }
       }
     },
-    "symbolScopeMap": {
-      "45": {
-        "map": {}
+    "symbolScopeMap" : {
+      "45" : {
+        "map" : {
+          
+        }
       },
-      "51": {
-        "map": {
-          "Port": {
-            "map": {
-              "Cmd": {
-                "Port": {
-                  "nodeId": 46,
-                  "unqualifiedName": "Cmd"
+      "51" : {
+        "map" : {
+          "Port" : {
+            "map" : {
+              "Cmd" : {
+                "Port" : {
+                  "nodeId" : 46,
+                  "unqualifiedName" : "Cmd"
                 }
               },
-              "CmdReg": {
-                "Port": {
-                  "nodeId": 47,
-                  "unqualifiedName": "CmdReg"
+              "CmdReg" : {
+                "Port" : {
+                  "nodeId" : 47,
+                  "unqualifiedName" : "CmdReg"
                 }
               },
-              "CmdResponse": {
-                "Port": {
-                  "nodeId": 50,
-                  "unqualifiedName": "CmdResponse"
+              "CmdResponse" : {
+                "Port" : {
+                  "nodeId" : 50,
+                  "unqualifiedName" : "CmdResponse"
                 }
               }
             }
@@ -281,96 +327,115 @@
         }
       }
     },
-    "topologyMap": {},
-    "typeMap": {
-      "11": {
-        "Primitive": {
-          "Float": {
-            "kind": {
-              "F32": {}
+    "topologyMap" : {
+      
+    },
+    "typeMap" : {
+      "11" : {
+        "Primitive" : {
+          "Float" : {
+            "kind" : {
+              "F32" : {
+                
+              }
             }
           }
         }
       },
-      "13": {
-        "Int": {
-          "Integer": {}
+      "13" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "5": {
-        "Int": {
-          "PrimitiveInt": {
-            "kind": {
-              "U32": {}
+      "5" : {
+        "Int" : {
+          "PrimitiveInt" : {
+            "kind" : {
+              "U32" : {
+                
+              }
             }
           }
         }
       },
-      "39": {
-        "String": {
-          "size": "None"
+      "39" : {
+        "String" : {
+          "size" : "None"
         }
       },
-      "42": {
-        "Int": {
-          "Integer": {}
+      "42" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "41": {
-        "Int": {
-          "Integer": {}
+      "41" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "3": {
-        "Int": {
-          "Integer": {}
+      "3" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       }
     },
-    "useDefMap": {
-      "0": {
-        "Port": {
-          "nodeId": 47,
-          "unqualifiedName": "CmdReg"
+    "useDefMap" : {
+      "0" : {
+        "Port" : {
+          "nodeId" : 47,
+          "unqualifiedName" : "CmdReg"
         }
       },
-      "1": {
-        "Port": {
-          "nodeId": 46,
-          "unqualifiedName": "Cmd"
+      "1" : {
+        "Port" : {
+          "nodeId" : 46,
+          "unqualifiedName" : "Cmd"
         }
       },
-      "2": {
-        "Port": {
-          "nodeId": 50,
-          "unqualifiedName": "CmdResponse"
+      "2" : {
+        "Port" : {
+          "nodeId" : 50,
+          "unqualifiedName" : "CmdResponse"
         }
       }
     },
-    "valueMap": {
-      "3": {
-        "Integer": {
-          "value": 10
+    "valueMap" : {
+      "3" : {
+        "Integer" : {
+          "value" : 10
         }
       },
-      "13": {
-        "Integer": {
-          "value": 20
+      "13" : {
+        "Integer" : {
+          "value" : 20
         }
       },
-      "41": {
-        "Integer": {
-          "value": 16
+      "41" : {
+        "Integer" : {
+          "value" : 16
         }
       },
-      "42": {
-        "Integer": {
-          "value": 30
+      "42" : {
+        "Integer" : {
+          "value" : 30
         }
       }
     },
-    "stateMachineMap": {},
-    "dictionarySymbolSet": [],
-    "interfaceMap": {}
+    "stateMachineMap" : {
+      
+    },
+    "dictionarySymbolSet" : [
+    ],
+    "interfaceMap" : {
+      
+    }
   }
 }

--- a/tests/commands/commands_analysis.json
+++ b/tests/commands/commands_analysis.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion": "[ fpp version ]",
+  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
   "analysis": {
     "componentInstanceMap": {},
     "componentMap": {

--- a/tests/commands/commands_ast.json
+++ b/tests/commands/commands_ast.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion": "[ fpp version ]",
+  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
   "ast": [
     {
       "members": [

--- a/tests/commands/commands_ast.json
+++ b/tests/commands/commands_ast.json
@@ -1,380 +1,441 @@
 {
-  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
-  "ast": [
+  "fppVersion" : "v3.1.0a10-54-g11243e778",
+  "ast" : [
     {
-      "members": [
+      "members" : [
         [
           [
             "A component for illustrating priority and queue full behavior for async",
             "commands"
           ],
           {
-            "DefComponent": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "kind": {
-                      "Active": {}
+            "DefComponent" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "kind" : {
+                      "Active" : {
+                        
+                      }
                     },
-                    "name": "PriorityQueueFull",
-                    "members": [
+                    "name" : "PriorityQueueFull",
+                    "members" : [
                       [
-                        ["Command registration"],
+                        [
+                          "Command registration"
+                        ],
                         {
-                          "SpecPortInstance": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "Special": {
-                                    "inputKind": "None",
-                                    "kind": {
-                                      "CommandReg": {}
+                          "SpecPortInstance" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "Special" : {
+                                    "inputKind" : "None",
+                                    "kind" : {
+                                      "CommandReg" : {
+                                        
+                                      }
                                     },
-                                    "name": "cmdRegOut",
-                                    "priority": "None",
-                                    "queueFull": "None"
+                                    "name" : "cmdRegOut",
+                                    "priority" : "None",
+                                    "queueFull" : "None"
                                   }
                                 },
-                                "id": 0
+                                "id" : 0
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        ["Command input"],
+                        [
+                          "Command input"
+                        ],
                         {
-                          "SpecPortInstance": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "Special": {
-                                    "inputKind": "None",
-                                    "kind": {
-                                      "CommandRecv": {}
+                          "SpecPortInstance" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "Special" : {
+                                    "inputKind" : "None",
+                                    "kind" : {
+                                      "CommandRecv" : {
+                                        
+                                      }
                                     },
-                                    "name": "cmdIn",
-                                    "priority": "None",
-                                    "queueFull": "None"
+                                    "name" : "cmdIn",
+                                    "priority" : "None",
+                                    "queueFull" : "None"
                                   }
                                 },
-                                "id": 1
+                                "id" : 1
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        ["Command response"],
+                        [
+                          "Command response"
+                        ],
                         {
-                          "SpecPortInstance": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "Special": {
-                                    "inputKind": "None",
-                                    "kind": {
-                                      "CommandResp": {}
+                          "SpecPortInstance" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "Special" : {
+                                    "inputKind" : "None",
+                                    "kind" : {
+                                      "CommandResp" : {
+                                        
+                                      }
                                     },
-                                    "name": "cmdResponseOut",
-                                    "priority": "None",
-                                    "queueFull": "None"
+                                    "name" : "cmdResponseOut",
+                                    "priority" : "None",
+                                    "queueFull" : "None"
                                   }
                                 },
-                                "id": 2
+                                "id" : 2
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        ["Command with priority"],
+                        [
+                          "Command with priority"
+                        ],
                         {
-                          "SpecCommand": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "kind": {
-                                    "Async": {}
+                          "SpecCommand" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "kind" : {
+                                    "Async" : {
+                                      
+                                    }
                                   },
-                                  "name": "COMMAND_1",
-                                  "params": [],
-                                  "opcode": "None",
-                                  "priority": {
-                                    "Some": {
-                                      "AstNode": {
-                                        "data": {
-                                          "ExprLiteralInt": {
-                                            "value": "10"
+                                  "name" : "COMMAND_1",
+                                  "params" : [
+                                  ],
+                                  "opcode" : "None",
+                                  "priority" : {
+                                    "Some" : {
+                                      "AstNode" : {
+                                        "data" : {
+                                          "ExprLiteralInt" : {
+                                            "value" : "10"
                                           }
                                         },
-                                        "id": 3
+                                        "id" : 3
                                       }
                                     }
                                   },
-                                  "queueFull": "None"
+                                  "queueFull" : "None"
                                 },
-                                "id": 4
+                                "id" : 4
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        ["Command with formal parameters and priority"],
+                        [
+                          "Command with formal parameters and priority"
+                        ],
                         {
-                          "SpecCommand": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "kind": {
-                                    "Async": {}
+                          "SpecCommand" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "kind" : {
+                                    "Async" : {
+                                      
+                                    }
                                   },
-                                  "name": "COMMAND_2",
-                                  "params": [
+                                  "name" : "COMMAND_2",
+                                  "params" : [
                                     [
-                                      [],
+                                      [
+                                      ],
                                       {
-                                        "AstNode": {
-                                          "data": {
-                                            "kind": {
-                                              "Value": {}
+                                        "AstNode" : {
+                                          "data" : {
+                                            "kind" : {
+                                              "Value" : {
+                                                
+                                              }
                                             },
-                                            "name": "a",
-                                            "typeName": {
-                                              "AstNode": {
-                                                "data": {
-                                                  "TypeNameInt": {
-                                                    "name": {
-                                                      "U32": {}
+                                            "name" : "a",
+                                            "typeName" : {
+                                              "AstNode" : {
+                                                "data" : {
+                                                  "TypeNameInt" : {
+                                                    "name" : {
+                                                      "U32" : {
+                                                        
+                                                      }
                                                     }
                                                   }
                                                 },
-                                                "id": 5
+                                                "id" : 5
                                               }
                                             }
                                           },
-                                          "id": 6
+                                          "id" : 6
                                         }
                                       },
-                                      []
+                                      [
+                                      ]
                                     ],
                                     [
-                                      [],
+                                      [
+                                      ],
                                       {
-                                        "AstNode": {
-                                          "data": {
-                                            "kind": {
-                                              "Value": {}
+                                        "AstNode" : {
+                                          "data" : {
+                                            "kind" : {
+                                              "Value" : {
+                                                
+                                              }
                                             },
-                                            "name": "b",
-                                            "typeName": {
-                                              "AstNode": {
-                                                "data": {
-                                                  "TypeNameFloat": {
-                                                    "name": {
-                                                      "F32": {}
+                                            "name" : "b",
+                                            "typeName" : {
+                                              "AstNode" : {
+                                                "data" : {
+                                                  "TypeNameFloat" : {
+                                                    "name" : {
+                                                      "F32" : {
+                                                        
+                                                      }
                                                     }
                                                   }
                                                 },
-                                                "id": 11
+                                                "id" : 11
                                               }
                                             }
                                           },
-                                          "id": 12
+                                          "id" : 12
                                         }
                                       },
-                                      []
+                                      [
+                                      ]
                                     ]
                                   ],
-                                  "opcode": "None",
-                                  "priority": {
-                                    "Some": {
-                                      "AstNode": {
-                                        "data": {
-                                          "ExprLiteralInt": {
-                                            "value": "20"
+                                  "opcode" : "None",
+                                  "priority" : {
+                                    "Some" : {
+                                      "AstNode" : {
+                                        "data" : {
+                                          "ExprLiteralInt" : {
+                                            "value" : "20"
                                           }
                                         },
-                                        "id": 13
+                                        "id" : 13
                                       }
                                     }
                                   },
-                                  "queueFull": "None"
+                                  "queueFull" : "None"
                                 },
-                                "id": 14
+                                "id" : 14
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
                         [
                           "Command with formal parameters, opcode, priority, and queue full behavior"
                         ],
                         {
-                          "SpecCommand": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "kind": {
-                                    "Async": {}
+                          "SpecCommand" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "kind" : {
+                                    "Async" : {
+                                      
+                                    }
                                   },
-                                  "name": "COMMAND_3",
-                                  "params": [
+                                  "name" : "COMMAND_3",
+                                  "params" : [
                                     [
-                                      [],
+                                      [
+                                      ],
                                       {
-                                        "AstNode": {
-                                          "data": {
-                                            "kind": {
-                                              "Value": {}
+                                        "AstNode" : {
+                                          "data" : {
+                                            "kind" : {
+                                              "Value" : {
+                                                
+                                              }
                                             },
-                                            "name": "a",
-                                            "typeName": {
-                                              "AstNode": {
-                                                "data": {
-                                                  "TypeNameString": {
-                                                    "size": "None"
+                                            "name" : "a",
+                                            "typeName" : {
+                                              "AstNode" : {
+                                                "data" : {
+                                                  "TypeNameString" : {
+                                                    "size" : "None"
                                                   }
                                                 },
-                                                "id": 39
+                                                "id" : 39
                                               }
                                             }
                                           },
-                                          "id": 40
+                                          "id" : 40
                                         }
                                       },
-                                      []
+                                      [
+                                      ]
                                     ]
                                   ],
-                                  "opcode": {
-                                    "Some": {
-                                      "AstNode": {
-                                        "data": {
-                                          "ExprLiteralInt": {
-                                            "value": "0x10"
+                                  "opcode" : {
+                                    "Some" : {
+                                      "AstNode" : {
+                                        "data" : {
+                                          "ExprLiteralInt" : {
+                                            "value" : "0x10"
                                           }
                                         },
-                                        "id": 41
+                                        "id" : 41
                                       }
                                     }
                                   },
-                                  "priority": {
-                                    "Some": {
-                                      "AstNode": {
-                                        "data": {
-                                          "ExprLiteralInt": {
-                                            "value": "30"
+                                  "priority" : {
+                                    "Some" : {
+                                      "AstNode" : {
+                                        "data" : {
+                                          "ExprLiteralInt" : {
+                                            "value" : "30"
                                           }
                                         },
-                                        "id": 42
+                                        "id" : 42
                                       }
                                     }
                                   },
-                                  "queueFull": {
-                                    "Some": {
-                                      "AstNode": {
-                                        "data": {
-                                          "Drop": {}
+                                  "queueFull" : {
+                                    "Some" : {
+                                      "AstNode" : {
+                                        "data" : {
+                                          "Drop" : {
+                                            
+                                          }
                                         },
-                                        "id": 43
+                                        "id" : 43
                                       }
                                     }
                                   }
                                 },
-                                "id": 44
+                                "id" : 44
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ]
                     ]
                   },
-                  "id": 45
+                  "id" : 45
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          [],
+          [
+          ],
           {
-            "DefModule": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "Fw",
-                    "members": [
+            "DefModule" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "Fw",
+                    "members" : [
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "DefPort": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "name": "Cmd",
-                                  "params": [],
-                                  "returnType": "None"
+                          "DefPort" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "name" : "Cmd",
+                                  "params" : [
+                                  ],
+                                  "returnType" : "None"
                                 },
-                                "id": 46
+                                "id" : 46
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "DefPort": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "name": "CmdReg",
-                                  "params": [],
-                                  "returnType": "None"
+                          "DefPort" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "name" : "CmdReg",
+                                  "params" : [
+                                  ],
+                                  "returnType" : "None"
                                 },
-                                "id": 47
+                                "id" : 47
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "DefPort": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "name": "CmdResponse",
-                                  "params": [],
-                                  "returnType": "None"
+                          "DefPort" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "name" : "CmdResponse",
+                                  "params" : [
+                                  ],
+                                  "returnType" : "None"
                                 },
-                                "id": 50
+                                "id" : 50
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ]
                     ]
                   },
-                  "id": 51
+                  "id" : 51
                 }
               }
             }
           },
-          []
+          [
+          ]
         ]
       ]
     }

--- a/tests/commands/commands_locations.json
+++ b/tests/commands/commands_locations.json
@@ -1,265 +1,265 @@
 {
-  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
-  "locationMap": {
-    "0": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
-      "pos": "10.3",
-      "includingLoc": "None"
+  "fppVersion" : "v3.1.0a10-54-g11243e778",
+  "locationMap" : {
+    "0" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
+      "pos" : "10.3",
+      "includingLoc" : "None"
     },
-    "1": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
-      "pos": "13.3",
-      "includingLoc": "None"
+    "1" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
+      "pos" : "13.3",
+      "includingLoc" : "None"
     },
-    "2": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
-      "pos": "16.3",
-      "includingLoc": "None"
+    "2" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
+      "pos" : "16.3",
+      "includingLoc" : "None"
     },
-    "3": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
-      "pos": "23.36",
-      "includingLoc": "None"
+    "3" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
+      "pos" : "23.36",
+      "includingLoc" : "None"
     },
-    "4": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
-      "pos": "23.3",
-      "includingLoc": "None"
+    "4" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
+      "pos" : "23.3",
+      "includingLoc" : "None"
     },
-    "5": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
-      "pos": "26.30",
-      "includingLoc": "None"
+    "5" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
+      "pos" : "26.30",
+      "includingLoc" : "None"
     },
-    "6": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
-      "pos": "26.27",
-      "includingLoc": "None"
+    "6" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
+      "pos" : "26.27",
+      "includingLoc" : "None"
     },
-    "7": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
-      "pos": "26.38",
-      "includingLoc": "None"
+    "7" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
+      "pos" : "26.38",
+      "includingLoc" : "None"
     },
-    "8": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
-      "pos": "26.35",
-      "includingLoc": "None"
+    "8" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
+      "pos" : "26.35",
+      "includingLoc" : "None"
     },
-    "9": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
-      "pos": "26.38",
-      "includingLoc": "None"
+    "9" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
+      "pos" : "26.38",
+      "includingLoc" : "None"
     },
-    "10": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
-      "pos": "26.35",
-      "includingLoc": "None"
+    "10" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
+      "pos" : "26.35",
+      "includingLoc" : "None"
     },
-    "11": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
-      "pos": "26.38",
-      "includingLoc": "None"
+    "11" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
+      "pos" : "26.38",
+      "includingLoc" : "None"
     },
-    "12": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
-      "pos": "26.35",
-      "includingLoc": "None"
+    "12" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
+      "pos" : "26.35",
+      "includingLoc" : "None"
     },
-    "13": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
-      "pos": "26.52",
-      "includingLoc": "None"
+    "13" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
+      "pos" : "26.52",
+      "includingLoc" : "None"
     },
-    "14": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
-      "pos": "26.3",
-      "includingLoc": "None"
+    "14" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
+      "pos" : "26.3",
+      "includingLoc" : "None"
     },
-    "15": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
-      "pos": "29.30",
-      "includingLoc": "None"
+    "15" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
+      "pos" : "29.30",
+      "includingLoc" : "None"
     },
-    "16": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
-      "pos": "29.27",
-      "includingLoc": "None"
+    "16" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
+      "pos" : "29.27",
+      "includingLoc" : "None"
     },
-    "17": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
-      "pos": "29.30",
-      "includingLoc": "None"
+    "17" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
+      "pos" : "29.30",
+      "includingLoc" : "None"
     },
-    "18": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
-      "pos": "29.27",
-      "includingLoc": "None"
+    "18" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
+      "pos" : "29.27",
+      "includingLoc" : "None"
     },
-    "19": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
-      "pos": "29.30",
-      "includingLoc": "None"
+    "19" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
+      "pos" : "29.30",
+      "includingLoc" : "None"
     },
-    "20": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
-      "pos": "29.27",
-      "includingLoc": "None"
+    "20" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
+      "pos" : "29.27",
+      "includingLoc" : "None"
     },
-    "21": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
-      "pos": "29.45",
-      "includingLoc": "None"
+    "21" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
+      "pos" : "29.45",
+      "includingLoc" : "None"
     },
-    "22": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
-      "pos": "29.59",
-      "includingLoc": "None"
+    "22" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
+      "pos" : "29.59",
+      "includingLoc" : "None"
     },
-    "23": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
-      "pos": "29.62",
-      "includingLoc": "None"
+    "23" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
+      "pos" : "29.62",
+      "includingLoc" : "None"
     },
-    "24": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
-      "pos": "29.3",
-      "includingLoc": "None"
+    "24" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
+      "pos" : "29.3",
+      "includingLoc" : "None"
     },
-    "25": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
-      "pos": "29.30",
-      "includingLoc": "None"
+    "25" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
+      "pos" : "29.30",
+      "includingLoc" : "None"
     },
-    "26": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
-      "pos": "29.27",
-      "includingLoc": "None"
+    "26" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
+      "pos" : "29.27",
+      "includingLoc" : "None"
     },
-    "27": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
-      "pos": "29.30",
-      "includingLoc": "None"
+    "27" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
+      "pos" : "29.30",
+      "includingLoc" : "None"
     },
-    "28": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
-      "pos": "29.27",
-      "includingLoc": "None"
+    "28" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
+      "pos" : "29.27",
+      "includingLoc" : "None"
     },
-    "29": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
-      "pos": "29.30",
-      "includingLoc": "None"
+    "29" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
+      "pos" : "29.30",
+      "includingLoc" : "None"
     },
-    "30": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
-      "pos": "29.27",
-      "includingLoc": "None"
+    "30" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
+      "pos" : "29.27",
+      "includingLoc" : "None"
     },
-    "31": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
-      "pos": "29.45",
-      "includingLoc": "None"
+    "31" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
+      "pos" : "29.45",
+      "includingLoc" : "None"
     },
-    "32": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
-      "pos": "29.59",
-      "includingLoc": "None"
+    "32" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
+      "pos" : "29.59",
+      "includingLoc" : "None"
     },
-    "33": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
-      "pos": "29.62",
-      "includingLoc": "None"
+    "33" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
+      "pos" : "29.62",
+      "includingLoc" : "None"
     },
-    "34": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
-      "pos": "29.3",
-      "includingLoc": "None"
+    "34" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
+      "pos" : "29.3",
+      "includingLoc" : "None"
     },
-    "35": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
-      "pos": "29.30",
-      "includingLoc": "None"
+    "35" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
+      "pos" : "29.30",
+      "includingLoc" : "None"
     },
-    "36": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
-      "pos": "29.27",
-      "includingLoc": "None"
+    "36" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
+      "pos" : "29.27",
+      "includingLoc" : "None"
     },
-    "37": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
-      "pos": "29.30",
-      "includingLoc": "None"
+    "37" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
+      "pos" : "29.30",
+      "includingLoc" : "None"
     },
-    "38": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
-      "pos": "29.27",
-      "includingLoc": "None"
+    "38" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
+      "pos" : "29.27",
+      "includingLoc" : "None"
     },
-    "39": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
-      "pos": "29.30",
-      "includingLoc": "None"
+    "39" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
+      "pos" : "29.30",
+      "includingLoc" : "None"
     },
-    "40": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
-      "pos": "29.27",
-      "includingLoc": "None"
+    "40" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
+      "pos" : "29.27",
+      "includingLoc" : "None"
     },
-    "41": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
-      "pos": "29.45",
-      "includingLoc": "None"
+    "41" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
+      "pos" : "29.45",
+      "includingLoc" : "None"
     },
-    "42": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
-      "pos": "29.59",
-      "includingLoc": "None"
+    "42" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
+      "pos" : "29.59",
+      "includingLoc" : "None"
     },
-    "43": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
-      "pos": "29.62",
-      "includingLoc": "None"
+    "43" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
+      "pos" : "29.62",
+      "includingLoc" : "None"
     },
-    "44": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
-      "pos": "29.3",
-      "includingLoc": "None"
+    "44" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
+      "pos" : "29.3",
+      "includingLoc" : "None"
     },
-    "45": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
-      "pos": "3.1",
-      "includingLoc": "None"
+    "45" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
+      "pos" : "3.1",
+      "includingLoc" : "None"
     },
-    "46": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
-      "pos": "34.3",
-      "includingLoc": "None"
+    "46" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
+      "pos" : "34.3",
+      "includingLoc" : "None"
     },
-    "47": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
-      "pos": "35.3",
-      "includingLoc": "None"
+    "47" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
+      "pos" : "35.3",
+      "includingLoc" : "None"
     },
-    "48": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
-      "pos": "36.3",
-      "includingLoc": "None"
+    "48" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
+      "pos" : "36.3",
+      "includingLoc" : "None"
     },
-    "49": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
-      "pos": "36.3",
-      "includingLoc": "None"
+    "49" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
+      "pos" : "36.3",
+      "includingLoc" : "None"
     },
-    "50": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
-      "pos": "36.3",
-      "includingLoc": "None"
+    "50" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
+      "pos" : "36.3",
+      "includingLoc" : "None"
     },
-    "51": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
-      "pos": "33.1",
-      "includingLoc": "None"
+    "51" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",
+      "pos" : "33.1",
+      "includingLoc" : "None"
     }
   }
 }

--- a/tests/commands/commands_locations.json
+++ b/tests/commands/commands_locations.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion": "[ fpp version ]",
+  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
   "locationMap": {
     "0": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",

--- a/tests/constants/constants.fpp
+++ b/tests/constants/constants.fpp
@@ -26,16 +26,20 @@ constant f = [
                ]
              ]
 
-constant g = {
+constant g = f[0]
+
+constant h = f[0][1]
+
+constant i = {
                x = 1
                y = "abc"
                z = false
              }
 
-constant h = {
+constant j = {
              }
 
-constant i = [
+constant k = [
                {
                  x = 1
                  y = 2
@@ -45,21 +49,21 @@ constant i = [
                }
              ]
 
-constant j = 1
+constant l = 1
 
-constant k = j
+constant m = l
 
-constant l = -1
+constant n = -1
 
-constant m = 1 + 2
+constant o = 1 + 2
 
-constant n = (1)
+constant p = (1)
 
-constant o = true
+constant q = true
 
-constant p = false
+constant r = false
 
 @ This is a pre annotation.
 @ It has two lines.
-constant q = 0 @< This is a post annotation.
+constant s = 0 @< This is a post annotation.
                @< It also has two lines.

--- a/tests/constants/constants_analysis.json
+++ b/tests/constants/constants_analysis.json
@@ -1,58 +1,82 @@
 {
-  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
-  "analysis": {
-    "componentInstanceMap": {},
-    "componentMap": {},
-    "includedFileSet": [],
-    "inputFileSet": [
+  "fppVersion" : "v3.1.0a10-54-g11243e778",
+  "analysis" : {
+    "componentInstanceMap" : {
+      
+    },
+    "componentMap" : {
+      
+    },
+    "includedFileSet" : [
+    ],
+    "inputFileSet" : [
       "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp"
     ],
-    "locationSpecifierMap": [],
-    "parentSymbolMap": {},
-    "symbolScopeMap": {},
-    "topologyMap": {},
-    "typeMap": {
-      "33": {
-        "Int": {
-          "Integer": {}
+    "locationSpecifierMap" : [
+    ],
+    "parentSymbolMap" : {
+      
+    },
+    "symbolScopeMap" : {
+      
+    },
+    "topologyMap" : {
+      
+    },
+    "typeMap" : {
+      "33" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "5": {
-        "String": {
-          "size": "None"
+      "5" : {
+        "String" : {
+          "size" : "None"
         }
       },
-      "42": {
-        "AnonStruct": {
-          "members": {}
+      "42" : {
+        "AnonStruct" : {
+          "members" : {
+            
+          }
         }
       },
-      "2": {
-        "Int": {
-          "Integer": {}
+      "2" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "18": {
-        "Int": {
-          "Integer": {}
+      "18" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "52": {
-        "AnonArray": {
-          "size": {
-            "Some": 2
+      "52" : {
+        "AnonArray" : {
+          "size" : {
+            "Some" : 2
           },
-          "eltType": {
-            "AnonStruct": {
-              "members": {
-                "x": {
-                  "Int": {
-                    "Integer": {}
+          "eltType" : {
+            "AnonStruct" : {
+              "members" : {
+                "x" : {
+                  "Int" : {
+                    "Integer" : {
+                      
+                    }
                   }
                 },
-                "y": {
-                  "Int": {
-                    "Integer": {}
+                "y" : {
+                  "Int" : {
+                    "Integer" : {
+                      
+                    }
                   }
                 }
               }
@@ -60,51 +84,65 @@
           }
         }
       },
-      "28": {
-        "Int": {
-          "Integer": {}
+      "28" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "45": {
-        "Int": {
-          "Integer": {}
+      "45" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "67": {
-        "Primitive": {
-          "Boolean": {}
+      "67" : {
+        "Primitive" : {
+          "Boolean" : {
+            
+          }
         }
       },
-      "12": {
-        "Primitive": {
-          "Float": {
-            "kind": {
-              "F64": {}
+      "12" : {
+        "Primitive" : {
+          "Float" : {
+            "kind" : {
+              "F64" : {
+                
+              }
             }
           }
         }
       },
-      "66": {
-        "Int": {
-          "Integer": {}
+      "66" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "51": {
-        "AnonArray": {
-          "size": {
-            "Some": 2
+      "51" : {
+        "AnonArray" : {
+          "size" : {
+            "Some" : 2
           },
-          "eltType": {
-            "AnonStruct": {
-              "members": {
-                "x": {
-                  "Int": {
-                    "Integer": {}
+          "eltType" : {
+            "AnonStruct" : {
+              "members" : {
+                "x" : {
+                  "Int" : {
+                    "Integer" : {
+                      
+                    }
                   }
                 },
-                "y": {
-                  "Int": {
-                    "Integer": {}
+                "y" : {
+                  "Int" : {
+                    "Integer" : {
+                      
+                    }
                   }
                 }
               }
@@ -112,600 +150,648 @@
           }
         }
       },
-      "8": {
-        "Int": {
-          "Integer": {}
+      "8" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "73": {
-        "Int": {
-          "Integer": {}
+      "73" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "19": {
-        "Int": {
-          "Integer": {}
+      "19" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "23": {
-        "AnonArray": {
-          "size": {
-            "Some": 2
+      "23" : {
+        "AnonArray" : {
+          "size" : {
+            "Some" : 2
           },
-          "eltType": {
-            "AnonArray": {
-              "size": {
-                "Some": 2
+          "eltType" : {
+            "AnonArray" : {
+              "size" : {
+                "Some" : 2
               },
-              "eltType": {
-                "Int": {
-                  "Integer": {}
+              "eltType" : {
+                "Int" : {
+                  "Integer" : {
+                    
+                  }
                 }
               }
             }
           }
         }
       },
-      "62": {
-        "Int": {
-          "Integer": {}
+      "62" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "4": {
-        "String": {
-          "size": "None"
+      "4" : {
+        "String" : {
+          "size" : "None"
         }
       },
-      "40": {
-        "AnonStruct": {
-          "members": {
-            "x": {
-              "Int": {
-                "Integer": {}
+      "40" : {
+        "AnonStruct" : {
+          "members" : {
+            "x" : {
+              "Int" : {
+                "Integer" : {
+                  
+                }
               }
             },
-            "y": {
-              "String": {
-                "size": "None"
+            "y" : {
+              "String" : {
+                "size" : "None"
               }
             },
-            "z": {
-              "Primitive": {
-                "Boolean": {}
+            "z" : {
+              "Primitive" : {
+                "Boolean" : {
+                  
+                }
               }
             }
           }
         }
       },
-      "15": {
-        "Int": {
-          "Integer": {}
+      "15" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "11": {
-        "Int": {
-          "Integer": {}
+      "11" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "9": {
-        "AnonArray": {
-          "size": {
-            "Some": 3
+      "9" : {
+        "AnonArray" : {
+          "size" : {
+            "Some" : 3
           },
-          "eltType": {
-            "Int": {
-              "Integer": {}
+          "eltType" : {
+            "Int" : {
+              "Integer" : {
+                
+              }
             }
           }
         }
       },
-      "22": {
-        "AnonArray": {
-          "size": {
-            "Some": 2
+      "22" : {
+        "AnonArray" : {
+          "size" : {
+            "Some" : 2
           },
-          "eltType": {
-            "AnonArray": {
-              "size": {
-                "Some": 2
+          "eltType" : {
+            "AnonArray" : {
+              "size" : {
+                "Some" : 2
               },
-              "eltType": {
-                "Int": {
-                  "Integer": {}
+              "eltType" : {
+                "Int" : {
+                  "Integer" : {
+                    
+                  }
                 }
               }
             }
           }
         }
       },
-      "56": {
-        "Int": {
-          "Integer": {}
-        }
-      },
-      "55": {
-        "Int": {
-          "Integer": {}
-        }
-      },
-      "26": {
-        "AnonArray": {
-          "size": {
-            "Some": 2
-          },
-          "eltType": {
-            "Int": {
-              "Integer": {}
-            }
+      "56" : {
+        "Int" : {
+          "Integer" : {
+            
           }
         }
       },
-      "50": {
-        "AnonStruct": {
-          "members": {
-            "x": {
-              "Int": {
-                "Integer": {}
+      "55" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
+        }
+      },
+      "26" : {
+        "AnonArray" : {
+          "size" : {
+            "Some" : 2
+          },
+          "eltType" : {
+            "Int" : {
+              "Integer" : {
+                
               }
             }
           }
         }
       },
-      "37": {
-        "Primitive": {
-          "Boolean": {}
-        }
-      },
-      "68": {
-        "Primitive": {
-          "Boolean": {}
-        }
-      },
-      "61": {
-        "Int": {
-          "Integer": {}
-        }
-      },
-      "13": {
-        "AnonArray": {
-          "size": {
-            "Some": 2
-          },
-          "eltType": {
-            "Primitive": {
-              "Float": {
-                "kind": {
-                  "F64": {}
+      "50" : {
+        "AnonStruct" : {
+          "members" : {
+            "x" : {
+              "Int" : {
+                "Integer" : {
+                  
                 }
               }
             }
           }
         }
       },
-      "24": {
-        "Int": {
-          "Integer": {}
+      "37" : {
+        "Primitive" : {
+          "Boolean" : {
+            
+          }
         }
       },
-      "35": {
-        "String": {
-          "size": "None"
+      "68" : {
+        "Primitive" : {
+          "Boolean" : {
+            
+          }
         }
       },
-      "16": {
-        "Int": {
-          "Integer": {}
+      "61" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "10": {
-        "AnonArray": {
-          "size": {
-            "Some": 3
+      "13" : {
+        "AnonArray" : {
+          "size" : {
+            "Some" : 2
           },
-          "eltType": {
-            "Int": {
-              "Integer": {}
+          "eltType" : {
+            "Primitive" : {
+              "Float" : {
+                "kind" : {
+                  "F64" : {
+                    
+                  }
+                }
+              }
             }
           }
         }
       },
-      "59": {
-        "Int": {
-          "Integer": {}
+      "24" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "48": {
-        "Int": {
-          "Integer": {}
+      "35" : {
+        "String" : {
+          "size" : "None"
         }
       },
-      "21": {
-        "AnonArray": {
-          "size": {
-            "Some": 2
+      "16" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
+        }
+      },
+      "10" : {
+        "AnonArray" : {
+          "size" : {
+            "Some" : 3
           },
-          "eltType": {
-            "AnonArray": {
-              "size": {
-                "Some": 2
+          "eltType" : {
+            "Int" : {
+              "Integer" : {
+                
+              }
+            }
+          }
+        }
+      },
+      "59" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
+        }
+      },
+      "48" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
+        }
+      },
+      "21" : {
+        "AnonArray" : {
+          "size" : {
+            "Some" : 2
+          },
+          "eltType" : {
+            "AnonArray" : {
+              "size" : {
+                "Some" : 2
               },
-              "eltType": {
-                "Int": {
-                  "Integer": {}
+              "eltType" : {
+                "Int" : {
+                  "Integer" : {
+                    
+                  }
                 }
               }
             }
           }
         }
       },
-      "54": {
-        "Int": {
-          "Integer": {}
+      "54" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "43": {
-        "Int": {
-          "Integer": {}
+      "43" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "65": {
-        "Int": {
-          "Integer": {}
+      "65" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "57": {
-        "Int": {
-          "Integer": {}
+      "57" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "32": {
-        "Int": {
-          "Integer": {}
+      "32" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "6": {
-        "Int": {
-          "Integer": {}
+      "6" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "1": {
-        "Int": {
-          "Integer": {}
+      "1" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "39": {
-        "AnonStruct": {
-          "members": {
-            "x": {
-              "Int": {
-                "Integer": {}
+      "39" : {
+        "AnonStruct" : {
+          "members" : {
+            "x" : {
+              "Int" : {
+                "Integer" : {
+                  
+                }
               }
             },
-            "y": {
-              "String": {
-                "size": "None"
+            "y" : {
+              "String" : {
+                "size" : "None"
               }
             },
-            "z": {
-              "Primitive": {
-                "Boolean": {}
-              }
-            }
-          }
-        }
-      },
-      "17": {
-        "AnonArray": {
-          "size": {
-            "Some": 2
-          },
-          "eltType": {
-            "Int": {
-              "Integer": {}
-            }
-          }
-        }
-      },
-      "25": {
-        "AnonArray": {
-          "size": {
-            "Some": 2
-          },
-          "eltType": {
-            "Int": {
-              "Integer": {}
-            }
-          }
-        }
-      },
-      "60": {
-        "Int": {
-          "Integer": {}
-        }
-      },
-      "14": {
-        "AnonArray": {
-          "size": {
-            "Some": 2
-          },
-          "eltType": {
-            "Primitive": {
-              "Float": {
-                "kind": {
-                  "F64": {}
+            "z" : {
+              "Primitive" : {
+                "Boolean" : {
+                  
                 }
               }
             }
           }
         }
       },
-      "47": {
-        "AnonStruct": {
-          "members": {
-            "x": {
-              "Int": {
-                "Integer": {}
+      "17" : {
+        "AnonArray" : {
+          "size" : {
+            "Some" : 2
+          },
+          "eltType" : {
+            "Int" : {
+              "Integer" : {
+                
+              }
+            }
+          }
+        }
+      },
+      "25" : {
+        "AnonArray" : {
+          "size" : {
+            "Some" : 2
+          },
+          "eltType" : {
+            "Int" : {
+              "Integer" : {
+                
+              }
+            }
+          }
+        }
+      },
+      "60" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
+        }
+      },
+      "14" : {
+        "AnonArray" : {
+          "size" : {
+            "Some" : 2
+          },
+          "eltType" : {
+            "Primitive" : {
+              "Float" : {
+                "kind" : {
+                  "F64" : {
+                    
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "47" : {
+        "AnonStruct" : {
+          "members" : {
+            "x" : {
+              "Int" : {
+                "Integer" : {
+                  
+                }
               }
             },
-            "y": {
-              "Int": {
-                "Integer": {}
+            "y" : {
+              "Int" : {
+                "Integer" : {
+                  
+                }
               }
             }
           }
         }
       },
-      "31": {
-        "Int": {
-          "Integer": {}
+      "31" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "69": {
-        "Primitive": {
-          "Boolean": {}
+      "69" : {
+        "Primitive" : {
+          "Boolean" : {
+            
+          }
         }
       },
-      "58": {
-        "Int": {
-          "Integer": {}
+      "58" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "64": {
-        "Int": {
-          "Integer": {}
+      "64" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "53": {
-        "Int": {
-          "Integer": {}
+      "53" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "0": {
-        "Int": {
-          "Integer": {}
+      "0" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "20": {
-        "AnonArray": {
-          "size": {
-            "Some": 2
+      "20" : {
+        "AnonArray" : {
+          "size" : {
+            "Some" : 2
           },
-          "eltType": {
-            "Int": {
-              "Integer": {}
+          "eltType" : {
+            "Int" : {
+              "Integer" : {
+                
+              }
             }
           }
         }
       },
-      "27": {
-        "AnonArray": {
-          "size": {
-            "Some": 2
+      "27" : {
+        "AnonArray" : {
+          "size" : {
+            "Some" : 2
           },
-          "eltType": {
-            "AnonArray": {
-              "size": {
-                "Some": 2
+          "eltType" : {
+            "AnonArray" : {
+              "size" : {
+                "Some" : 2
               },
-              "eltType": {
-                "Int": {
-                  "Integer": {}
+              "eltType" : {
+                "Int" : {
+                  "Integer" : {
+                    
+                  }
                 }
               }
             }
           }
         }
       },
-      "70": {
-        "Primitive": {
-          "Boolean": {}
+      "70" : {
+        "Primitive" : {
+          "Boolean" : {
+            
+          }
         }
       },
-      "30": {
-        "AnonArray": {
-          "size": {
-            "Some": 2
+      "30" : {
+        "AnonArray" : {
+          "size" : {
+            "Some" : 2
           },
-          "eltType": {
-            "Int": {
-              "Integer": {}
+          "eltType" : {
+            "Int" : {
+              "Integer" : {
+                
+              }
             }
           }
         }
       },
-      "7": {
-        "Int": {
-          "Integer": {}
+      "7" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "29": {
-        "Int": {
-          "Integer": {}
+      "29" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "41": {
-        "AnonStruct": {
-          "members": {}
+      "41" : {
+        "AnonStruct" : {
+          "members" : {
+            
+          }
         }
       },
-      "63": {
-        "Int": {
-          "Integer": {}
+      "63" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "3": {
-        "Int": {
-          "Integer": {}
+      "3" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "74": {
-        "Int": {
-          "Integer": {}
+      "74" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       }
     },
-    "useDefMap": {
-      "23": {
-        "Constant": {
-          "nodeId": 22,
-          "unqualifiedName": "f"
+    "useDefMap" : {
+      "23" : {
+        "Constant" : {
+          "nodeId" : 22,
+          "unqualifiedName" : "f"
         }
       },
-      "27": {
-        "Constant": {
-          "nodeId": 22,
-          "unqualifiedName": "f"
+      "27" : {
+        "Constant" : {
+          "nodeId" : 22,
+          "unqualifiedName" : "f"
         }
       },
-      "55": {
-        "Constant": {
-          "nodeId": 54,
-          "unqualifiedName": "l"
+      "55" : {
+        "Constant" : {
+          "nodeId" : 54,
+          "unqualifiedName" : "l"
         }
       }
     },
-    "valueMap": {
-      "33": {
-        "Integer": {
-          "value": 1
+    "valueMap" : {
+      "33" : {
+        "Integer" : {
+          "value" : 1
         }
       },
-      "5": {
-        "String": {
-          "value": "This is a string."
+      "5" : {
+        "String" : {
+          "value" : "This is a string."
         }
       },
-      "42": {
-        "AnonStruct": {
-          "members": {}
-        }
-      },
-      "2": {
-        "Integer": {
-          "value": 43981
-        }
-      },
-      "18": {
-        "Integer": {
-          "value": 3
-        }
-      },
-      "52": {
-        "AnonArray": {
-          "elements": [
-            {
-              "AnonStruct": {
-                "members": {
-                  "x": {
-                    "Integer": {
-                      "value": 1
-                    }
-                  },
-                  "y": {
-                    "Integer": {
-                      "value": 2
-                    }
-                  }
-                }
-              }
-            },
-            {
-              "AnonStruct": {
-                "members": {
-                  "x": {
-                    "Integer": {
-                      "value": 3
-                    }
-                  },
-                  "y": {
-                    "Integer": {
-                      "value": 0
-                    }
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "28": {
-        "Integer": {
-          "value": 0
-        }
-      },
-      "45": {
-        "Integer": {
-          "value": 2
-        }
-      },
-      "67": {
-        "Boolean": {
-          "value": true
-        }
-      },
-      "12": {
-        "Float": {
-          "value": 2.0,
-          "kind": {
-            "F64": {}
+      "42" : {
+        "AnonStruct" : {
+          "members" : {
+            
           }
         }
       },
-      "66": {
-        "Integer": {
-          "value": 1
+      "2" : {
+        "Integer" : {
+          "value" : 43981
         }
       },
-      "51": {
-        "AnonArray": {
-          "elements": [
+      "18" : {
+        "Integer" : {
+          "value" : 3
+        }
+      },
+      "52" : {
+        "AnonArray" : {
+          "elements" : [
             {
-              "AnonStruct": {
-                "members": {
-                  "x": {
-                    "Integer": {
-                      "value": 1
+              "AnonStruct" : {
+                "members" : {
+                  "x" : {
+                    "Integer" : {
+                      "value" : 1
                     }
                   },
-                  "y": {
-                    "Integer": {
-                      "value": 2
+                  "y" : {
+                    "Integer" : {
+                      "value" : 2
                     }
                   }
                 }
               }
             },
             {
-              "AnonStruct": {
-                "members": {
-                  "x": {
-                    "Integer": {
-                      "value": 3
+              "AnonStruct" : {
+                "members" : {
+                  "x" : {
+                    "Integer" : {
+                      "value" : 3
                     }
                   },
-                  "y": {
-                    "Integer": {
-                      "value": 0
+                  "y" : {
+                    "Integer" : {
+                      "value" : 0
                     }
                   }
                 }
@@ -714,151 +800,119 @@
           ]
         }
       },
-      "8": {
-        "Integer": {
-          "value": 3
+      "28" : {
+        "Integer" : {
+          "value" : 0
         }
       },
-      "73": {
-        "Integer": {
-          "value": 0
+      "45" : {
+        "Integer" : {
+          "value" : 2
         }
       },
-      "19": {
-        "Integer": {
-          "value": 4
+      "67" : {
+        "Boolean" : {
+          "value" : true
         }
       },
-      "23": {
-        "AnonArray": {
-          "elements": [
-            {
-              "AnonArray": {
-                "elements": [
-                  {
-                    "Integer": {
-                      "value": 1
-                    }
-                  },
-                  {
-                    "Integer": {
-                      "value": 2
-                    }
-                  }
-                ]
-              }
-            },
-            {
-              "AnonArray": {
-                "elements": [
-                  {
-                    "Integer": {
-                      "value": 3
-                    }
-                  },
-                  {
-                    "Integer": {
-                      "value": 4
-                    }
-                  }
-                ]
-              }
-            }
-          ]
-        }
-      },
-      "62": {
-        "Integer": {
-          "value": 3
-        }
-      },
-      "4": {
-        "String": {
-          "value": "This is a string."
-        }
-      },
-      "40": {
-        "AnonStruct": {
-          "members": {
-            "x": {
-              "Integer": {
-                "value": 1
-              }
-            },
-            "y": {
-              "String": {
-                "value": "abc"
-              }
-            },
-            "z": {
-              "Boolean": {
-                "value": false
-              }
+      "12" : {
+        "Float" : {
+          "value" : 2.0,
+          "kind" : {
+            "F64" : {
+              
             }
           }
         }
       },
-      "15": {
-        "Integer": {
-          "value": 1
+      "66" : {
+        "Integer" : {
+          "value" : 1
         }
       },
-      "11": {
-        "Integer": {
-          "value": 1
-        }
-      },
-      "9": {
-        "AnonArray": {
-          "elements": [
+      "51" : {
+        "AnonArray" : {
+          "elements" : [
             {
-              "Integer": {
-                "value": 1
+              "AnonStruct" : {
+                "members" : {
+                  "x" : {
+                    "Integer" : {
+                      "value" : 1
+                    }
+                  },
+                  "y" : {
+                    "Integer" : {
+                      "value" : 2
+                    }
+                  }
+                }
               }
             },
             {
-              "Integer": {
-                "value": 2
-              }
-            },
-            {
-              "Integer": {
-                "value": 3
+              "AnonStruct" : {
+                "members" : {
+                  "x" : {
+                    "Integer" : {
+                      "value" : 3
+                    }
+                  },
+                  "y" : {
+                    "Integer" : {
+                      "value" : 0
+                    }
+                  }
+                }
               }
             }
           ]
         }
       },
-      "22": {
-        "AnonArray": {
-          "elements": [
+      "8" : {
+        "Integer" : {
+          "value" : 3
+        }
+      },
+      "73" : {
+        "Integer" : {
+          "value" : 0
+        }
+      },
+      "19" : {
+        "Integer" : {
+          "value" : 4
+        }
+      },
+      "23" : {
+        "AnonArray" : {
+          "elements" : [
             {
-              "AnonArray": {
-                "elements": [
+              "AnonArray" : {
+                "elements" : [
                   {
-                    "Integer": {
-                      "value": 1
+                    "Integer" : {
+                      "value" : 1
                     }
                   },
                   {
-                    "Integer": {
-                      "value": 2
+                    "Integer" : {
+                      "value" : 2
                     }
                   }
                 ]
               }
             },
             {
-              "AnonArray": {
-                "elements": [
+              "AnonArray" : {
+                "elements" : [
                   {
-                    "Integer": {
-                      "value": 3
+                    "Integer" : {
+                      "value" : 3
                     }
                   },
                   {
-                    "Integer": {
-                      "value": 4
+                    "Integer" : {
+                      "value" : 4
                     }
                   }
                 ]
@@ -867,156 +921,98 @@
           ]
         }
       },
-      "56": {
-        "Integer": {
-          "value": 1
+      "62" : {
+        "Integer" : {
+          "value" : 3
         }
       },
-      "55": {
-        "Integer": {
-          "value": 1
+      "4" : {
+        "String" : {
+          "value" : "This is a string."
         }
       },
-      "26": {
-        "AnonArray": {
-          "elements": [
-            {
-              "Integer": {
-                "value": 1
+      "40" : {
+        "AnonStruct" : {
+          "members" : {
+            "x" : {
+              "Integer" : {
+                "value" : 1
               }
             },
-            {
-              "Integer": {
-                "value": 2
+            "y" : {
+              "String" : {
+                "value" : "abc"
               }
-            }
-          ]
-        }
-      },
-      "50": {
-        "AnonStruct": {
-          "members": {
-            "x": {
-              "Integer": {
-                "value": 3
+            },
+            "z" : {
+              "Boolean" : {
+                "value" : false
               }
             }
           }
         }
       },
-      "37": {
-        "Boolean": {
-          "value": false
+      "15" : {
+        "Integer" : {
+          "value" : 1
         }
       },
-      "68": {
-        "Boolean": {
-          "value": true
+      "11" : {
+        "Integer" : {
+          "value" : 1
         }
       },
-      "61": {
-        "Integer": {
-          "value": 2
-        }
-      },
-      "13": {
-        "AnonArray": {
-          "elements": [
+      "9" : {
+        "AnonArray" : {
+          "elements" : [
             {
-              "Float": {
-                "value": 1.0,
-                "kind": {
-                  "F64": {}
-                }
+              "Integer" : {
+                "value" : 1
               }
             },
             {
-              "Float": {
-                "value": 2.0,
-                "kind": {
-                  "F64": {}
-                }
+              "Integer" : {
+                "value" : 2
+              }
+            },
+            {
+              "Integer" : {
+                "value" : 3
               }
             }
           ]
         }
       },
-      "24": {
-        "Integer": {
-          "value": 0
-        }
-      },
-      "35": {
-        "String": {
-          "value": "abc"
-        }
-      },
-      "16": {
-        "Integer": {
-          "value": 2
-        }
-      },
-      "10": {
-        "AnonArray": {
-          "elements": [
+      "22" : {
+        "AnonArray" : {
+          "elements" : [
             {
-              "Integer": {
-                "value": 1
-              }
-            },
-            {
-              "Integer": {
-                "value": 2
-              }
-            },
-            {
-              "Integer": {
-                "value": 3
-              }
-            }
-          ]
-        }
-      },
-      "59": {
-        "Integer": {
-          "value": -1
-        }
-      },
-      "48": {
-        "Integer": {
-          "value": 3
-        }
-      },
-      "21": {
-        "AnonArray": {
-          "elements": [
-            {
-              "AnonArray": {
-                "elements": [
+              "AnonArray" : {
+                "elements" : [
                   {
-                    "Integer": {
-                      "value": 1
+                    "Integer" : {
+                      "value" : 1
                     }
                   },
                   {
-                    "Integer": {
-                      "value": 2
+                    "Integer" : {
+                      "value" : 2
                     }
                   }
                 ]
               }
             },
             {
-              "AnonArray": {
-                "elements": [
+              "AnonArray" : {
+                "elements" : [
                   {
-                    "Integer": {
-                      "value": 3
+                    "Integer" : {
+                      "value" : 3
                     }
                   },
                   {
-                    "Integer": {
-                      "value": 4
+                    "Integer" : {
+                      "value" : 4
                     }
                   }
                 ]
@@ -1025,213 +1021,379 @@
           ]
         }
       },
-      "54": {
-        "Integer": {
-          "value": 1
+      "56" : {
+        "Integer" : {
+          "value" : 1
         }
       },
-      "43": {
-        "Integer": {
-          "value": 1
+      "55" : {
+        "Integer" : {
+          "value" : 1
         }
       },
-      "65": {
-        "Integer": {
-          "value": 1
-        }
-      },
-      "57": {
-        "Integer": {
-          "value": 1
-        }
-      },
-      "32": {
-        "Integer": {
-          "value": 2
-        }
-      },
-      "6": {
-        "Integer": {
-          "value": 1
-        }
-      },
-      "1": {
-        "Integer": {
-          "value": 1234
-        }
-      },
-      "39": {
-        "AnonStruct": {
-          "members": {
-            "x": {
-              "Integer": {
-                "value": 1
+      "26" : {
+        "AnonArray" : {
+          "elements" : [
+            {
+              "Integer" : {
+                "value" : 1
               }
             },
-            "y": {
-              "String": {
-                "value": "abc"
+            {
+              "Integer" : {
+                "value" : 2
               }
-            },
-            "z": {
-              "Boolean": {
-                "value": false
+            }
+          ]
+        }
+      },
+      "50" : {
+        "AnonStruct" : {
+          "members" : {
+            "x" : {
+              "Integer" : {
+                "value" : 3
               }
             }
           }
         }
       },
-      "17": {
-        "AnonArray": {
-          "elements": [
-            {
-              "Integer": {
-                "value": 1
-              }
-            },
-            {
-              "Integer": {
-                "value": 2
-              }
-            }
-          ]
+      "37" : {
+        "Boolean" : {
+          "value" : false
         }
       },
-      "25": {
-        "AnonArray": {
-          "elements": [
-            {
-              "Integer": {
-                "value": 1
-              }
-            },
-            {
-              "Integer": {
-                "value": 2
-              }
-            }
-          ]
+      "68" : {
+        "Boolean" : {
+          "value" : true
         }
       },
-      "60": {
-        "Integer": {
-          "value": 1
+      "61" : {
+        "Integer" : {
+          "value" : 2
         }
       },
-      "14": {
-        "AnonArray": {
-          "elements": [
+      "13" : {
+        "AnonArray" : {
+          "elements" : [
             {
-              "Float": {
-                "value": 1.0,
-                "kind": {
-                  "F64": {}
+              "Float" : {
+                "value" : 1.0,
+                "kind" : {
+                  "F64" : {
+                    
+                  }
                 }
               }
             },
             {
-              "Float": {
-                "value": 2.0,
-                "kind": {
-                  "F64": {}
+              "Float" : {
+                "value" : 2.0,
+                "kind" : {
+                  "F64" : {
+                    
+                  }
                 }
               }
             }
           ]
         }
       },
-      "47": {
-        "AnonStruct": {
-          "members": {
-            "x": {
-              "Integer": {
-                "value": 1
+      "24" : {
+        "Integer" : {
+          "value" : 0
+        }
+      },
+      "35" : {
+        "String" : {
+          "value" : "abc"
+        }
+      },
+      "16" : {
+        "Integer" : {
+          "value" : 2
+        }
+      },
+      "10" : {
+        "AnonArray" : {
+          "elements" : [
+            {
+              "Integer" : {
+                "value" : 1
               }
             },
-            "y": {
-              "Integer": {
-                "value": 2
+            {
+              "Integer" : {
+                "value" : 2
+              }
+            },
+            {
+              "Integer" : {
+                "value" : 3
+              }
+            }
+          ]
+        }
+      },
+      "59" : {
+        "Integer" : {
+          "value" : -1
+        }
+      },
+      "48" : {
+        "Integer" : {
+          "value" : 3
+        }
+      },
+      "21" : {
+        "AnonArray" : {
+          "elements" : [
+            {
+              "AnonArray" : {
+                "elements" : [
+                  {
+                    "Integer" : {
+                      "value" : 1
+                    }
+                  },
+                  {
+                    "Integer" : {
+                      "value" : 2
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "AnonArray" : {
+                "elements" : [
+                  {
+                    "Integer" : {
+                      "value" : 3
+                    }
+                  },
+                  {
+                    "Integer" : {
+                      "value" : 4
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "54" : {
+        "Integer" : {
+          "value" : 1
+        }
+      },
+      "43" : {
+        "Integer" : {
+          "value" : 1
+        }
+      },
+      "65" : {
+        "Integer" : {
+          "value" : 1
+        }
+      },
+      "57" : {
+        "Integer" : {
+          "value" : 1
+        }
+      },
+      "32" : {
+        "Integer" : {
+          "value" : 2
+        }
+      },
+      "6" : {
+        "Integer" : {
+          "value" : 1
+        }
+      },
+      "1" : {
+        "Integer" : {
+          "value" : 1234
+        }
+      },
+      "39" : {
+        "AnonStruct" : {
+          "members" : {
+            "x" : {
+              "Integer" : {
+                "value" : 1
+              }
+            },
+            "y" : {
+              "String" : {
+                "value" : "abc"
+              }
+            },
+            "z" : {
+              "Boolean" : {
+                "value" : false
               }
             }
           }
         }
       },
-      "31": {
-        "Integer": {
-          "value": 2
-        }
-      },
-      "69": {
-        "Boolean": {
-          "value": false
-        }
-      },
-      "58": {
-        "Integer": {
-          "value": -1
-        }
-      },
-      "64": {
-        "Integer": {
-          "value": 1
-        }
-      },
-      "53": {
-        "Integer": {
-          "value": 1
-        }
-      },
-      "0": {
-        "Integer": {
-          "value": 1234
-        }
-      },
-      "20": {
-        "AnonArray": {
-          "elements": [
+      "17" : {
+        "AnonArray" : {
+          "elements" : [
             {
-              "Integer": {
-                "value": 3
+              "Integer" : {
+                "value" : 1
               }
             },
             {
-              "Integer": {
-                "value": 4
+              "Integer" : {
+                "value" : 2
               }
             }
           ]
         }
       },
-      "27": {
-        "AnonArray": {
-          "elements": [
+      "25" : {
+        "AnonArray" : {
+          "elements" : [
             {
-              "AnonArray": {
-                "elements": [
+              "Integer" : {
+                "value" : 1
+              }
+            },
+            {
+              "Integer" : {
+                "value" : 2
+              }
+            }
+          ]
+        }
+      },
+      "60" : {
+        "Integer" : {
+          "value" : 1
+        }
+      },
+      "14" : {
+        "AnonArray" : {
+          "elements" : [
+            {
+              "Float" : {
+                "value" : 1.0,
+                "kind" : {
+                  "F64" : {
+                    
+                  }
+                }
+              }
+            },
+            {
+              "Float" : {
+                "value" : 2.0,
+                "kind" : {
+                  "F64" : {
+                    
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "47" : {
+        "AnonStruct" : {
+          "members" : {
+            "x" : {
+              "Integer" : {
+                "value" : 1
+              }
+            },
+            "y" : {
+              "Integer" : {
+                "value" : 2
+              }
+            }
+          }
+        }
+      },
+      "31" : {
+        "Integer" : {
+          "value" : 2
+        }
+      },
+      "69" : {
+        "Boolean" : {
+          "value" : false
+        }
+      },
+      "58" : {
+        "Integer" : {
+          "value" : -1
+        }
+      },
+      "64" : {
+        "Integer" : {
+          "value" : 1
+        }
+      },
+      "53" : {
+        "Integer" : {
+          "value" : 1
+        }
+      },
+      "0" : {
+        "Integer" : {
+          "value" : 1234
+        }
+      },
+      "20" : {
+        "AnonArray" : {
+          "elements" : [
+            {
+              "Integer" : {
+                "value" : 3
+              }
+            },
+            {
+              "Integer" : {
+                "value" : 4
+              }
+            }
+          ]
+        }
+      },
+      "27" : {
+        "AnonArray" : {
+          "elements" : [
+            {
+              "AnonArray" : {
+                "elements" : [
                   {
-                    "Integer": {
-                      "value": 1
+                    "Integer" : {
+                      "value" : 1
                     }
                   },
                   {
-                    "Integer": {
-                      "value": 2
+                    "Integer" : {
+                      "value" : 2
                     }
                   }
                 ]
               }
             },
             {
-              "AnonArray": {
-                "elements": [
+              "AnonArray" : {
+                "elements" : [
                   {
-                    "Integer": {
-                      "value": 3
+                    "Integer" : {
+                      "value" : 3
                     }
                   },
                   {
-                    "Integer": {
-                      "value": 4
+                    "Integer" : {
+                      "value" : 4
                     }
                   }
                 ]
@@ -1240,60 +1402,67 @@
           ]
         }
       },
-      "70": {
-        "Boolean": {
-          "value": false
+      "70" : {
+        "Boolean" : {
+          "value" : false
         }
       },
-      "30": {
-        "AnonArray": {
-          "elements": [
+      "30" : {
+        "AnonArray" : {
+          "elements" : [
             {
-              "Integer": {
-                "value": 1
+              "Integer" : {
+                "value" : 1
               }
             },
             {
-              "Integer": {
-                "value": 2
+              "Integer" : {
+                "value" : 2
               }
             }
           ]
         }
       },
-      "7": {
-        "Integer": {
-          "value": 2
+      "7" : {
+        "Integer" : {
+          "value" : 2
         }
       },
-      "29": {
-        "Integer": {
-          "value": 1
+      "29" : {
+        "Integer" : {
+          "value" : 1
         }
       },
-      "41": {
-        "AnonStruct": {
-          "members": {}
+      "41" : {
+        "AnonStruct" : {
+          "members" : {
+            
+          }
         }
       },
-      "63": {
-        "Integer": {
-          "value": 3
+      "63" : {
+        "Integer" : {
+          "value" : 3
         }
       },
-      "3": {
-        "Integer": {
-          "value": 43981
+      "3" : {
+        "Integer" : {
+          "value" : 43981
         }
       },
-      "74": {
-        "Integer": {
-          "value": 0
+      "74" : {
+        "Integer" : {
+          "value" : 0
         }
       }
     },
-    "stateMachineMap": {},
-    "dictionarySymbolSet": [],
-    "interfaceMap": {}
+    "stateMachineMap" : {
+      
+    },
+    "dictionarySymbolSet" : [
+    ],
+    "interfaceMap" : {
+      
+    }
   }
 }

--- a/tests/constants/constants_analysis.json
+++ b/tests/constants/constants_analysis.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion": "[ fpp version ]",
+  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
   "analysis": {
     "componentInstanceMap": {},
     "componentMap": {},
@@ -12,12 +12,7 @@
     "symbolScopeMap": {},
     "topologyMap": {},
     "typeMap": {
-      "45": {
-        "Int": {
-          "Integer": {}
-        }
-      },
-      "8": {
+      "33": {
         "Int": {
           "Integer": {}
         }
@@ -28,6 +23,21 @@
         }
       },
       "42": {
+        "AnonStruct": {
+          "members": {}
+        }
+      },
+      "2": {
+        "Int": {
+          "Integer": {}
+        }
+      },
+      "18": {
+        "Int": {
+          "Integer": {}
+        }
+      },
+      "52": {
         "AnonArray": {
           "size": {
             "Some": 2
@@ -50,14 +60,19 @@
           }
         }
       },
-      "18": {
+      "28": {
         "Int": {
           "Integer": {}
         }
       },
-      "52": {
+      "45": {
         "Int": {
           "Integer": {}
+        }
+      },
+      "67": {
+        "Primitive": {
+          "Boolean": {}
         }
       },
       "12": {
@@ -69,7 +84,40 @@
           }
         }
       },
+      "66": {
+        "Int": {
+          "Integer": {}
+        }
+      },
       "51": {
+        "AnonArray": {
+          "size": {
+            "Some": 2
+          },
+          "eltType": {
+            "AnonStruct": {
+              "members": {
+                "x": {
+                  "Int": {
+                    "Integer": {}
+                  }
+                },
+                "y": {
+                  "Int": {
+                    "Integer": {}
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "8": {
+        "Int": {
+          "Integer": {}
+        }
+      },
+      "73": {
         "Int": {
           "Integer": {}
         }
@@ -80,6 +128,25 @@
         }
       },
       "23": {
+        "AnonArray": {
+          "size": {
+            "Some": 2
+          },
+          "eltType": {
+            "AnonArray": {
+              "size": {
+                "Some": 2
+              },
+              "eltType": {
+                "Int": {
+                  "Integer": {}
+                }
+              }
+            }
+          }
+        }
+      },
+      "62": {
         "Int": {
           "Integer": {}
         }
@@ -95,6 +162,16 @@
             "x": {
               "Int": {
                 "Integer": {}
+              }
+            },
+            "y": {
+              "String": {
+                "size": "None"
+              }
+            },
+            "z": {
+              "Primitive": {
+                "Boolean": {}
               }
             }
           }
@@ -120,16 +197,6 @@
               "Integer": {}
             }
           }
-        }
-      },
-      "44": {
-        "Int": {
-          "Integer": {}
-        }
-      },
-      "33": {
-        "Int": {
-          "Integer": {}
         }
       },
       "22": {
@@ -161,25 +228,42 @@
           "Integer": {}
         }
       },
-      "50": {
-        "Int": {
-          "Integer": {}
+      "26": {
+        "AnonArray": {
+          "size": {
+            "Some": 2
+          },
+          "eltType": {
+            "Int": {
+              "Integer": {}
+            }
+          }
         }
       },
-      "37": {
+      "50": {
         "AnonStruct": {
           "members": {
             "x": {
               "Int": {
                 "Integer": {}
               }
-            },
-            "y": {
-              "Int": {
-                "Integer": {}
-              }
             }
           }
+        }
+      },
+      "37": {
+        "Primitive": {
+          "Boolean": {}
+        }
+      },
+      "68": {
+        "Primitive": {
+          "Boolean": {}
+        }
+      },
+      "61": {
+        "Int": {
+          "Integer": {}
         }
       },
       "13": {
@@ -198,14 +282,14 @@
           }
         }
       },
-      "46": {
+      "24": {
         "Int": {
           "Integer": {}
         }
       },
       "35": {
-        "Int": {
-          "Integer": {}
+        "String": {
+          "size": "None"
         }
       },
       "16": {
@@ -226,8 +310,8 @@
         }
       },
       "59": {
-        "Primitive": {
-          "Boolean": {}
+        "Int": {
+          "Integer": {}
         }
       },
       "48": {
@@ -264,17 +348,17 @@
           "Integer": {}
         }
       },
+      "65": {
+        "Int": {
+          "Integer": {}
+        }
+      },
       "57": {
-        "Primitive": {
-          "Boolean": {}
+        "Int": {
+          "Integer": {}
         }
       },
       "32": {
-        "AnonStruct": {
-          "members": {}
-        }
-      },
-      "49": {
         "Int": {
           "Integer": {}
         }
@@ -287,6 +371,27 @@
       "1": {
         "Int": {
           "Integer": {}
+        }
+      },
+      "39": {
+        "AnonStruct": {
+          "members": {
+            "x": {
+              "Int": {
+                "Integer": {}
+              }
+            },
+            "y": {
+              "String": {
+                "size": "None"
+              }
+            },
+            "z": {
+              "Primitive": {
+                "Boolean": {}
+              }
+            }
+          }
         }
       },
       "17": {
@@ -302,13 +407,20 @@
         }
       },
       "25": {
-        "String": {
-          "size": "None"
+        "AnonArray": {
+          "size": {
+            "Some": 2
+          },
+          "eltType": {
+            "Int": {
+              "Integer": {}
+            }
+          }
         }
       },
       "60": {
-        "Primitive": {
-          "Boolean": {}
+        "Int": {
+          "Integer": {}
         }
       },
       "14": {
@@ -328,18 +440,34 @@
         }
       },
       "47": {
+        "AnonStruct": {
+          "members": {
+            "x": {
+              "Int": {
+                "Integer": {}
+              }
+            },
+            "y": {
+              "Int": {
+                "Integer": {}
+              }
+            }
+          }
+        }
+      },
+      "31": {
         "Int": {
           "Integer": {}
         }
       },
-      "31": {
-        "AnonStruct": {
-          "members": {}
+      "69": {
+        "Primitive": {
+          "Boolean": {}
         }
       },
       "58": {
-        "Primitive": {
-          "Boolean": {}
+        "Int": {
+          "Integer": {}
         }
       },
       "64": {
@@ -370,37 +498,37 @@
         }
       },
       "27": {
+        "AnonArray": {
+          "size": {
+            "Some": 2
+          },
+          "eltType": {
+            "AnonArray": {
+              "size": {
+                "Some": 2
+              },
+              "eltType": {
+                "Int": {
+                  "Integer": {}
+                }
+              }
+            }
+          }
+        }
+      },
+      "70": {
         "Primitive": {
           "Boolean": {}
         }
       },
-      "2": {
-        "Int": {
-          "Integer": {}
-        }
-      },
-      "38": {
-        "Int": {
-          "Integer": {}
-        }
-      },
       "30": {
-        "AnonStruct": {
-          "members": {
-            "x": {
-              "Int": {
-                "Integer": {}
-              }
-            },
-            "y": {
-              "String": {
-                "size": "None"
-              }
-            },
-            "z": {
-              "Primitive": {
-                "Boolean": {}
-              }
+        "AnonArray": {
+          "size": {
+            "Some": 2
+          },
+          "eltType": {
+            "Int": {
+              "Integer": {}
             }
           }
         }
@@ -411,47 +539,13 @@
         }
       },
       "29": {
-        "AnonStruct": {
-          "members": {
-            "x": {
-              "Int": {
-                "Integer": {}
-              }
-            },
-            "y": {
-              "String": {
-                "size": "None"
-              }
-            },
-            "z": {
-              "Primitive": {
-                "Boolean": {}
-              }
-            }
-          }
+        "Int": {
+          "Integer": {}
         }
       },
       "41": {
-        "AnonArray": {
-          "size": {
-            "Some": 2
-          },
-          "eltType": {
-            "AnonStruct": {
-              "members": {
-                "x": {
-                  "Int": {
-                    "Integer": {}
-                  }
-                },
-                "y": {
-                  "Int": {
-                    "Integer": {}
-                  }
-                }
-              }
-            }
-          }
+        "AnonStruct": {
+          "members": {}
         }
       },
       "63": {
@@ -463,25 +557,37 @@
         "Int": {
           "Integer": {}
         }
+      },
+      "74": {
+        "Int": {
+          "Integer": {}
+        }
       }
     },
     "useDefMap": {
-      "45": {
+      "23": {
         "Constant": {
-          "nodeId": 44,
-          "unqualifiedName": "j"
+          "nodeId": 22,
+          "unqualifiedName": "f"
+        }
+      },
+      "27": {
+        "Constant": {
+          "nodeId": 22,
+          "unqualifiedName": "f"
+        }
+      },
+      "55": {
+        "Constant": {
+          "nodeId": 54,
+          "unqualifiedName": "l"
         }
       }
     },
     "valueMap": {
-      "45": {
+      "33": {
         "Integer": {
           "value": 1
-        }
-      },
-      "8": {
-        "Integer": {
-          "value": 3
         }
       },
       "5": {
@@ -490,6 +596,21 @@
         }
       },
       "42": {
+        "AnonStruct": {
+          "members": {}
+        }
+      },
+      "2": {
+        "Integer": {
+          "value": 43981
+        }
+      },
+      "18": {
+        "Integer": {
+          "value": 3
+        }
+      },
+      "52": {
         "AnonArray": {
           "elements": [
             {
@@ -527,14 +648,19 @@
           ]
         }
       },
-      "18": {
+      "28": {
         "Integer": {
-          "value": 3
+          "value": 0
         }
       },
-      "52": {
+      "45": {
         "Integer": {
-          "value": 3
+          "value": 2
+        }
+      },
+      "67": {
+        "Boolean": {
+          "value": true
         }
       },
       "12": {
@@ -545,9 +671,57 @@
           }
         }
       },
-      "51": {
+      "66": {
         "Integer": {
-          "value": 2
+          "value": 1
+        }
+      },
+      "51": {
+        "AnonArray": {
+          "elements": [
+            {
+              "AnonStruct": {
+                "members": {
+                  "x": {
+                    "Integer": {
+                      "value": 1
+                    }
+                  },
+                  "y": {
+                    "Integer": {
+                      "value": 2
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "AnonStruct": {
+                "members": {
+                  "x": {
+                    "Integer": {
+                      "value": 3
+                    }
+                  },
+                  "y": {
+                    "Integer": {
+                      "value": 0
+                    }
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "8": {
+        "Integer": {
+          "value": 3
+        }
+      },
+      "73": {
+        "Integer": {
+          "value": 0
         }
       },
       "19": {
@@ -556,8 +730,46 @@
         }
       },
       "23": {
+        "AnonArray": {
+          "elements": [
+            {
+              "AnonArray": {
+                "elements": [
+                  {
+                    "Integer": {
+                      "value": 1
+                    }
+                  },
+                  {
+                    "Integer": {
+                      "value": 2
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "AnonArray": {
+                "elements": [
+                  {
+                    "Integer": {
+                      "value": 3
+                    }
+                  },
+                  {
+                    "Integer": {
+                      "value": 4
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "62": {
         "Integer": {
-          "value": 1
+          "value": 3
         }
       },
       "4": {
@@ -570,7 +782,17 @@
           "members": {
             "x": {
               "Integer": {
-                "value": 3
+                "value": 1
+              }
+            },
+            "y": {
+              "String": {
+                "value": "abc"
+              }
+            },
+            "z": {
+              "Boolean": {
+                "value": false
               }
             }
           }
@@ -605,16 +827,6 @@
               }
             }
           ]
-        }
-      },
-      "44": {
-        "Integer": {
-          "value": 1
-        }
-      },
-      "33": {
-        "Integer": {
-          "value": 1
         }
       },
       "22": {
@@ -665,25 +877,46 @@
           "value": 1
         }
       },
-      "50": {
-        "Integer": {
-          "value": 1
-        }
-      },
-      "37": {
-        "AnonStruct": {
-          "members": {
-            "x": {
+      "26": {
+        "AnonArray": {
+          "elements": [
+            {
               "Integer": {
                 "value": 1
               }
             },
-            "y": {
+            {
               "Integer": {
                 "value": 2
               }
             }
+          ]
+        }
+      },
+      "50": {
+        "AnonStruct": {
+          "members": {
+            "x": {
+              "Integer": {
+                "value": 3
+              }
+            }
           }
+        }
+      },
+      "37": {
+        "Boolean": {
+          "value": false
+        }
+      },
+      "68": {
+        "Boolean": {
+          "value": true
+        }
+      },
+      "61": {
+        "Integer": {
+          "value": 2
         }
       },
       "13": {
@@ -708,14 +941,14 @@
           ]
         }
       },
-      "46": {
+      "24": {
         "Integer": {
-          "value": 1
+          "value": 0
         }
       },
       "35": {
-        "Integer": {
-          "value": 2
+        "String": {
+          "value": "abc"
         }
       },
       "16": {
@@ -745,13 +978,13 @@
         }
       },
       "59": {
-        "Boolean": {
-          "value": false
+        "Integer": {
+          "value": -1
         }
       },
       "48": {
         "Integer": {
-          "value": -1
+          "value": 3
         }
       },
       "21": {
@@ -802,19 +1035,19 @@
           "value": 1
         }
       },
+      "65": {
+        "Integer": {
+          "value": 1
+        }
+      },
       "57": {
-        "Boolean": {
-          "value": true
+        "Integer": {
+          "value": 1
         }
       },
       "32": {
-        "AnonStruct": {
-          "members": {}
-        }
-      },
-      "49": {
         "Integer": {
-          "value": -1
+          "value": 2
         }
       },
       "6": {
@@ -825,6 +1058,27 @@
       "1": {
         "Integer": {
           "value": 1234
+        }
+      },
+      "39": {
+        "AnonStruct": {
+          "members": {
+            "x": {
+              "Integer": {
+                "value": 1
+              }
+            },
+            "y": {
+              "String": {
+                "value": "abc"
+              }
+            },
+            "z": {
+              "Boolean": {
+                "value": false
+              }
+            }
+          }
         }
       },
       "17": {
@@ -844,13 +1098,24 @@
         }
       },
       "25": {
-        "String": {
-          "value": "abc"
+        "AnonArray": {
+          "elements": [
+            {
+              "Integer": {
+                "value": 1
+              }
+            },
+            {
+              "Integer": {
+                "value": 2
+              }
+            }
+          ]
         }
       },
       "60": {
-        "Boolean": {
-          "value": false
+        "Integer": {
+          "value": 1
         }
       },
       "14": {
@@ -876,28 +1141,44 @@
         }
       },
       "47": {
-        "Integer": {
-          "value": 1
+        "AnonStruct": {
+          "members": {
+            "x": {
+              "Integer": {
+                "value": 1
+              }
+            },
+            "y": {
+              "Integer": {
+                "value": 2
+              }
+            }
+          }
         }
       },
       "31": {
-        "AnonStruct": {
-          "members": {}
+        "Integer": {
+          "value": 2
+        }
+      },
+      "69": {
+        "Boolean": {
+          "value": false
         }
       },
       "58": {
-        "Boolean": {
-          "value": true
+        "Integer": {
+          "value": -1
         }
       },
       "64": {
         "Integer": {
-          "value": 0
+          "value": 1
         }
       },
       "53": {
         "Integer": {
-          "value": 3
+          "value": 1
         }
       },
       "0": {
@@ -922,39 +1203,62 @@
         }
       },
       "27": {
+        "AnonArray": {
+          "elements": [
+            {
+              "AnonArray": {
+                "elements": [
+                  {
+                    "Integer": {
+                      "value": 1
+                    }
+                  },
+                  {
+                    "Integer": {
+                      "value": 2
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "AnonArray": {
+                "elements": [
+                  {
+                    "Integer": {
+                      "value": 3
+                    }
+                  },
+                  {
+                    "Integer": {
+                      "value": 4
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "70": {
         "Boolean": {
           "value": false
         }
       },
-      "2": {
-        "Integer": {
-          "value": 43981
-        }
-      },
-      "38": {
-        "Integer": {
-          "value": 3
-        }
-      },
       "30": {
-        "AnonStruct": {
-          "members": {
-            "x": {
+        "AnonArray": {
+          "elements": [
+            {
               "Integer": {
                 "value": 1
               }
             },
-            "y": {
-              "String": {
-                "value": "abc"
-              }
-            },
-            "z": {
-              "Boolean": {
-                "value": false
+            {
+              "Integer": {
+                "value": 2
               }
             }
-          }
+          ]
         }
       },
       "7": {
@@ -963,76 +1267,33 @@
         }
       },
       "29": {
-        "AnonStruct": {
-          "members": {
-            "x": {
-              "Integer": {
-                "value": 1
-              }
-            },
-            "y": {
-              "String": {
-                "value": "abc"
-              }
-            },
-            "z": {
-              "Boolean": {
-                "value": false
-              }
-            }
-          }
+        "Integer": {
+          "value": 1
         }
       },
       "41": {
-        "AnonArray": {
-          "elements": [
-            {
-              "AnonStruct": {
-                "members": {
-                  "x": {
-                    "Integer": {
-                      "value": 1
-                    }
-                  },
-                  "y": {
-                    "Integer": {
-                      "value": 2
-                    }
-                  }
-                }
-              }
-            },
-            {
-              "AnonStruct": {
-                "members": {
-                  "x": {
-                    "Integer": {
-                      "value": 3
-                    }
-                  },
-                  "y": {
-                    "Integer": {
-                      "value": 0
-                    }
-                  }
-                }
-              }
-            }
-          ]
+        "AnonStruct": {
+          "members": {}
         }
       },
       "63": {
         "Integer": {
-          "value": 0
+          "value": 3
         }
       },
       "3": {
         "Integer": {
           "value": 43981
         }
+      },
+      "74": {
+        "Integer": {
+          "value": 0
+        }
       }
     },
     "stateMachineMap": {},
+    "dictionarySymbolSet": [],
     "interfaceMap": {}
   }
 }

--- a/tests/constants/constants_ast.json
+++ b/tests/constants/constants_ast.json
@@ -1,873 +1,926 @@
 {
-  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
-  "ast": [
+  "fppVersion" : "v3.1.0a10-54-g11243e778",
+  "ast" : [
     {
-      "members": [
+      "members" : [
         [
-          [],
+          [
+          ],
           {
-            "DefConstant": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "a",
-                    "value": {
-                      "AstNode": {
-                        "data": {
-                          "ExprLiteralInt": {
-                            "value": "1234"
+            "DefConstant" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "a",
+                    "value" : {
+                      "AstNode" : {
+                        "data" : {
+                          "ExprLiteralInt" : {
+                            "value" : "1234"
                           }
                         },
-                        "id": 0
+                        "id" : 0
                       }
                     },
-                    "isDictionaryDef": false
+                    "isDictionaryDef" : false
                   },
-                  "id": 1
+                  "id" : 1
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          [],
+          [
+          ],
           {
-            "DefConstant": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "b",
-                    "value": {
-                      "AstNode": {
-                        "data": {
-                          "ExprLiteralInt": {
-                            "value": "0xABCD"
+            "DefConstant" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "b",
+                    "value" : {
+                      "AstNode" : {
+                        "data" : {
+                          "ExprLiteralInt" : {
+                            "value" : "0xABCD"
                           }
                         },
-                        "id": 2
+                        "id" : 2
                       }
                     },
-                    "isDictionaryDef": false
+                    "isDictionaryDef" : false
                   },
-                  "id": 3
+                  "id" : 3
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          [],
+          [
+          ],
           {
-            "DefConstant": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "c",
-                    "value": {
-                      "AstNode": {
-                        "data": {
-                          "ExprLiteralString": {
-                            "value": "This is a string."
+            "DefConstant" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "c",
+                    "value" : {
+                      "AstNode" : {
+                        "data" : {
+                          "ExprLiteralString" : {
+                            "value" : "This is a string."
                           }
                         },
-                        "id": 4
+                        "id" : 4
                       }
                     },
-                    "isDictionaryDef": false
+                    "isDictionaryDef" : false
                   },
-                  "id": 5
+                  "id" : 5
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          [],
+          [
+          ],
           {
-            "DefConstant": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "d",
-                    "value": {
-                      "AstNode": {
-                        "data": {
-                          "ExprArray": {
-                            "elts": [
+            "DefConstant" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "d",
+                    "value" : {
+                      "AstNode" : {
+                        "data" : {
+                          "ExprArray" : {
+                            "elts" : [
                               {
-                                "AstNode": {
-                                  "data": {
-                                    "ExprLiteralInt": {
-                                      "value": "1"
+                                "AstNode" : {
+                                  "data" : {
+                                    "ExprLiteralInt" : {
+                                      "value" : "1"
                                     }
                                   },
-                                  "id": 6
+                                  "id" : 6
                                 }
                               },
                               {
-                                "AstNode": {
-                                  "data": {
-                                    "ExprLiteralInt": {
-                                      "value": "2"
+                                "AstNode" : {
+                                  "data" : {
+                                    "ExprLiteralInt" : {
+                                      "value" : "2"
                                     }
                                   },
-                                  "id": 7
+                                  "id" : 7
                                 }
                               },
                               {
-                                "AstNode": {
-                                  "data": {
-                                    "ExprLiteralInt": {
-                                      "value": "3"
+                                "AstNode" : {
+                                  "data" : {
+                                    "ExprLiteralInt" : {
+                                      "value" : "3"
                                     }
                                   },
-                                  "id": 8
+                                  "id" : 8
                                 }
                               }
                             ]
                           }
                         },
-                        "id": 9
+                        "id" : 9
                       }
                     },
-                    "isDictionaryDef": false
+                    "isDictionaryDef" : false
                   },
-                  "id": 10
+                  "id" : 10
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          [],
+          [
+          ],
           {
-            "DefConstant": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "e",
-                    "value": {
-                      "AstNode": {
-                        "data": {
-                          "ExprArray": {
-                            "elts": [
+            "DefConstant" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "e",
+                    "value" : {
+                      "AstNode" : {
+                        "data" : {
+                          "ExprArray" : {
+                            "elts" : [
                               {
-                                "AstNode": {
-                                  "data": {
-                                    "ExprLiteralInt": {
-                                      "value": "1"
+                                "AstNode" : {
+                                  "data" : {
+                                    "ExprLiteralInt" : {
+                                      "value" : "1"
                                     }
                                   },
-                                  "id": 11
+                                  "id" : 11
                                 }
                               },
                               {
-                                "AstNode": {
-                                  "data": {
-                                    "ExprLiteralFloat": {
-                                      "value": "2.0"
+                                "AstNode" : {
+                                  "data" : {
+                                    "ExprLiteralFloat" : {
+                                      "value" : "2.0"
                                     }
                                   },
-                                  "id": 12
+                                  "id" : 12
                                 }
                               }
                             ]
                           }
                         },
-                        "id": 13
+                        "id" : 13
                       }
                     },
-                    "isDictionaryDef": false
+                    "isDictionaryDef" : false
                   },
-                  "id": 14
+                  "id" : 14
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          [],
+          [
+          ],
           {
-            "DefConstant": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "f",
-                    "value": {
-                      "AstNode": {
-                        "data": {
-                          "ExprArray": {
-                            "elts": [
+            "DefConstant" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "f",
+                    "value" : {
+                      "AstNode" : {
+                        "data" : {
+                          "ExprArray" : {
+                            "elts" : [
                               {
-                                "AstNode": {
-                                  "data": {
-                                    "ExprArray": {
-                                      "elts": [
+                                "AstNode" : {
+                                  "data" : {
+                                    "ExprArray" : {
+                                      "elts" : [
                                         {
-                                          "AstNode": {
-                                            "data": {
-                                              "ExprLiteralInt": {
-                                                "value": "1"
+                                          "AstNode" : {
+                                            "data" : {
+                                              "ExprLiteralInt" : {
+                                                "value" : "1"
                                               }
                                             },
-                                            "id": 15
+                                            "id" : 15
                                           }
                                         },
                                         {
-                                          "AstNode": {
-                                            "data": {
-                                              "ExprLiteralInt": {
-                                                "value": "2"
+                                          "AstNode" : {
+                                            "data" : {
+                                              "ExprLiteralInt" : {
+                                                "value" : "2"
                                               }
                                             },
-                                            "id": 16
+                                            "id" : 16
                                           }
                                         }
                                       ]
                                     }
                                   },
-                                  "id": 17
+                                  "id" : 17
                                 }
                               },
                               {
-                                "AstNode": {
-                                  "data": {
-                                    "ExprArray": {
-                                      "elts": [
+                                "AstNode" : {
+                                  "data" : {
+                                    "ExprArray" : {
+                                      "elts" : [
                                         {
-                                          "AstNode": {
-                                            "data": {
-                                              "ExprLiteralInt": {
-                                                "value": "3"
+                                          "AstNode" : {
+                                            "data" : {
+                                              "ExprLiteralInt" : {
+                                                "value" : "3"
                                               }
                                             },
-                                            "id": 18
+                                            "id" : 18
                                           }
                                         },
                                         {
-                                          "AstNode": {
-                                            "data": {
-                                              "ExprLiteralInt": {
-                                                "value": "4"
+                                          "AstNode" : {
+                                            "data" : {
+                                              "ExprLiteralInt" : {
+                                                "value" : "4"
                                               }
                                             },
-                                            "id": 19
+                                            "id" : 19
                                           }
                                         }
                                       ]
                                     }
                                   },
-                                  "id": 20
+                                  "id" : 20
                                 }
                               }
                             ]
                           }
                         },
-                        "id": 21
+                        "id" : 21
                       }
                     },
-                    "isDictionaryDef": false
+                    "isDictionaryDef" : false
                   },
-                  "id": 22
+                  "id" : 22
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          [],
+          [
+          ],
           {
-            "DefConstant": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "g",
-                    "value": {
-                      "AstNode": {
-                        "data": {
-                          "ExprArraySubscript": {
-                            "e1": {
-                              "AstNode": {
-                                "data": {
-                                  "ExprIdent": {
-                                    "value": "f"
+            "DefConstant" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "g",
+                    "value" : {
+                      "AstNode" : {
+                        "data" : {
+                          "ExprArraySubscript" : {
+                            "e1" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "ExprIdent" : {
+                                    "value" : "f"
                                   }
                                 },
-                                "id": 23
+                                "id" : 23
                               }
                             },
-                            "e2": {
-                              "AstNode": {
-                                "data": {
-                                  "ExprLiteralInt": {
-                                    "value": "0"
+                            "e2" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "ExprLiteralInt" : {
+                                    "value" : "0"
                                   }
                                 },
-                                "id": 24
+                                "id" : 24
                               }
                             }
                           }
                         },
-                        "id": 25
+                        "id" : 25
                       }
                     },
-                    "isDictionaryDef": false
+                    "isDictionaryDef" : false
                   },
-                  "id": 26
+                  "id" : 26
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          [],
+          [
+          ],
           {
-            "DefConstant": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "h",
-                    "value": {
-                      "AstNode": {
-                        "data": {
-                          "ExprArraySubscript": {
-                            "e1": {
-                              "AstNode": {
-                                "data": {
-                                  "ExprArraySubscript": {
-                                    "e1": {
-                                      "AstNode": {
-                                        "data": {
-                                          "ExprIdent": {
-                                            "value": "f"
+            "DefConstant" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "h",
+                    "value" : {
+                      "AstNode" : {
+                        "data" : {
+                          "ExprArraySubscript" : {
+                            "e1" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "ExprArraySubscript" : {
+                                    "e1" : {
+                                      "AstNode" : {
+                                        "data" : {
+                                          "ExprIdent" : {
+                                            "value" : "f"
                                           }
                                         },
-                                        "id": 27
+                                        "id" : 27
                                       }
                                     },
-                                    "e2": {
-                                      "AstNode": {
-                                        "data": {
-                                          "ExprLiteralInt": {
-                                            "value": "0"
+                                    "e2" : {
+                                      "AstNode" : {
+                                        "data" : {
+                                          "ExprLiteralInt" : {
+                                            "value" : "0"
                                           }
                                         },
-                                        "id": 28
+                                        "id" : 28
                                       }
                                     }
                                   }
                                 },
-                                "id": 30
+                                "id" : 30
                               }
                             },
-                            "e2": {
-                              "AstNode": {
-                                "data": {
-                                  "ExprLiteralInt": {
-                                    "value": "1"
+                            "e2" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "ExprLiteralInt" : {
+                                    "value" : "1"
                                   }
                                 },
-                                "id": 29
+                                "id" : 29
                               }
                             }
                           }
                         },
-                        "id": 31
+                        "id" : 31
                       }
                     },
-                    "isDictionaryDef": false
+                    "isDictionaryDef" : false
                   },
-                  "id": 32
+                  "id" : 32
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          [],
+          [
+          ],
           {
-            "DefConstant": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "i",
-                    "value": {
-                      "AstNode": {
-                        "data": {
-                          "ExprStruct": {
-                            "members": [
+            "DefConstant" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "i",
+                    "value" : {
+                      "AstNode" : {
+                        "data" : {
+                          "ExprStruct" : {
+                            "members" : [
                               {
-                                "AstNode": {
-                                  "data": {
-                                    "name": "x",
-                                    "value": {
-                                      "AstNode": {
-                                        "data": {
-                                          "ExprLiteralInt": {
-                                            "value": "1"
+                                "AstNode" : {
+                                  "data" : {
+                                    "name" : "x",
+                                    "value" : {
+                                      "AstNode" : {
+                                        "data" : {
+                                          "ExprLiteralInt" : {
+                                            "value" : "1"
                                           }
                                         },
-                                        "id": 33
+                                        "id" : 33
                                       }
                                     }
                                   },
-                                  "id": 34
+                                  "id" : 34
                                 }
                               },
                               {
-                                "AstNode": {
-                                  "data": {
-                                    "name": "y",
-                                    "value": {
-                                      "AstNode": {
-                                        "data": {
-                                          "ExprLiteralString": {
-                                            "value": "abc"
+                                "AstNode" : {
+                                  "data" : {
+                                    "name" : "y",
+                                    "value" : {
+                                      "AstNode" : {
+                                        "data" : {
+                                          "ExprLiteralString" : {
+                                            "value" : "abc"
                                           }
                                         },
-                                        "id": 35
+                                        "id" : 35
                                       }
                                     }
                                   },
-                                  "id": 36
+                                  "id" : 36
                                 }
                               },
                               {
-                                "AstNode": {
-                                  "data": {
-                                    "name": "z",
-                                    "value": {
-                                      "AstNode": {
-                                        "data": {
-                                          "ExprLiteralBool": {
-                                            "value": {
-                                              "False": {}
+                                "AstNode" : {
+                                  "data" : {
+                                    "name" : "z",
+                                    "value" : {
+                                      "AstNode" : {
+                                        "data" : {
+                                          "ExprLiteralBool" : {
+                                            "value" : {
+                                              "False" : {
+                                                
+                                              }
                                             }
                                           }
                                         },
-                                        "id": 37
+                                        "id" : 37
                                       }
                                     }
                                   },
-                                  "id": 38
+                                  "id" : 38
                                 }
                               }
                             ]
                           }
                         },
-                        "id": 39
+                        "id" : 39
                       }
                     },
-                    "isDictionaryDef": false
+                    "isDictionaryDef" : false
                   },
-                  "id": 40
+                  "id" : 40
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          [],
+          [
+          ],
           {
-            "DefConstant": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "j",
-                    "value": {
-                      "AstNode": {
-                        "data": {
-                          "ExprStruct": {
-                            "members": []
+            "DefConstant" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "j",
+                    "value" : {
+                      "AstNode" : {
+                        "data" : {
+                          "ExprStruct" : {
+                            "members" : [
+                            ]
                           }
                         },
-                        "id": 41
+                        "id" : 41
                       }
                     },
-                    "isDictionaryDef": false
+                    "isDictionaryDef" : false
                   },
-                  "id": 42
+                  "id" : 42
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          [],
+          [
+          ],
           {
-            "DefConstant": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "k",
-                    "value": {
-                      "AstNode": {
-                        "data": {
-                          "ExprArray": {
-                            "elts": [
+            "DefConstant" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "k",
+                    "value" : {
+                      "AstNode" : {
+                        "data" : {
+                          "ExprArray" : {
+                            "elts" : [
                               {
-                                "AstNode": {
-                                  "data": {
-                                    "ExprStruct": {
-                                      "members": [
+                                "AstNode" : {
+                                  "data" : {
+                                    "ExprStruct" : {
+                                      "members" : [
                                         {
-                                          "AstNode": {
-                                            "data": {
-                                              "name": "x",
-                                              "value": {
-                                                "AstNode": {
-                                                  "data": {
-                                                    "ExprLiteralInt": {
-                                                      "value": "1"
+                                          "AstNode" : {
+                                            "data" : {
+                                              "name" : "x",
+                                              "value" : {
+                                                "AstNode" : {
+                                                  "data" : {
+                                                    "ExprLiteralInt" : {
+                                                      "value" : "1"
                                                     }
                                                   },
-                                                  "id": 43
+                                                  "id" : 43
                                                 }
                                               }
                                             },
-                                            "id": 44
+                                            "id" : 44
                                           }
                                         },
                                         {
-                                          "AstNode": {
-                                            "data": {
-                                              "name": "y",
-                                              "value": {
-                                                "AstNode": {
-                                                  "data": {
-                                                    "ExprLiteralInt": {
-                                                      "value": "2"
+                                          "AstNode" : {
+                                            "data" : {
+                                              "name" : "y",
+                                              "value" : {
+                                                "AstNode" : {
+                                                  "data" : {
+                                                    "ExprLiteralInt" : {
+                                                      "value" : "2"
                                                     }
                                                   },
-                                                  "id": 45
+                                                  "id" : 45
                                                 }
                                               }
                                             },
-                                            "id": 46
+                                            "id" : 46
                                           }
                                         }
                                       ]
                                     }
                                   },
-                                  "id": 47
+                                  "id" : 47
                                 }
                               },
                               {
-                                "AstNode": {
-                                  "data": {
-                                    "ExprStruct": {
-                                      "members": [
+                                "AstNode" : {
+                                  "data" : {
+                                    "ExprStruct" : {
+                                      "members" : [
                                         {
-                                          "AstNode": {
-                                            "data": {
-                                              "name": "x",
-                                              "value": {
-                                                "AstNode": {
-                                                  "data": {
-                                                    "ExprLiteralInt": {
-                                                      "value": "3"
+                                          "AstNode" : {
+                                            "data" : {
+                                              "name" : "x",
+                                              "value" : {
+                                                "AstNode" : {
+                                                  "data" : {
+                                                    "ExprLiteralInt" : {
+                                                      "value" : "3"
                                                     }
                                                   },
-                                                  "id": 48
+                                                  "id" : 48
                                                 }
                                               }
                                             },
-                                            "id": 49
+                                            "id" : 49
                                           }
                                         }
                                       ]
                                     }
                                   },
-                                  "id": 50
+                                  "id" : 50
                                 }
                               }
                             ]
                           }
                         },
-                        "id": 51
+                        "id" : 51
                       }
                     },
-                    "isDictionaryDef": false
+                    "isDictionaryDef" : false
                   },
-                  "id": 52
+                  "id" : 52
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          [],
+          [
+          ],
           {
-            "DefConstant": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "l",
-                    "value": {
-                      "AstNode": {
-                        "data": {
-                          "ExprLiteralInt": {
-                            "value": "1"
+            "DefConstant" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "l",
+                    "value" : {
+                      "AstNode" : {
+                        "data" : {
+                          "ExprLiteralInt" : {
+                            "value" : "1"
                           }
                         },
-                        "id": 53
+                        "id" : 53
                       }
                     },
-                    "isDictionaryDef": false
+                    "isDictionaryDef" : false
                   },
-                  "id": 54
+                  "id" : 54
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          [],
+          [
+          ],
           {
-            "DefConstant": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "m",
-                    "value": {
-                      "AstNode": {
-                        "data": {
-                          "ExprIdent": {
-                            "value": "l"
+            "DefConstant" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "m",
+                    "value" : {
+                      "AstNode" : {
+                        "data" : {
+                          "ExprIdent" : {
+                            "value" : "l"
                           }
                         },
-                        "id": 55
+                        "id" : 55
                       }
                     },
-                    "isDictionaryDef": false
+                    "isDictionaryDef" : false
                   },
-                  "id": 56
+                  "id" : 56
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          [],
+          [
+          ],
           {
-            "DefConstant": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "n",
-                    "value": {
-                      "AstNode": {
-                        "data": {
-                          "ExprUnop": {
-                            "op": {
-                              "Minus": {}
-                            },
-                            "e": {
-                              "AstNode": {
-                                "data": {
-                                  "ExprLiteralInt": {
-                                    "value": "1"
-                                  }
-                                },
-                                "id": 57
-                              }
-                            }
-                          }
-                        },
-                        "id": 58
-                      }
-                    },
-                    "isDictionaryDef": false
-                  },
-                  "id": 59
-                }
-              }
-            }
-          },
-          []
-        ],
-        [
-          [],
-          {
-            "DefConstant": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "o",
-                    "value": {
-                      "AstNode": {
-                        "data": {
-                          "ExprBinop": {
-                            "e1": {
-                              "AstNode": {
-                                "data": {
-                                  "ExprLiteralInt": {
-                                    "value": "1"
-                                  }
-                                },
-                                "id": 60
+            "DefConstant" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "n",
+                    "value" : {
+                      "AstNode" : {
+                        "data" : {
+                          "ExprUnop" : {
+                            "op" : {
+                              "Minus" : {
+                                
                               }
                             },
-                            "op": {
-                              "Add": {}
+                            "e" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "ExprLiteralInt" : {
+                                    "value" : "1"
+                                  }
+                                },
+                                "id" : 57
+                              }
+                            }
+                          }
+                        },
+                        "id" : 58
+                      }
+                    },
+                    "isDictionaryDef" : false
+                  },
+                  "id" : 59
+                }
+              }
+            }
+          },
+          [
+          ]
+        ],
+        [
+          [
+          ],
+          {
+            "DefConstant" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "o",
+                    "value" : {
+                      "AstNode" : {
+                        "data" : {
+                          "ExprBinop" : {
+                            "e1" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "ExprLiteralInt" : {
+                                    "value" : "1"
+                                  }
+                                },
+                                "id" : 60
+                              }
                             },
-                            "e2": {
-                              "AstNode": {
-                                "data": {
-                                  "ExprLiteralInt": {
-                                    "value": "2"
+                            "op" : {
+                              "Add" : {
+                                
+                              }
+                            },
+                            "e2" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "ExprLiteralInt" : {
+                                    "value" : "2"
                                   }
                                 },
-                                "id": 61
+                                "id" : 61
                               }
                             }
                           }
                         },
-                        "id": 62
+                        "id" : 62
                       }
                     },
-                    "isDictionaryDef": false
+                    "isDictionaryDef" : false
                   },
-                  "id": 63
+                  "id" : 63
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          [],
+          [
+          ],
           {
-            "DefConstant": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "p",
-                    "value": {
-                      "AstNode": {
-                        "data": {
-                          "ExprParen": {
-                            "e": {
-                              "AstNode": {
-                                "data": {
-                                  "ExprLiteralInt": {
-                                    "value": "1"
+            "DefConstant" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "p",
+                    "value" : {
+                      "AstNode" : {
+                        "data" : {
+                          "ExprParen" : {
+                            "e" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "ExprLiteralInt" : {
+                                    "value" : "1"
                                   }
                                 },
-                                "id": 64
+                                "id" : 64
                               }
                             }
                           }
                         },
-                        "id": 65
+                        "id" : 65
                       }
                     },
-                    "isDictionaryDef": false
+                    "isDictionaryDef" : false
                   },
-                  "id": 66
+                  "id" : 66
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          [],
+          [
+          ],
           {
-            "DefConstant": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "q",
-                    "value": {
-                      "AstNode": {
-                        "data": {
-                          "ExprLiteralBool": {
-                            "value": {
-                              "True": {}
+            "DefConstant" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "q",
+                    "value" : {
+                      "AstNode" : {
+                        "data" : {
+                          "ExprLiteralBool" : {
+                            "value" : {
+                              "True" : {
+                                
+                              }
                             }
                           }
                         },
-                        "id": 67
+                        "id" : 67
                       }
                     },
-                    "isDictionaryDef": false
+                    "isDictionaryDef" : false
                   },
-                  "id": 68
+                  "id" : 68
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          [],
+          [
+          ],
           {
-            "DefConstant": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "r",
-                    "value": {
-                      "AstNode": {
-                        "data": {
-                          "ExprLiteralBool": {
-                            "value": {
-                              "False": {}
+            "DefConstant" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "r",
+                    "value" : {
+                      "AstNode" : {
+                        "data" : {
+                          "ExprLiteralBool" : {
+                            "value" : {
+                              "False" : {
+                                
+                              }
                             }
                           }
                         },
-                        "id": 69
+                        "id" : 69
                       }
                     },
-                    "isDictionaryDef": false
+                    "isDictionaryDef" : false
                   },
-                  "id": 70
+                  "id" : 70
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          ["This is a pre annotation.", "It has two lines."],
+          [
+            "This is a pre annotation.",
+            "It has two lines."
+          ],
           {
-            "DefConstant": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "s",
-                    "value": {
-                      "AstNode": {
-                        "data": {
-                          "ExprLiteralInt": {
-                            "value": "0"
+            "DefConstant" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "s",
+                    "value" : {
+                      "AstNode" : {
+                        "data" : {
+                          "ExprLiteralInt" : {
+                            "value" : "0"
                           }
                         },
-                        "id": 73
+                        "id" : 73
                       }
                     },
-                    "isDictionaryDef": false
+                    "isDictionaryDef" : false
                   },
-                  "id": 74
+                  "id" : 74
                 }
               }
             }
           },
-          ["This is a post annotation.", "It also has two lines."]
+          [
+            "This is a post annotation.",
+            "It also has two lines."
+          ]
         ]
       ]
     }

--- a/tests/constants/constants_ast.json
+++ b/tests/constants/constants_ast.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion": "[ fpp version ]",
+  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
   "ast": [
     {
       "members": [
@@ -20,7 +20,8 @@
                         },
                         "id": 0
                       }
-                    }
+                    },
+                    "isDictionaryDef": false
                   },
                   "id": 1
                 }
@@ -46,7 +47,8 @@
                         },
                         "id": 2
                       }
-                    }
+                    },
+                    "isDictionaryDef": false
                   },
                   "id": 3
                 }
@@ -72,7 +74,8 @@
                         },
                         "id": 4
                       }
-                    }
+                    },
+                    "isDictionaryDef": false
                   },
                   "id": 5
                 }
@@ -129,7 +132,8 @@
                         },
                         "id": 9
                       }
-                    }
+                    },
+                    "isDictionaryDef": false
                   },
                   "id": 10
                 }
@@ -176,7 +180,8 @@
                         },
                         "id": 13
                       }
-                    }
+                    },
+                    "isDictionaryDef": false
                   },
                   "id": 14
                 }
@@ -265,7 +270,8 @@
                         },
                         "id": 21
                       }
-                    }
+                    },
+                    "isDictionaryDef": false
                   },
                   "id": 22
                 }
@@ -285,72 +291,35 @@
                     "value": {
                       "AstNode": {
                         "data": {
-                          "ExprStruct": {
-                            "members": [
-                              {
-                                "AstNode": {
-                                  "data": {
-                                    "name": "x",
-                                    "value": {
-                                      "AstNode": {
-                                        "data": {
-                                          "ExprLiteralInt": {
-                                            "value": "1"
-                                          }
-                                        },
-                                        "id": 23
-                                      }
-                                    }
-                                  },
-                                  "id": 24
-                                }
-                              },
-                              {
-                                "AstNode": {
-                                  "data": {
-                                    "name": "y",
-                                    "value": {
-                                      "AstNode": {
-                                        "data": {
-                                          "ExprLiteralString": {
-                                            "value": "abc"
-                                          }
-                                        },
-                                        "id": 25
-                                      }
-                                    }
-                                  },
-                                  "id": 26
-                                }
-                              },
-                              {
-                                "AstNode": {
-                                  "data": {
-                                    "name": "z",
-                                    "value": {
-                                      "AstNode": {
-                                        "data": {
-                                          "ExprLiteralBool": {
-                                            "value": {
-                                              "False": {}
-                                            }
-                                          }
-                                        },
-                                        "id": 27
-                                      }
-                                    }
-                                  },
-                                  "id": 28
-                                }
+                          "ExprArraySubscript": {
+                            "e1": {
+                              "AstNode": {
+                                "data": {
+                                  "ExprIdent": {
+                                    "value": "f"
+                                  }
+                                },
+                                "id": 23
                               }
-                            ]
+                            },
+                            "e2": {
+                              "AstNode": {
+                                "data": {
+                                  "ExprLiteralInt": {
+                                    "value": "0"
+                                  }
+                                },
+                                "id": 24
+                              }
+                            }
                           }
                         },
-                        "id": 29
+                        "id": 25
                       }
-                    }
+                    },
+                    "isDictionaryDef": false
                   },
-                  "id": 30
+                  "id": 26
                 }
               }
             }
@@ -368,13 +337,52 @@
                     "value": {
                       "AstNode": {
                         "data": {
-                          "ExprStruct": {
-                            "members": []
+                          "ExprArraySubscript": {
+                            "e1": {
+                              "AstNode": {
+                                "data": {
+                                  "ExprArraySubscript": {
+                                    "e1": {
+                                      "AstNode": {
+                                        "data": {
+                                          "ExprIdent": {
+                                            "value": "f"
+                                          }
+                                        },
+                                        "id": 27
+                                      }
+                                    },
+                                    "e2": {
+                                      "AstNode": {
+                                        "data": {
+                                          "ExprLiteralInt": {
+                                            "value": "0"
+                                          }
+                                        },
+                                        "id": 28
+                                      }
+                                    }
+                                  }
+                                },
+                                "id": 30
+                              }
+                            },
+                            "e2": {
+                              "AstNode": {
+                                "data": {
+                                  "ExprLiteralInt": {
+                                    "value": "1"
+                                  }
+                                },
+                                "id": 29
+                              }
+                            }
                           }
                         },
                         "id": 31
                       }
-                    }
+                    },
+                    "isDictionaryDef": false
                   },
                   "id": 32
                 }
@@ -391,6 +399,117 @@
                 "AstNode": {
                   "data": {
                     "name": "i",
+                    "value": {
+                      "AstNode": {
+                        "data": {
+                          "ExprStruct": {
+                            "members": [
+                              {
+                                "AstNode": {
+                                  "data": {
+                                    "name": "x",
+                                    "value": {
+                                      "AstNode": {
+                                        "data": {
+                                          "ExprLiteralInt": {
+                                            "value": "1"
+                                          }
+                                        },
+                                        "id": 33
+                                      }
+                                    }
+                                  },
+                                  "id": 34
+                                }
+                              },
+                              {
+                                "AstNode": {
+                                  "data": {
+                                    "name": "y",
+                                    "value": {
+                                      "AstNode": {
+                                        "data": {
+                                          "ExprLiteralString": {
+                                            "value": "abc"
+                                          }
+                                        },
+                                        "id": 35
+                                      }
+                                    }
+                                  },
+                                  "id": 36
+                                }
+                              },
+                              {
+                                "AstNode": {
+                                  "data": {
+                                    "name": "z",
+                                    "value": {
+                                      "AstNode": {
+                                        "data": {
+                                          "ExprLiteralBool": {
+                                            "value": {
+                                              "False": {}
+                                            }
+                                          }
+                                        },
+                                        "id": 37
+                                      }
+                                    }
+                                  },
+                                  "id": 38
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        "id": 39
+                      }
+                    },
+                    "isDictionaryDef": false
+                  },
+                  "id": 40
+                }
+              }
+            }
+          },
+          []
+        ],
+        [
+          [],
+          {
+            "DefConstant": {
+              "node": {
+                "AstNode": {
+                  "data": {
+                    "name": "j",
+                    "value": {
+                      "AstNode": {
+                        "data": {
+                          "ExprStruct": {
+                            "members": []
+                          }
+                        },
+                        "id": 41
+                      }
+                    },
+                    "isDictionaryDef": false
+                  },
+                  "id": 42
+                }
+              }
+            }
+          },
+          []
+        ],
+        [
+          [],
+          {
+            "DefConstant": {
+              "node": {
+                "AstNode": {
+                  "data": {
+                    "name": "k",
                     "value": {
                       "AstNode": {
                         "data": {
@@ -412,11 +531,11 @@
                                                       "value": "1"
                                                     }
                                                   },
-                                                  "id": 33
+                                                  "id": 43
                                                 }
                                               }
                                             },
-                                            "id": 34
+                                            "id": 44
                                           }
                                         },
                                         {
@@ -430,17 +549,17 @@
                                                       "value": "2"
                                                     }
                                                   },
-                                                  "id": 35
+                                                  "id": 45
                                                 }
                                               }
                                             },
-                                            "id": 36
+                                            "id": 46
                                           }
                                         }
                                       ]
                                     }
                                   },
-                                  "id": 37
+                                  "id": 47
                                 }
                               },
                               {
@@ -459,79 +578,28 @@
                                                       "value": "3"
                                                     }
                                                   },
-                                                  "id": 38
+                                                  "id": 48
                                                 }
                                               }
                                             },
-                                            "id": 39
+                                            "id": 49
                                           }
                                         }
                                       ]
                                     }
                                   },
-                                  "id": 40
+                                  "id": 50
                                 }
                               }
                             ]
                           }
                         },
-                        "id": 41
+                        "id": 51
                       }
-                    }
+                    },
+                    "isDictionaryDef": false
                   },
-                  "id": 42
-                }
-              }
-            }
-          },
-          []
-        ],
-        [
-          [],
-          {
-            "DefConstant": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "j",
-                    "value": {
-                      "AstNode": {
-                        "data": {
-                          "ExprLiteralInt": {
-                            "value": "1"
-                          }
-                        },
-                        "id": 43
-                      }
-                    }
-                  },
-                  "id": 44
-                }
-              }
-            }
-          },
-          []
-        ],
-        [
-          [],
-          {
-            "DefConstant": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "k",
-                    "value": {
-                      "AstNode": {
-                        "data": {
-                          "ExprIdent": {
-                            "value": "j"
-                          }
-                        },
-                        "id": 45
-                      }
-                    }
-                  },
-                  "id": 46
+                  "id": 52
                 }
               }
             }
@@ -549,27 +617,16 @@
                     "value": {
                       "AstNode": {
                         "data": {
-                          "ExprUnop": {
-                            "op": {
-                              "Minus": {}
-                            },
-                            "e": {
-                              "AstNode": {
-                                "data": {
-                                  "ExprLiteralInt": {
-                                    "value": "1"
-                                  }
-                                },
-                                "id": 47
-                              }
-                            }
+                          "ExprLiteralInt": {
+                            "value": "1"
                           }
                         },
-                        "id": 48
+                        "id": 53
                       }
-                    }
+                    },
+                    "isDictionaryDef": false
                   },
-                  "id": 49
+                  "id": 54
                 }
               }
             }
@@ -587,37 +644,16 @@
                     "value": {
                       "AstNode": {
                         "data": {
-                          "ExprBinop": {
-                            "e1": {
-                              "AstNode": {
-                                "data": {
-                                  "ExprLiteralInt": {
-                                    "value": "1"
-                                  }
-                                },
-                                "id": 50
-                              }
-                            },
-                            "op": {
-                              "Add": {}
-                            },
-                            "e2": {
-                              "AstNode": {
-                                "data": {
-                                  "ExprLiteralInt": {
-                                    "value": "2"
-                                  }
-                                },
-                                "id": 51
-                              }
-                            }
+                          "ExprIdent": {
+                            "value": "l"
                           }
                         },
-                        "id": 52
+                        "id": 55
                       }
-                    }
+                    },
+                    "isDictionaryDef": false
                   },
-                  "id": 53
+                  "id": 56
                 }
               }
             }
@@ -635,7 +671,10 @@
                     "value": {
                       "AstNode": {
                         "data": {
-                          "ExprParen": {
+                          "ExprUnop": {
+                            "op": {
+                              "Minus": {}
+                            },
                             "e": {
                               "AstNode": {
                                 "data": {
@@ -643,16 +682,17 @@
                                     "value": "1"
                                   }
                                 },
-                                "id": 54
+                                "id": 57
                               }
                             }
                           }
                         },
-                        "id": 55
+                        "id": 58
                       }
-                    }
+                    },
+                    "isDictionaryDef": false
                   },
-                  "id": 56
+                  "id": 59
                 }
               }
             }
@@ -670,17 +710,38 @@
                     "value": {
                       "AstNode": {
                         "data": {
-                          "ExprLiteralBool": {
-                            "value": {
-                              "True": {}
+                          "ExprBinop": {
+                            "e1": {
+                              "AstNode": {
+                                "data": {
+                                  "ExprLiteralInt": {
+                                    "value": "1"
+                                  }
+                                },
+                                "id": 60
+                              }
+                            },
+                            "op": {
+                              "Add": {}
+                            },
+                            "e2": {
+                              "AstNode": {
+                                "data": {
+                                  "ExprLiteralInt": {
+                                    "value": "2"
+                                  }
+                                },
+                                "id": 61
+                              }
                             }
                           }
                         },
-                        "id": 57
+                        "id": 62
                       }
-                    }
+                    },
+                    "isDictionaryDef": false
                   },
-                  "id": 58
+                  "id": 63
                 }
               }
             }
@@ -698,17 +759,83 @@
                     "value": {
                       "AstNode": {
                         "data": {
+                          "ExprParen": {
+                            "e": {
+                              "AstNode": {
+                                "data": {
+                                  "ExprLiteralInt": {
+                                    "value": "1"
+                                  }
+                                },
+                                "id": 64
+                              }
+                            }
+                          }
+                        },
+                        "id": 65
+                      }
+                    },
+                    "isDictionaryDef": false
+                  },
+                  "id": 66
+                }
+              }
+            }
+          },
+          []
+        ],
+        [
+          [],
+          {
+            "DefConstant": {
+              "node": {
+                "AstNode": {
+                  "data": {
+                    "name": "q",
+                    "value": {
+                      "AstNode": {
+                        "data": {
+                          "ExprLiteralBool": {
+                            "value": {
+                              "True": {}
+                            }
+                          }
+                        },
+                        "id": 67
+                      }
+                    },
+                    "isDictionaryDef": false
+                  },
+                  "id": 68
+                }
+              }
+            }
+          },
+          []
+        ],
+        [
+          [],
+          {
+            "DefConstant": {
+              "node": {
+                "AstNode": {
+                  "data": {
+                    "name": "r",
+                    "value": {
+                      "AstNode": {
+                        "data": {
                           "ExprLiteralBool": {
                             "value": {
                               "False": {}
                             }
                           }
                         },
-                        "id": 59
+                        "id": 69
                       }
-                    }
+                    },
+                    "isDictionaryDef": false
                   },
-                  "id": 60
+                  "id": 70
                 }
               }
             }
@@ -722,7 +849,7 @@
               "node": {
                 "AstNode": {
                   "data": {
-                    "name": "q",
+                    "name": "s",
                     "value": {
                       "AstNode": {
                         "data": {
@@ -730,11 +857,12 @@
                             "value": "0"
                           }
                         },
-                        "id": 63
+                        "id": 73
                       }
-                    }
+                    },
+                    "isDictionaryDef": false
                   },
-                  "id": 64
+                  "id": 74
                 }
               }
             }

--- a/tests/constants/constants_locations.json
+++ b/tests/constants/constants_locations.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion": "[ fpp version ]",
+  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
   "locationMap": {
     "0": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
@@ -118,7 +118,7 @@
     },
     "23": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "10.20",
+      "pos": "10.14",
       "includingLoc": "None"
     },
     "24": {
@@ -128,32 +128,32 @@
     },
     "25": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "10.27",
+      "pos": "10.14",
       "includingLoc": "None"
     },
     "26": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "10.23",
+      "pos": "10.1",
       "includingLoc": "None"
     },
     "27": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "10.38",
+      "pos": "11.14",
       "includingLoc": "None"
     },
     "28": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "10.34",
+      "pos": "11.16",
       "includingLoc": "None"
     },
     "29": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "10.14",
+      "pos": "11.19",
       "includingLoc": "None"
     },
     "30": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "10.1",
+      "pos": "11.14",
       "includingLoc": "None"
     },
     "31": {
@@ -168,162 +168,212 @@
     },
     "33": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "13.22",
+      "pos": "13.20",
       "includingLoc": "None"
     },
     "34": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "13.18",
+      "pos": "13.16",
       "includingLoc": "None"
     },
     "35": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "13.29",
+      "pos": "13.27",
       "includingLoc": "None"
     },
     "36": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "13.25",
+      "pos": "13.23",
       "includingLoc": "None"
     },
     "37": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "13.16",
+      "pos": "13.38",
       "includingLoc": "None"
     },
     "38": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "13.40",
+      "pos": "13.34",
       "includingLoc": "None"
     },
     "39": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "13.36",
+      "pos": "13.14",
       "includingLoc": "None"
     },
     "40": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "13.34",
+      "pos": "13.1",
       "includingLoc": "None"
     },
     "41": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "13.14",
+      "pos": "14.14",
       "includingLoc": "None"
     },
     "42": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "13.1",
+      "pos": "14.1",
       "includingLoc": "None"
     },
     "43": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "15.14",
+      "pos": "16.22",
       "includingLoc": "None"
     },
     "44": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "15.1",
+      "pos": "16.18",
       "includingLoc": "None"
     },
     "45": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "16.14",
+      "pos": "16.29",
       "includingLoc": "None"
     },
     "46": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "16.1",
+      "pos": "16.25",
       "includingLoc": "None"
     },
     "47": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "18.15",
+      "pos": "16.16",
       "includingLoc": "None"
     },
     "48": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "18.14",
+      "pos": "16.40",
       "includingLoc": "None"
     },
     "49": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "18.1",
+      "pos": "16.36",
       "includingLoc": "None"
     },
     "50": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "19.14",
+      "pos": "16.34",
       "includingLoc": "None"
     },
     "51": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "19.18",
+      "pos": "16.14",
       "includingLoc": "None"
     },
     "52": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "19.16",
+      "pos": "16.1",
       "includingLoc": "None"
     },
     "53": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "19.1",
+      "pos": "18.14",
       "includingLoc": "None"
     },
     "54": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "20.15",
+      "pos": "18.1",
       "includingLoc": "None"
     },
     "55": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "20.14",
+      "pos": "19.14",
       "includingLoc": "None"
     },
     "56": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "20.1",
+      "pos": "19.1",
       "includingLoc": "None"
     },
     "57": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "22.14",
+      "pos": "21.15",
       "includingLoc": "None"
     },
     "58": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "22.1",
+      "pos": "21.14",
       "includingLoc": "None"
     },
     "59": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "23.14",
+      "pos": "21.1",
       "includingLoc": "None"
     },
     "60": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "23.1",
+      "pos": "22.14",
       "includingLoc": "None"
     },
     "61": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "27.14",
+      "pos": "22.18",
       "includingLoc": "None"
     },
     "62": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "27.1",
+      "pos": "22.16",
       "includingLoc": "None"
     },
     "63": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "27.14",
+      "pos": "22.1",
       "includingLoc": "None"
     },
     "64": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "27.1",
+      "pos": "23.15",
+      "includingLoc": "None"
+    },
+    "65": {
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
+      "pos": "23.14",
+      "includingLoc": "None"
+    },
+    "66": {
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
+      "pos": "23.1",
+      "includingLoc": "None"
+    },
+    "67": {
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
+      "pos": "25.14",
+      "includingLoc": "None"
+    },
+    "68": {
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
+      "pos": "25.1",
+      "includingLoc": "None"
+    },
+    "69": {
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
+      "pos": "26.14",
+      "includingLoc": "None"
+    },
+    "70": {
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
+      "pos": "26.1",
+      "includingLoc": "None"
+    },
+    "71": {
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
+      "pos": "30.14",
+      "includingLoc": "None"
+    },
+    "72": {
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
+      "pos": "30.1",
+      "includingLoc": "None"
+    },
+    "73": {
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
+      "pos": "30.14",
+      "includingLoc": "None"
+    },
+    "74": {
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
+      "pos": "30.1",
       "includingLoc": "None"
     }
   }

--- a/tests/constants/constants_locations.json
+++ b/tests/constants/constants_locations.json
@@ -1,380 +1,380 @@
 {
-  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
-  "locationMap": {
-    "0": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "1.14",
-      "includingLoc": "None"
-    },
-    "1": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "1.1",
-      "includingLoc": "None"
-    },
-    "2": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "2.14",
-      "includingLoc": "None"
-    },
-    "3": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "2.1",
-      "includingLoc": "None"
-    },
-    "4": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "4.14",
-      "includingLoc": "None"
-    },
-    "5": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "4.1",
-      "includingLoc": "None"
-    },
-    "6": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "6.16",
-      "includingLoc": "None"
-    },
-    "7": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "6.19",
-      "includingLoc": "None"
-    },
-    "8": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "6.22",
-      "includingLoc": "None"
-    },
-    "9": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "6.14",
-      "includingLoc": "None"
-    },
-    "10": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "6.1",
-      "includingLoc": "None"
-    },
-    "11": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "7.16",
-      "includingLoc": "None"
-    },
-    "12": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "7.19",
-      "includingLoc": "None"
-    },
-    "13": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "7.14",
-      "includingLoc": "None"
-    },
-    "14": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "7.1",
-      "includingLoc": "None"
-    },
-    "15": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "8.18",
-      "includingLoc": "None"
-    },
-    "16": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "8.21",
-      "includingLoc": "None"
-    },
-    "17": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "8.16",
-      "includingLoc": "None"
-    },
-    "18": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "8.28",
-      "includingLoc": "None"
-    },
-    "19": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "8.31",
-      "includingLoc": "None"
-    },
-    "20": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "8.26",
-      "includingLoc": "None"
-    },
-    "21": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "8.14",
-      "includingLoc": "None"
-    },
-    "22": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "8.1",
-      "includingLoc": "None"
-    },
-    "23": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "10.14",
-      "includingLoc": "None"
-    },
-    "24": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "10.16",
-      "includingLoc": "None"
-    },
-    "25": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "10.14",
-      "includingLoc": "None"
-    },
-    "26": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "10.1",
-      "includingLoc": "None"
-    },
-    "27": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "11.14",
-      "includingLoc": "None"
-    },
-    "28": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "11.16",
-      "includingLoc": "None"
-    },
-    "29": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "11.19",
-      "includingLoc": "None"
-    },
-    "30": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "11.14",
-      "includingLoc": "None"
-    },
-    "31": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "11.14",
-      "includingLoc": "None"
-    },
-    "32": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "11.1",
-      "includingLoc": "None"
-    },
-    "33": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "13.20",
-      "includingLoc": "None"
-    },
-    "34": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "13.16",
-      "includingLoc": "None"
-    },
-    "35": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "13.27",
-      "includingLoc": "None"
-    },
-    "36": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "13.23",
-      "includingLoc": "None"
-    },
-    "37": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "13.38",
-      "includingLoc": "None"
-    },
-    "38": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "13.34",
-      "includingLoc": "None"
-    },
-    "39": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "13.14",
-      "includingLoc": "None"
-    },
-    "40": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "13.1",
-      "includingLoc": "None"
-    },
-    "41": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "14.14",
-      "includingLoc": "None"
-    },
-    "42": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "14.1",
-      "includingLoc": "None"
-    },
-    "43": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "16.22",
-      "includingLoc": "None"
-    },
-    "44": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "16.18",
-      "includingLoc": "None"
-    },
-    "45": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "16.29",
-      "includingLoc": "None"
-    },
-    "46": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "16.25",
-      "includingLoc": "None"
-    },
-    "47": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "16.16",
-      "includingLoc": "None"
-    },
-    "48": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "16.40",
-      "includingLoc": "None"
-    },
-    "49": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "16.36",
-      "includingLoc": "None"
-    },
-    "50": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "16.34",
-      "includingLoc": "None"
-    },
-    "51": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "16.14",
-      "includingLoc": "None"
-    },
-    "52": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "16.1",
-      "includingLoc": "None"
-    },
-    "53": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "18.14",
-      "includingLoc": "None"
-    },
-    "54": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "18.1",
-      "includingLoc": "None"
-    },
-    "55": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "19.14",
-      "includingLoc": "None"
-    },
-    "56": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "19.1",
-      "includingLoc": "None"
-    },
-    "57": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "21.15",
-      "includingLoc": "None"
-    },
-    "58": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "21.14",
-      "includingLoc": "None"
-    },
-    "59": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "21.1",
-      "includingLoc": "None"
-    },
-    "60": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "22.14",
-      "includingLoc": "None"
-    },
-    "61": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "22.18",
-      "includingLoc": "None"
-    },
-    "62": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "22.16",
-      "includingLoc": "None"
-    },
-    "63": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "22.1",
-      "includingLoc": "None"
-    },
-    "64": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "23.15",
-      "includingLoc": "None"
-    },
-    "65": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "23.14",
-      "includingLoc": "None"
-    },
-    "66": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "23.1",
-      "includingLoc": "None"
-    },
-    "67": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "25.14",
-      "includingLoc": "None"
-    },
-    "68": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "25.1",
-      "includingLoc": "None"
-    },
-    "69": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "26.14",
-      "includingLoc": "None"
-    },
-    "70": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "26.1",
-      "includingLoc": "None"
-    },
-    "71": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "30.14",
-      "includingLoc": "None"
-    },
-    "72": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "30.1",
-      "includingLoc": "None"
-    },
-    "73": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "30.14",
-      "includingLoc": "None"
-    },
-    "74": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
-      "pos": "30.1",
-      "includingLoc": "None"
+  "fppVersion" : "v3.1.0a10-54-g11243e778",
+  "locationMap" : {
+    "0" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
+      "pos" : "1.14",
+      "includingLoc" : "None"
+    },
+    "1" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
+      "pos" : "1.1",
+      "includingLoc" : "None"
+    },
+    "2" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
+      "pos" : "2.14",
+      "includingLoc" : "None"
+    },
+    "3" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
+      "pos" : "2.1",
+      "includingLoc" : "None"
+    },
+    "4" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
+      "pos" : "4.14",
+      "includingLoc" : "None"
+    },
+    "5" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
+      "pos" : "4.1",
+      "includingLoc" : "None"
+    },
+    "6" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
+      "pos" : "6.16",
+      "includingLoc" : "None"
+    },
+    "7" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
+      "pos" : "6.19",
+      "includingLoc" : "None"
+    },
+    "8" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
+      "pos" : "6.22",
+      "includingLoc" : "None"
+    },
+    "9" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
+      "pos" : "6.14",
+      "includingLoc" : "None"
+    },
+    "10" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
+      "pos" : "6.1",
+      "includingLoc" : "None"
+    },
+    "11" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
+      "pos" : "7.16",
+      "includingLoc" : "None"
+    },
+    "12" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
+      "pos" : "7.19",
+      "includingLoc" : "None"
+    },
+    "13" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
+      "pos" : "7.14",
+      "includingLoc" : "None"
+    },
+    "14" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
+      "pos" : "7.1",
+      "includingLoc" : "None"
+    },
+    "15" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
+      "pos" : "8.18",
+      "includingLoc" : "None"
+    },
+    "16" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
+      "pos" : "8.21",
+      "includingLoc" : "None"
+    },
+    "17" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
+      "pos" : "8.16",
+      "includingLoc" : "None"
+    },
+    "18" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
+      "pos" : "8.28",
+      "includingLoc" : "None"
+    },
+    "19" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
+      "pos" : "8.31",
+      "includingLoc" : "None"
+    },
+    "20" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
+      "pos" : "8.26",
+      "includingLoc" : "None"
+    },
+    "21" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
+      "pos" : "8.14",
+      "includingLoc" : "None"
+    },
+    "22" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
+      "pos" : "8.1",
+      "includingLoc" : "None"
+    },
+    "23" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
+      "pos" : "10.14",
+      "includingLoc" : "None"
+    },
+    "24" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
+      "pos" : "10.16",
+      "includingLoc" : "None"
+    },
+    "25" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
+      "pos" : "10.14",
+      "includingLoc" : "None"
+    },
+    "26" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
+      "pos" : "10.1",
+      "includingLoc" : "None"
+    },
+    "27" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
+      "pos" : "11.14",
+      "includingLoc" : "None"
+    },
+    "28" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
+      "pos" : "11.16",
+      "includingLoc" : "None"
+    },
+    "29" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
+      "pos" : "11.19",
+      "includingLoc" : "None"
+    },
+    "30" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
+      "pos" : "11.14",
+      "includingLoc" : "None"
+    },
+    "31" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
+      "pos" : "11.14",
+      "includingLoc" : "None"
+    },
+    "32" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
+      "pos" : "11.1",
+      "includingLoc" : "None"
+    },
+    "33" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
+      "pos" : "13.20",
+      "includingLoc" : "None"
+    },
+    "34" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
+      "pos" : "13.16",
+      "includingLoc" : "None"
+    },
+    "35" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
+      "pos" : "13.27",
+      "includingLoc" : "None"
+    },
+    "36" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
+      "pos" : "13.23",
+      "includingLoc" : "None"
+    },
+    "37" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
+      "pos" : "13.38",
+      "includingLoc" : "None"
+    },
+    "38" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
+      "pos" : "13.34",
+      "includingLoc" : "None"
+    },
+    "39" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
+      "pos" : "13.14",
+      "includingLoc" : "None"
+    },
+    "40" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
+      "pos" : "13.1",
+      "includingLoc" : "None"
+    },
+    "41" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
+      "pos" : "14.14",
+      "includingLoc" : "None"
+    },
+    "42" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
+      "pos" : "14.1",
+      "includingLoc" : "None"
+    },
+    "43" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
+      "pos" : "16.22",
+      "includingLoc" : "None"
+    },
+    "44" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
+      "pos" : "16.18",
+      "includingLoc" : "None"
+    },
+    "45" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
+      "pos" : "16.29",
+      "includingLoc" : "None"
+    },
+    "46" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
+      "pos" : "16.25",
+      "includingLoc" : "None"
+    },
+    "47" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
+      "pos" : "16.16",
+      "includingLoc" : "None"
+    },
+    "48" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
+      "pos" : "16.40",
+      "includingLoc" : "None"
+    },
+    "49" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
+      "pos" : "16.36",
+      "includingLoc" : "None"
+    },
+    "50" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
+      "pos" : "16.34",
+      "includingLoc" : "None"
+    },
+    "51" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
+      "pos" : "16.14",
+      "includingLoc" : "None"
+    },
+    "52" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
+      "pos" : "16.1",
+      "includingLoc" : "None"
+    },
+    "53" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
+      "pos" : "18.14",
+      "includingLoc" : "None"
+    },
+    "54" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
+      "pos" : "18.1",
+      "includingLoc" : "None"
+    },
+    "55" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
+      "pos" : "19.14",
+      "includingLoc" : "None"
+    },
+    "56" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
+      "pos" : "19.1",
+      "includingLoc" : "None"
+    },
+    "57" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
+      "pos" : "21.15",
+      "includingLoc" : "None"
+    },
+    "58" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
+      "pos" : "21.14",
+      "includingLoc" : "None"
+    },
+    "59" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
+      "pos" : "21.1",
+      "includingLoc" : "None"
+    },
+    "60" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
+      "pos" : "22.14",
+      "includingLoc" : "None"
+    },
+    "61" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
+      "pos" : "22.18",
+      "includingLoc" : "None"
+    },
+    "62" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
+      "pos" : "22.16",
+      "includingLoc" : "None"
+    },
+    "63" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
+      "pos" : "22.1",
+      "includingLoc" : "None"
+    },
+    "64" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
+      "pos" : "23.15",
+      "includingLoc" : "None"
+    },
+    "65" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
+      "pos" : "23.14",
+      "includingLoc" : "None"
+    },
+    "66" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
+      "pos" : "23.1",
+      "includingLoc" : "None"
+    },
+    "67" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
+      "pos" : "25.14",
+      "includingLoc" : "None"
+    },
+    "68" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
+      "pos" : "25.1",
+      "includingLoc" : "None"
+    },
+    "69" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
+      "pos" : "26.14",
+      "includingLoc" : "None"
+    },
+    "70" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
+      "pos" : "26.1",
+      "includingLoc" : "None"
+    },
+    "71" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
+      "pos" : "30.14",
+      "includingLoc" : "None"
+    },
+    "72" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
+      "pos" : "30.1",
+      "includingLoc" : "None"
+    },
+    "73" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
+      "pos" : "30.14",
+      "includingLoc" : "None"
+    },
+    "74" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",
+      "pos" : "30.1",
+      "includingLoc" : "None"
     }
   }
 }

--- a/tests/data_products/data_products_analysis.json
+++ b/tests/data_products/data_products_analysis.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion": "[ fpp version ]",
+  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
   "analysis": {
     "componentInstanceMap": {},
     "componentMap": {

--- a/tests/data_products/data_products_analysis.json
+++ b/tests/data_products/data_products_analysis.json
@@ -1,453 +1,528 @@
 {
-  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
-  "analysis": {
-    "componentInstanceMap": {},
-    "componentMap": {
-      "28": {
-        "aNode": {
-          "astNodeId": 28
+  "fppVersion" : "v3.1.0a10-54-g11243e778",
+  "analysis" : {
+    "componentInstanceMap" : {
+      
+    },
+    "componentMap" : {
+      "28" : {
+        "aNode" : {
+          "astNodeId" : 28
         },
-        "portMap": {
-          "productRequestOut": {
-            "Special": {
-              "aNode": {
-                "astNodeId": 7
+        "portMap" : {
+          "productRequestOut" : {
+            "Special" : {
+              "aNode" : {
+                "astNodeId" : 7
               },
-              "specifier": {
-                "inputKind": "None",
-                "kind": {
-                  "ProductRequest": {}
-                },
-                "name": "productRequestOut",
-                "priority": "None",
-                "queueFull": "None"
-              },
-              "symbol": {
-                "Port": {
-                  "nodeId": 0,
-                  "unqualifiedName": "DpRequest"
-                }
-              },
-              "priority": "None",
-              "queueFull": "None",
-              "importNodeIds": []
-            }
-          },
-          "productRecvIn": {
-            "Special": {
-              "aNode": {
-                "astNodeId": 8
-              },
-              "specifier": {
-                "inputKind": {
-                  "Some": {
-                    "Sync": {}
+              "specifier" : {
+                "inputKind" : "None",
+                "kind" : {
+                  "ProductRequest" : {
+                    
                   }
                 },
-                "kind": {
-                  "ProductRecv": {}
-                },
-                "name": "productRecvIn",
-                "priority": "None",
-                "queueFull": "None"
+                "name" : "productRequestOut",
+                "priority" : "None",
+                "queueFull" : "None"
               },
-              "symbol": {
-                "Port": {
-                  "nodeId": 1,
-                  "unqualifiedName": "DpResponse"
+              "symbol" : {
+                "Port" : {
+                  "nodeId" : 0,
+                  "unqualifiedName" : "DpRequest"
                 }
               },
-              "priority": "None",
-              "queueFull": {
-                "Some": {
-                  "Assert": {}
-                }
-              },
-              "importNodeIds": []
+              "priority" : "None",
+              "queueFull" : "None",
+              "importNodeIds" : [
+              ]
             }
           },
-          "productSendOut": {
-            "Special": {
-              "aNode": {
-                "astNodeId": 9
+          "productRecvIn" : {
+            "Special" : {
+              "aNode" : {
+                "astNodeId" : 8
               },
-              "specifier": {
-                "inputKind": "None",
-                "kind": {
-                  "ProductSend": {}
+              "specifier" : {
+                "inputKind" : {
+                  "Some" : {
+                    "Sync" : {
+                      
+                    }
+                  }
                 },
-                "name": "productSendOut",
-                "priority": "None",
-                "queueFull": "None"
+                "kind" : {
+                  "ProductRecv" : {
+                    
+                  }
+                },
+                "name" : "productRecvIn",
+                "priority" : "None",
+                "queueFull" : "None"
               },
-              "symbol": {
-                "Port": {
-                  "nodeId": 2,
-                  "unqualifiedName": "DpSend"
+              "symbol" : {
+                "Port" : {
+                  "nodeId" : 1,
+                  "unqualifiedName" : "DpResponse"
                 }
               },
-              "priority": "None",
-              "queueFull": "None",
-              "importNodeIds": []
+              "priority" : "None",
+              "queueFull" : {
+                "Some" : {
+                  "Assert" : {
+                    
+                  }
+                }
+              },
+              "importNodeIds" : [
+              ]
             }
           },
-          "timeGetOut": {
-            "Special": {
-              "aNode": {
-                "astNodeId": 10
+          "productSendOut" : {
+            "Special" : {
+              "aNode" : {
+                "astNodeId" : 9
               },
-              "specifier": {
-                "inputKind": "None",
-                "kind": {
-                  "TimeGet": {}
+              "specifier" : {
+                "inputKind" : "None",
+                "kind" : {
+                  "ProductSend" : {
+                    
+                  }
                 },
-                "name": "timeGetOut",
-                "priority": "None",
-                "queueFull": "None"
+                "name" : "productSendOut",
+                "priority" : "None",
+                "queueFull" : "None"
               },
-              "symbol": {
-                "Port": {
-                  "nodeId": 5,
-                  "unqualifiedName": "Time"
+              "symbol" : {
+                "Port" : {
+                  "nodeId" : 2,
+                  "unqualifiedName" : "DpSend"
                 }
               },
-              "priority": "None",
-              "queueFull": "None",
-              "importNodeIds": []
+              "priority" : "None",
+              "queueFull" : "None",
+              "importNodeIds" : [
+              ]
+            }
+          },
+          "timeGetOut" : {
+            "Special" : {
+              "aNode" : {
+                "astNodeId" : 10
+              },
+              "specifier" : {
+                "inputKind" : "None",
+                "kind" : {
+                  "TimeGet" : {
+                    
+                  }
+                },
+                "name" : "timeGetOut",
+                "priority" : "None",
+                "queueFull" : "None"
+              },
+              "symbol" : {
+                "Port" : {
+                  "nodeId" : 5,
+                  "unqualifiedName" : "Time"
+                }
+              },
+              "priority" : "None",
+              "queueFull" : "None",
+              "importNodeIds" : [
+              ]
             }
           }
         },
-        "specialPortMap": {
-          "product request": {
-            "aNode": {
-              "astNodeId": 7
+        "specialPortMap" : {
+          "product request" : {
+            "aNode" : {
+              "astNodeId" : 7
             },
-            "specifier": {
-              "inputKind": "None",
-              "kind": {
-                "ProductRequest": {}
-              },
-              "name": "productRequestOut",
-              "priority": "None",
-              "queueFull": "None"
-            },
-            "symbol": {
-              "Port": {
-                "nodeId": 0,
-                "unqualifiedName": "DpRequest"
-              }
-            },
-            "priority": "None",
-            "queueFull": "None",
-            "importNodeIds": []
-          },
-          "product recv": {
-            "aNode": {
-              "astNodeId": 8
-            },
-            "specifier": {
-              "inputKind": {
-                "Some": {
-                  "Sync": {}
+            "specifier" : {
+              "inputKind" : "None",
+              "kind" : {
+                "ProductRequest" : {
+                  
                 }
               },
-              "kind": {
-                "ProductRecv": {}
-              },
-              "name": "productRecvIn",
-              "priority": "None",
-              "queueFull": "None"
+              "name" : "productRequestOut",
+              "priority" : "None",
+              "queueFull" : "None"
             },
-            "symbol": {
-              "Port": {
-                "nodeId": 1,
-                "unqualifiedName": "DpResponse"
+            "symbol" : {
+              "Port" : {
+                "nodeId" : 0,
+                "unqualifiedName" : "DpRequest"
               }
             },
-            "priority": "None",
-            "queueFull": {
-              "Some": {
-                "Assert": {}
-              }
-            },
-            "importNodeIds": []
+            "priority" : "None",
+            "queueFull" : "None",
+            "importNodeIds" : [
+            ]
           },
-          "product send": {
-            "aNode": {
-              "astNodeId": 9
+          "product recv" : {
+            "aNode" : {
+              "astNodeId" : 8
             },
-            "specifier": {
-              "inputKind": "None",
-              "kind": {
-                "ProductSend": {}
+            "specifier" : {
+              "inputKind" : {
+                "Some" : {
+                  "Sync" : {
+                    
+                  }
+                }
               },
-              "name": "productSendOut",
-              "priority": "None",
-              "queueFull": "None"
+              "kind" : {
+                "ProductRecv" : {
+                  
+                }
+              },
+              "name" : "productRecvIn",
+              "priority" : "None",
+              "queueFull" : "None"
             },
-            "symbol": {
-              "Port": {
-                "nodeId": 2,
-                "unqualifiedName": "DpSend"
+            "symbol" : {
+              "Port" : {
+                "nodeId" : 1,
+                "unqualifiedName" : "DpResponse"
               }
             },
-            "priority": "None",
-            "queueFull": "None",
-            "importNodeIds": []
+            "priority" : "None",
+            "queueFull" : {
+              "Some" : {
+                "Assert" : {
+                  
+                }
+              }
+            },
+            "importNodeIds" : [
+            ]
           },
-          "time get": {
-            "aNode": {
-              "astNodeId": 10
+          "product send" : {
+            "aNode" : {
+              "astNodeId" : 9
             },
-            "specifier": {
-              "inputKind": "None",
-              "kind": {
-                "TimeGet": {}
+            "specifier" : {
+              "inputKind" : "None",
+              "kind" : {
+                "ProductSend" : {
+                  
+                }
               },
-              "name": "timeGetOut",
-              "priority": "None",
-              "queueFull": "None"
+              "name" : "productSendOut",
+              "priority" : "None",
+              "queueFull" : "None"
             },
-            "symbol": {
-              "Port": {
-                "nodeId": 5,
-                "unqualifiedName": "Time"
+            "symbol" : {
+              "Port" : {
+                "nodeId" : 2,
+                "unqualifiedName" : "DpSend"
               }
             },
-            "priority": "None",
-            "queueFull": "None",
-            "importNodeIds": []
+            "priority" : "None",
+            "queueFull" : "None",
+            "importNodeIds" : [
+            ]
+          },
+          "time get" : {
+            "aNode" : {
+              "astNodeId" : 10
+            },
+            "specifier" : {
+              "inputKind" : "None",
+              "kind" : {
+                "TimeGet" : {
+                  
+                }
+              },
+              "name" : "timeGetOut",
+              "priority" : "None",
+              "queueFull" : "None"
+            },
+            "symbol" : {
+              "Port" : {
+                "nodeId" : 5,
+                "unqualifiedName" : "Time"
+              }
+            },
+            "priority" : "None",
+            "queueFull" : "None",
+            "importNodeIds" : [
+            ]
           }
         },
-        "commandMap": {},
-        "defaultOpcode": 0,
-        "tlmChannelMap": {},
-        "tlmChannelNameMap": {},
-        "defaultTlmChannelId": 0,
-        "eventMap": {},
-        "defaultEventId": 0,
-        "paramMap": {},
-        "specPortMatchingList": [],
-        "stateMachineInstanceMap": {},
-        "portMatchingList": [],
-        "defaultParamId": 0,
-        "containerMap": {
-          "0": {
-            "aNode": {
-              "astNodeId": 11
+        "commandMap" : {
+          
+        },
+        "defaultOpcode" : 0,
+        "tlmChannelMap" : {
+          
+        },
+        "tlmChannelNameMap" : {
+          
+        },
+        "defaultTlmChannelId" : 0,
+        "eventMap" : {
+          
+        },
+        "defaultEventId" : 0,
+        "paramMap" : {
+          
+        },
+        "specPortMatchingList" : [
+        ],
+        "stateMachineInstanceMap" : {
+          
+        },
+        "portMatchingList" : [
+        ],
+        "defaultParamId" : 0,
+        "containerMap" : {
+          "0" : {
+            "aNode" : {
+              "astNodeId" : 11
             },
-            "defaultPriority": "None"
+            "defaultPriority" : "None"
           },
-          "256": {
-            "aNode": {
-              "astNodeId": 13
+          "256" : {
+            "aNode" : {
+              "astNodeId" : 13
             },
-            "defaultPriority": "None"
+            "defaultPriority" : "None"
           },
-          "512": {
-            "aNode": {
-              "astNodeId": 16
+          "512" : {
+            "aNode" : {
+              "astNodeId" : 16
             },
-            "defaultPriority": {
-              "Some": 3
+            "defaultPriority" : {
+              "Some" : 3
             }
           }
         },
-        "defaultContainerId": 513,
-        "recordMap": {
-          "0": {
-            "aNode": {
-              "astNodeId": 18
+        "defaultContainerId" : 513,
+        "recordMap" : {
+          "0" : {
+            "aNode" : {
+              "astNodeId" : 18
             },
-            "recordType": {
-              "Int": {
-                "PrimitiveInt": {
-                  "kind": {
-                    "U32": {}
+            "recordType" : {
+              "Int" : {
+                "PrimitiveInt" : {
+                  "kind" : {
+                    "U32" : {
+                      
+                    }
                   }
                 }
               }
             },
-            "isArray": false
+            "isArray" : false
           },
-          "256": {
-            "aNode": {
-              "astNodeId": 27
+          "256" : {
+            "aNode" : {
+              "astNodeId" : 27
             },
-            "recordType": {
-              "Int": {
-                "PrimitiveInt": {
-                  "kind": {
-                    "U32": {}
+            "recordType" : {
+              "Int" : {
+                "PrimitiveInt" : {
+                  "kind" : {
+                    "U32" : {
+                      
+                    }
                   }
                 }
               }
             },
-            "isArray": false
+            "isArray" : false
           }
         },
-        "defaultRecordId": 257
+        "defaultRecordId" : 257
       }
     },
-    "includedFileSet": [],
-    "inputFileSet": [
+    "includedFileSet" : [
+    ],
+    "inputFileSet" : [
       "[ local path prefix ]/compiler/tools/fpp-to-json/test/dataProducts.fpp"
     ],
-    "locationSpecifierMap": [],
-    "parentSymbolMap": {
-      "0": {
-        "Module": {
-          "nodeId": 6,
-          "unqualifiedName": "Fw"
+    "locationSpecifierMap" : [
+    ],
+    "parentSymbolMap" : {
+      "0" : {
+        "Module" : {
+          "nodeId" : 6,
+          "unqualifiedName" : "Fw"
         }
       },
-      "1": {
-        "Module": {
-          "nodeId": 6,
-          "unqualifiedName": "Fw"
+      "1" : {
+        "Module" : {
+          "nodeId" : 6,
+          "unqualifiedName" : "Fw"
         }
       },
-      "2": {
-        "Module": {
-          "nodeId": 6,
-          "unqualifiedName": "Fw"
+      "2" : {
+        "Module" : {
+          "nodeId" : 6,
+          "unqualifiedName" : "Fw"
         }
       },
-      "5": {
-        "Module": {
-          "nodeId": 6,
-          "unqualifiedName": "Fw"
+      "5" : {
+        "Module" : {
+          "nodeId" : 6,
+          "unqualifiedName" : "Fw"
         }
       }
     },
-    "symbolScopeMap": {
-      "6": {
-        "map": {
-          "Port": {
-            "map": {
-              "DpRequest": {
-                "Port": {
-                  "nodeId": 0,
-                  "unqualifiedName": "DpRequest"
+    "symbolScopeMap" : {
+      "6" : {
+        "map" : {
+          "Port" : {
+            "map" : {
+              "DpRequest" : {
+                "Port" : {
+                  "nodeId" : 0,
+                  "unqualifiedName" : "DpRequest"
                 }
               },
-              "DpResponse": {
-                "Port": {
-                  "nodeId": 1,
-                  "unqualifiedName": "DpResponse"
+              "DpResponse" : {
+                "Port" : {
+                  "nodeId" : 1,
+                  "unqualifiedName" : "DpResponse"
                 }
               },
-              "DpSend": {
-                "Port": {
-                  "nodeId": 2,
-                  "unqualifiedName": "DpSend"
+              "DpSend" : {
+                "Port" : {
+                  "nodeId" : 2,
+                  "unqualifiedName" : "DpSend"
                 }
               },
-              "Time": {
-                "Port": {
-                  "nodeId": 5,
-                  "unqualifiedName": "Time"
+              "Time" : {
+                "Port" : {
+                  "nodeId" : 5,
+                  "unqualifiedName" : "Time"
                 }
               }
             }
           }
         }
       },
-      "28": {
-        "map": {}
+      "28" : {
+        "map" : {
+          
+        }
       }
     },
-    "topologyMap": {},
-    "typeMap": {
-      "12": {
-        "Int": {
-          "Integer": {}
+    "topologyMap" : {
+      
+    },
+    "typeMap" : {
+      "12" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "15": {
-        "Int": {
-          "Integer": {}
+      "15" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "26": {
-        "Int": {
-          "Integer": {}
+      "26" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "17": {
-        "Int": {
-          "PrimitiveInt": {
-            "kind": {
-              "U32": {}
+      "17" : {
+        "Int" : {
+          "PrimitiveInt" : {
+            "kind" : {
+              "U32" : {
+                
+              }
             }
           }
         }
       },
-      "25": {
-        "Int": {
-          "PrimitiveInt": {
-            "kind": {
-              "U32": {}
+      "25" : {
+        "Int" : {
+          "PrimitiveInt" : {
+            "kind" : {
+              "U32" : {
+                
+              }
             }
           }
         }
       },
-      "14": {
-        "Int": {
-          "Integer": {}
+      "14" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       }
     },
-    "useDefMap": {
-      "7": {
-        "Port": {
-          "nodeId": 0,
-          "unqualifiedName": "DpRequest"
+    "useDefMap" : {
+      "7" : {
+        "Port" : {
+          "nodeId" : 0,
+          "unqualifiedName" : "DpRequest"
         }
       },
-      "8": {
-        "Port": {
-          "nodeId": 1,
-          "unqualifiedName": "DpResponse"
+      "8" : {
+        "Port" : {
+          "nodeId" : 1,
+          "unqualifiedName" : "DpResponse"
         }
       },
-      "9": {
-        "Port": {
-          "nodeId": 2,
-          "unqualifiedName": "DpSend"
+      "9" : {
+        "Port" : {
+          "nodeId" : 2,
+          "unqualifiedName" : "DpSend"
         }
       },
-      "10": {
-        "Port": {
-          "nodeId": 5,
-          "unqualifiedName": "Time"
+      "10" : {
+        "Port" : {
+          "nodeId" : 5,
+          "unqualifiedName" : "Time"
         }
       }
     },
-    "valueMap": {
-      "12": {
-        "Integer": {
-          "value": 256
+    "valueMap" : {
+      "12" : {
+        "Integer" : {
+          "value" : 256
         }
       },
-      "14": {
-        "Integer": {
-          "value": 512
+      "14" : {
+        "Integer" : {
+          "value" : 512
         }
       },
-      "15": {
-        "Integer": {
-          "value": 3
+      "15" : {
+        "Integer" : {
+          "value" : 3
         }
       },
-      "26": {
-        "Integer": {
-          "value": 256
+      "26" : {
+        "Integer" : {
+          "value" : 256
         }
       }
     },
-    "stateMachineMap": {},
-    "dictionarySymbolSet": [],
-    "interfaceMap": {}
+    "stateMachineMap" : {
+      
+    },
+    "dictionarySymbolSet" : [
+    ],
+    "interfaceMap" : {
+      
+    }
   }
 }

--- a/tests/data_products/data_products_ast.json
+++ b/tests/data_products/data_products_ast.json
@@ -1,376 +1,431 @@
 {
-  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
-  "ast": [
+  "fppVersion" : "v3.1.0a10-54-g11243e778",
+  "ast" : [
     {
-      "members": [
+      "members" : [
         [
-          [],
+          [
+          ],
           {
-            "DefModule": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "Fw",
-                    "members": [
+            "DefModule" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "Fw",
+                    "members" : [
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "DefPort": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "name": "DpRequest",
-                                  "params": [],
-                                  "returnType": "None"
+                          "DefPort" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "name" : "DpRequest",
+                                  "params" : [
+                                  ],
+                                  "returnType" : "None"
                                 },
-                                "id": 0
+                                "id" : 0
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "DefPort": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "name": "DpResponse",
-                                  "params": [],
-                                  "returnType": "None"
+                          "DefPort" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "name" : "DpResponse",
+                                  "params" : [
+                                  ],
+                                  "returnType" : "None"
                                 },
-                                "id": 1
+                                "id" : 1
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "DefPort": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "name": "DpSend",
-                                  "params": [],
-                                  "returnType": "None"
+                          "DefPort" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "name" : "DpSend",
+                                  "params" : [
+                                  ],
+                                  "returnType" : "None"
                                 },
-                                "id": 2
+                                "id" : 2
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "DefPort": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "name": "Time",
-                                  "params": [],
-                                  "returnType": "None"
+                          "DefPort" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "name" : "Time",
+                                  "params" : [
+                                  ],
+                                  "returnType" : "None"
                                 },
-                                "id": 5
+                                "id" : 5
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ]
                     ]
                   },
-                  "id": 6
+                  "id" : 6
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          [],
+          [
+          ],
           {
-            "DefComponent": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "kind": {
-                      "Passive": {}
+            "DefComponent" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "kind" : {
+                      "Passive" : {
+                        
+                      }
                     },
-                    "name": "C",
-                    "members": [
+                    "name" : "C",
+                    "members" : [
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "SpecPortInstance": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "Special": {
-                                    "inputKind": "None",
-                                    "kind": {
-                                      "ProductRequest": {}
-                                    },
-                                    "name": "productRequestOut",
-                                    "priority": "None",
-                                    "queueFull": "None"
-                                  }
-                                },
-                                "id": 7
-                              }
-                            }
-                          }
-                        },
-                        []
-                      ],
-                      [
-                        [],
-                        {
-                          "SpecPortInstance": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "Special": {
-                                    "inputKind": {
-                                      "Some": {
-                                        "Sync": {}
+                          "SpecPortInstance" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "Special" : {
+                                    "inputKind" : "None",
+                                    "kind" : {
+                                      "ProductRequest" : {
+                                        
                                       }
                                     },
-                                    "kind": {
-                                      "ProductRecv": {}
-                                    },
-                                    "name": "productRecvIn",
-                                    "priority": "None",
-                                    "queueFull": "None"
+                                    "name" : "productRequestOut",
+                                    "priority" : "None",
+                                    "queueFull" : "None"
                                   }
                                 },
-                                "id": 8
+                                "id" : 7
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "SpecPortInstance": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "Special": {
-                                    "inputKind": "None",
-                                    "kind": {
-                                      "ProductSend": {}
+                          "SpecPortInstance" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "Special" : {
+                                    "inputKind" : {
+                                      "Some" : {
+                                        "Sync" : {
+                                          
+                                        }
+                                      }
                                     },
-                                    "name": "productSendOut",
-                                    "priority": "None",
-                                    "queueFull": "None"
+                                    "kind" : {
+                                      "ProductRecv" : {
+                                        
+                                      }
+                                    },
+                                    "name" : "productRecvIn",
+                                    "priority" : "None",
+                                    "queueFull" : "None"
                                   }
                                 },
-                                "id": 9
+                                "id" : 8
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "SpecPortInstance": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "Special": {
-                                    "inputKind": "None",
-                                    "kind": {
-                                      "TimeGet": {}
+                          "SpecPortInstance" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "Special" : {
+                                    "inputKind" : "None",
+                                    "kind" : {
+                                      "ProductSend" : {
+                                        
+                                      }
                                     },
-                                    "name": "timeGetOut",
-                                    "priority": "None",
-                                    "queueFull": "None"
+                                    "name" : "productSendOut",
+                                    "priority" : "None",
+                                    "queueFull" : "None"
                                   }
                                 },
-                                "id": 10
+                                "id" : 9
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        ["A container with no ID and no default priority"],
+                        [
+                        ],
                         {
-                          "SpecContainer": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "name": "Basic",
-                                  "id": "None",
-                                  "defaultPriority": "None"
+                          "SpecPortInstance" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "Special" : {
+                                    "inputKind" : "None",
+                                    "kind" : {
+                                      "TimeGet" : {
+                                        
+                                      }
+                                    },
+                                    "name" : "timeGetOut",
+                                    "priority" : "None",
+                                    "queueFull" : "None"
+                                  }
                                 },
-                                "id": 11
+                                "id" : 10
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        ["A container with ID and no default priority"],
+                        [
+                          "A container with no ID and no default priority"
+                        ],
                         {
-                          "SpecContainer": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "name": "IdOnly",
-                                  "id": {
-                                    "Some": {
-                                      "AstNode": {
-                                        "data": {
-                                          "ExprLiteralInt": {
-                                            "value": "0x100"
+                          "SpecContainer" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "name" : "Basic",
+                                  "id" : "None",
+                                  "defaultPriority" : "None"
+                                },
+                                "id" : 11
+                              }
+                            }
+                          }
+                        },
+                        [
+                        ]
+                      ],
+                      [
+                        [
+                          "A container with ID and no default priority"
+                        ],
+                        {
+                          "SpecContainer" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "name" : "IdOnly",
+                                  "id" : {
+                                    "Some" : {
+                                      "AstNode" : {
+                                        "data" : {
+                                          "ExprLiteralInt" : {
+                                            "value" : "0x100"
                                           }
                                         },
-                                        "id": 12
+                                        "id" : 12
                                       }
                                     }
                                   },
-                                  "defaultPriority": "None"
+                                  "defaultPriority" : "None"
                                 },
-                                "id": 13
+                                "id" : 13
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        ["A container with ID and default priority"],
+                        [
+                          "A container with ID and default priority"
+                        ],
                         {
-                          "SpecContainer": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "name": "IdPriority",
-                                  "id": {
-                                    "Some": {
-                                      "AstNode": {
-                                        "data": {
-                                          "ExprLiteralInt": {
-                                            "value": "0x200"
+                          "SpecContainer" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "name" : "IdPriority",
+                                  "id" : {
+                                    "Some" : {
+                                      "AstNode" : {
+                                        "data" : {
+                                          "ExprLiteralInt" : {
+                                            "value" : "0x200"
                                           }
                                         },
-                                        "id": 14
+                                        "id" : 14
                                       }
                                     }
                                   },
-                                  "defaultPriority": {
-                                    "Some": {
-                                      "AstNode": {
-                                        "data": {
-                                          "ExprLiteralInt": {
-                                            "value": "3"
+                                  "defaultPriority" : {
+                                    "Some" : {
+                                      "AstNode" : {
+                                        "data" : {
+                                          "ExprLiteralInt" : {
+                                            "value" : "3"
                                           }
                                         },
-                                        "id": 15
+                                        "id" : 15
                                       }
                                     }
                                   }
                                 },
-                                "id": 16
+                                "id" : 16
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        ["A record with no ID"],
+                        [
+                          "A record with no ID"
+                        ],
                         {
-                          "SpecRecord": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "name": "Basic",
-                                  "recordType": {
-                                    "AstNode": {
-                                      "data": {
-                                        "TypeNameInt": {
-                                          "name": {
-                                            "U32": {}
+                          "SpecRecord" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "name" : "Basic",
+                                  "recordType" : {
+                                    "AstNode" : {
+                                      "data" : {
+                                        "TypeNameInt" : {
+                                          "name" : {
+                                            "U32" : {
+                                              
+                                            }
                                           }
                                         }
                                       },
-                                      "id": 17
+                                      "id" : 17
                                     }
                                   },
-                                  "isArray": false,
-                                  "id": "None"
+                                  "isArray" : false,
+                                  "id" : "None"
                                 },
-                                "id": 18
+                                "id" : 18
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        ["A record with an ID"],
+                        [
+                          "A record with an ID"
+                        ],
                         {
-                          "SpecRecord": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "name": "Id",
-                                  "recordType": {
-                                    "AstNode": {
-                                      "data": {
-                                        "TypeNameInt": {
-                                          "name": {
-                                            "U32": {}
+                          "SpecRecord" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "name" : "Id",
+                                  "recordType" : {
+                                    "AstNode" : {
+                                      "data" : {
+                                        "TypeNameInt" : {
+                                          "name" : {
+                                            "U32" : {
+                                              
+                                            }
                                           }
                                         }
                                       },
-                                      "id": 25
+                                      "id" : 25
                                     }
                                   },
-                                  "isArray": false,
-                                  "id": {
-                                    "Some": {
-                                      "AstNode": {
-                                        "data": {
-                                          "ExprLiteralInt": {
-                                            "value": "0x100"
+                                  "isArray" : false,
+                                  "id" : {
+                                    "Some" : {
+                                      "AstNode" : {
+                                        "data" : {
+                                          "ExprLiteralInt" : {
+                                            "value" : "0x100"
                                           }
                                         },
-                                        "id": 26
+                                        "id" : 26
                                       }
                                     }
                                   }
                                 },
-                                "id": 27
+                                "id" : 27
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ]
                     ]
                   },
-                  "id": 28
+                  "id" : 28
                 }
               }
             }
           },
-          []
+          [
+          ]
         ]
       ]
     }

--- a/tests/data_products/data_products_ast.json
+++ b/tests/data_products/data_products_ast.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion": "[ fpp version ]",
+  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
   "ast": [
     {
       "members": [

--- a/tests/data_products/data_products_locations.json
+++ b/tests/data_products/data_products_locations.json
@@ -1,150 +1,150 @@
 {
-  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
-  "locationMap": {
-    "0": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/dataProducts.fpp",
-      "pos": "3.3",
-      "includingLoc": "None"
+  "fppVersion" : "v3.1.0a10-54-g11243e778",
+  "locationMap" : {
+    "0" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/dataProducts.fpp",
+      "pos" : "3.3",
+      "includingLoc" : "None"
     },
-    "1": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/dataProducts.fpp",
-      "pos": "4.3",
-      "includingLoc": "None"
+    "1" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/dataProducts.fpp",
+      "pos" : "4.3",
+      "includingLoc" : "None"
     },
-    "2": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/dataProducts.fpp",
-      "pos": "5.3",
-      "includingLoc": "None"
+    "2" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/dataProducts.fpp",
+      "pos" : "5.3",
+      "includingLoc" : "None"
     },
-    "3": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/dataProducts.fpp",
-      "pos": "6.3",
-      "includingLoc": "None"
+    "3" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/dataProducts.fpp",
+      "pos" : "6.3",
+      "includingLoc" : "None"
     },
-    "4": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/dataProducts.fpp",
-      "pos": "6.3",
-      "includingLoc": "None"
+    "4" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/dataProducts.fpp",
+      "pos" : "6.3",
+      "includingLoc" : "None"
     },
-    "5": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/dataProducts.fpp",
-      "pos": "6.3",
-      "includingLoc": "None"
+    "5" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/dataProducts.fpp",
+      "pos" : "6.3",
+      "includingLoc" : "None"
     },
-    "6": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/dataProducts.fpp",
-      "pos": "1.1",
-      "includingLoc": "None"
+    "6" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/dataProducts.fpp",
+      "pos" : "1.1",
+      "includingLoc" : "None"
     },
-    "7": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/dataProducts.fpp",
-      "pos": "12.3",
-      "includingLoc": "None"
+    "7" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/dataProducts.fpp",
+      "pos" : "12.3",
+      "includingLoc" : "None"
     },
-    "8": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/dataProducts.fpp",
-      "pos": "13.3",
-      "includingLoc": "None"
+    "8" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/dataProducts.fpp",
+      "pos" : "13.3",
+      "includingLoc" : "None"
     },
-    "9": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/dataProducts.fpp",
-      "pos": "14.3",
-      "includingLoc": "None"
+    "9" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/dataProducts.fpp",
+      "pos" : "14.3",
+      "includingLoc" : "None"
     },
-    "10": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/dataProducts.fpp",
-      "pos": "15.3",
-      "includingLoc": "None"
+    "10" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/dataProducts.fpp",
+      "pos" : "15.3",
+      "includingLoc" : "None"
     },
-    "11": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/dataProducts.fpp",
-      "pos": "18.3",
-      "includingLoc": "None"
+    "11" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/dataProducts.fpp",
+      "pos" : "18.3",
+      "includingLoc" : "None"
     },
-    "12": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/dataProducts.fpp",
-      "pos": "21.31",
-      "includingLoc": "None"
+    "12" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/dataProducts.fpp",
+      "pos" : "21.31",
+      "includingLoc" : "None"
     },
-    "13": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/dataProducts.fpp",
-      "pos": "21.3",
-      "includingLoc": "None"
+    "13" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/dataProducts.fpp",
+      "pos" : "21.3",
+      "includingLoc" : "None"
     },
-    "14": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/dataProducts.fpp",
-      "pos": "24.35",
-      "includingLoc": "None"
+    "14" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/dataProducts.fpp",
+      "pos" : "24.35",
+      "includingLoc" : "None"
     },
-    "15": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/dataProducts.fpp",
-      "pos": "24.58",
-      "includingLoc": "None"
+    "15" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/dataProducts.fpp",
+      "pos" : "24.58",
+      "includingLoc" : "None"
     },
-    "16": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/dataProducts.fpp",
-      "pos": "24.3",
-      "includingLoc": "None"
+    "16" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/dataProducts.fpp",
+      "pos" : "24.3",
+      "includingLoc" : "None"
     },
-    "17": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/dataProducts.fpp",
-      "pos": "27.25",
-      "includingLoc": "None"
+    "17" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/dataProducts.fpp",
+      "pos" : "27.25",
+      "includingLoc" : "None"
     },
-    "18": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/dataProducts.fpp",
-      "pos": "27.3",
-      "includingLoc": "None"
+    "18" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/dataProducts.fpp",
+      "pos" : "27.3",
+      "includingLoc" : "None"
     },
-    "19": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/dataProducts.fpp",
-      "pos": "30.22",
-      "includingLoc": "None"
+    "19" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/dataProducts.fpp",
+      "pos" : "30.22",
+      "includingLoc" : "None"
     },
-    "20": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/dataProducts.fpp",
-      "pos": "30.29",
-      "includingLoc": "None"
+    "20" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/dataProducts.fpp",
+      "pos" : "30.29",
+      "includingLoc" : "None"
     },
-    "21": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/dataProducts.fpp",
-      "pos": "30.3",
-      "includingLoc": "None"
+    "21" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/dataProducts.fpp",
+      "pos" : "30.3",
+      "includingLoc" : "None"
     },
-    "22": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/dataProducts.fpp",
-      "pos": "30.22",
-      "includingLoc": "None"
+    "22" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/dataProducts.fpp",
+      "pos" : "30.22",
+      "includingLoc" : "None"
     },
-    "23": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/dataProducts.fpp",
-      "pos": "30.29",
-      "includingLoc": "None"
+    "23" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/dataProducts.fpp",
+      "pos" : "30.29",
+      "includingLoc" : "None"
     },
-    "24": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/dataProducts.fpp",
-      "pos": "30.3",
-      "includingLoc": "None"
+    "24" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/dataProducts.fpp",
+      "pos" : "30.3",
+      "includingLoc" : "None"
     },
-    "25": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/dataProducts.fpp",
-      "pos": "30.22",
-      "includingLoc": "None"
+    "25" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/dataProducts.fpp",
+      "pos" : "30.22",
+      "includingLoc" : "None"
     },
-    "26": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/dataProducts.fpp",
-      "pos": "30.29",
-      "includingLoc": "None"
+    "26" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/dataProducts.fpp",
+      "pos" : "30.29",
+      "includingLoc" : "None"
     },
-    "27": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/dataProducts.fpp",
-      "pos": "30.3",
-      "includingLoc": "None"
+    "27" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/dataProducts.fpp",
+      "pos" : "30.3",
+      "includingLoc" : "None"
     },
-    "28": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/dataProducts.fpp",
-      "pos": "10.1",
-      "includingLoc": "None"
+    "28" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/dataProducts.fpp",
+      "pos" : "10.1",
+      "includingLoc" : "None"
     }
   }
 }

--- a/tests/data_products/data_products_locations.json
+++ b/tests/data_products/data_products_locations.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion": "[ fpp version ]",
+  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
   "locationMap": {
     "0": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/dataProducts.fpp",

--- a/tests/events/events.fpp
+++ b/tests/events/events.fpp
@@ -52,7 +52,8 @@ module M {
     event Event1 \
       severity activity low \
       id 0x10 \
-      format "Event 1 occurred"
+      format "Event 1 occurred" \
+      throttle 10
 
     @ Event 2
     event Event2(
@@ -60,7 +61,11 @@ module M {
                 ) \
       severity command \
       id 2 \
-      format "Port {}"
+      format "Port {}" \
+      throttle 10 every {
+                          seconds = 10
+                          useconds = 10
+                        }
 
     @ Event 3
     @ Event with 3 args

--- a/tests/events/events_analysis.json
+++ b/tests/events/events_analysis.json
@@ -1,434 +1,505 @@
 {
-  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
-  "analysis": {
-    "componentInstanceMap": {},
-    "componentMap": {
-      "19": {
-        "aNode": {
-          "astNodeId": 19
+  "fppVersion" : "v3.1.0a10-54-g11243e778",
+  "analysis" : {
+    "componentInstanceMap" : {
+      
+    },
+    "componentMap" : {
+      "19" : {
+        "aNode" : {
+          "astNodeId" : 19
         },
-        "portMap": {
-          "eventOut": {
-            "Special": {
-              "aNode": {
-                "astNodeId": 0
+        "portMap" : {
+          "eventOut" : {
+            "Special" : {
+              "aNode" : {
+                "astNodeId" : 0
               },
-              "specifier": {
-                "inputKind": "None",
-                "kind": {
-                  "Event": {}
+              "specifier" : {
+                "inputKind" : "None",
+                "kind" : {
+                  "Event" : {
+                    
+                  }
                 },
-                "name": "eventOut",
-                "priority": "None",
-                "queueFull": "None"
+                "name" : "eventOut",
+                "priority" : "None",
+                "queueFull" : "None"
               },
-              "symbol": {
-                "Port": {
-                  "nodeId": 198,
-                  "unqualifiedName": "Log"
+              "symbol" : {
+                "Port" : {
+                  "nodeId" : 198,
+                  "unqualifiedName" : "Log"
                 }
               },
-              "priority": "None",
-              "queueFull": "None",
-              "importNodeIds": []
+              "priority" : "None",
+              "queueFull" : "None",
+              "importNodeIds" : [
+              ]
             }
           },
-          "textEventOut": {
-            "Special": {
-              "aNode": {
-                "astNodeId": 1
+          "textEventOut" : {
+            "Special" : {
+              "aNode" : {
+                "astNodeId" : 1
               },
-              "specifier": {
-                "inputKind": "None",
-                "kind": {
-                  "TextEvent": {}
+              "specifier" : {
+                "inputKind" : "None",
+                "kind" : {
+                  "TextEvent" : {
+                    
+                  }
                 },
-                "name": "textEventOut",
-                "priority": "None",
-                "queueFull": "None"
+                "name" : "textEventOut",
+                "priority" : "None",
+                "queueFull" : "None"
               },
-              "symbol": {
-                "Port": {
-                  "nodeId": 199,
-                  "unqualifiedName": "LogText"
+              "symbol" : {
+                "Port" : {
+                  "nodeId" : 199,
+                  "unqualifiedName" : "LogText"
                 }
               },
-              "priority": "None",
-              "queueFull": "None",
-              "importNodeIds": []
+              "priority" : "None",
+              "queueFull" : "None",
+              "importNodeIds" : [
+              ]
             }
           },
-          "timeGetOut": {
-            "Special": {
-              "aNode": {
-                "astNodeId": 2
+          "timeGetOut" : {
+            "Special" : {
+              "aNode" : {
+                "astNodeId" : 2
               },
-              "specifier": {
-                "inputKind": "None",
-                "kind": {
-                  "TimeGet": {}
+              "specifier" : {
+                "inputKind" : "None",
+                "kind" : {
+                  "TimeGet" : {
+                    
+                  }
                 },
-                "name": "timeGetOut",
-                "priority": "None",
-                "queueFull": "None"
+                "name" : "timeGetOut",
+                "priority" : "None",
+                "queueFull" : "None"
               },
-              "symbol": {
-                "Port": {
-                  "nodeId": 202,
-                  "unqualifiedName": "Time"
+              "symbol" : {
+                "Port" : {
+                  "nodeId" : 202,
+                  "unqualifiedName" : "Time"
                 }
               },
-              "priority": "None",
-              "queueFull": "None",
-              "importNodeIds": []
+              "priority" : "None",
+              "queueFull" : "None",
+              "importNodeIds" : [
+              ]
             }
           }
         },
-        "specialPortMap": {
-          "event": {
-            "aNode": {
-              "astNodeId": 0
+        "specialPortMap" : {
+          "event" : {
+            "aNode" : {
+              "astNodeId" : 0
             },
-            "specifier": {
-              "inputKind": "None",
-              "kind": {
-                "Event": {}
+            "specifier" : {
+              "inputKind" : "None",
+              "kind" : {
+                "Event" : {
+                  
+                }
               },
-              "name": "eventOut",
-              "priority": "None",
-              "queueFull": "None"
+              "name" : "eventOut",
+              "priority" : "None",
+              "queueFull" : "None"
             },
-            "symbol": {
-              "Port": {
-                "nodeId": 198,
-                "unqualifiedName": "Log"
+            "symbol" : {
+              "Port" : {
+                "nodeId" : 198,
+                "unqualifiedName" : "Log"
               }
             },
-            "priority": "None",
-            "queueFull": "None",
-            "importNodeIds": []
+            "priority" : "None",
+            "queueFull" : "None",
+            "importNodeIds" : [
+            ]
           },
-          "text event": {
-            "aNode": {
-              "astNodeId": 1
+          "text event" : {
+            "aNode" : {
+              "astNodeId" : 1
             },
-            "specifier": {
-              "inputKind": "None",
-              "kind": {
-                "TextEvent": {}
+            "specifier" : {
+              "inputKind" : "None",
+              "kind" : {
+                "TextEvent" : {
+                  
+                }
               },
-              "name": "textEventOut",
-              "priority": "None",
-              "queueFull": "None"
+              "name" : "textEventOut",
+              "priority" : "None",
+              "queueFull" : "None"
             },
-            "symbol": {
-              "Port": {
-                "nodeId": 199,
-                "unqualifiedName": "LogText"
+            "symbol" : {
+              "Port" : {
+                "nodeId" : 199,
+                "unqualifiedName" : "LogText"
               }
             },
-            "priority": "None",
-            "queueFull": "None",
-            "importNodeIds": []
+            "priority" : "None",
+            "queueFull" : "None",
+            "importNodeIds" : [
+            ]
           },
-          "time get": {
-            "aNode": {
-              "astNodeId": 2
+          "time get" : {
+            "aNode" : {
+              "astNodeId" : 2
             },
-            "specifier": {
-              "inputKind": "None",
-              "kind": {
-                "TimeGet": {}
+            "specifier" : {
+              "inputKind" : "None",
+              "kind" : {
+                "TimeGet" : {
+                  
+                }
               },
-              "name": "timeGetOut",
-              "priority": "None",
-              "queueFull": "None"
+              "name" : "timeGetOut",
+              "priority" : "None",
+              "queueFull" : "None"
             },
-            "symbol": {
-              "Port": {
-                "nodeId": 202,
-                "unqualifiedName": "Time"
+            "symbol" : {
+              "Port" : {
+                "nodeId" : 202,
+                "unqualifiedName" : "Time"
               }
             },
-            "priority": "None",
-            "queueFull": "None",
-            "importNodeIds": []
+            "priority" : "None",
+            "queueFull" : "None",
+            "importNodeIds" : [
+            ]
           }
         },
-        "commandMap": {},
-        "defaultOpcode": 0,
-        "tlmChannelMap": {},
-        "tlmChannelNameMap": {},
-        "defaultTlmChannelId": 0,
-        "eventMap": {
-          "16": {
-            "aNode": {
-              "astNodeId": 5
+        "commandMap" : {
+          
+        },
+        "defaultOpcode" : 0,
+        "tlmChannelMap" : {
+          
+        },
+        "tlmChannelNameMap" : {
+          
+        },
+        "defaultTlmChannelId" : 0,
+        "eventMap" : {
+          "16" : {
+            "aNode" : {
+              "astNodeId" : 5
             },
-            "format": {
-              "prefix": "Event 1 occurred",
-              "fields": []
+            "format" : {
+              "prefix" : "Event 1 occurred",
+              "fields" : [
+              ]
             },
-            "throttle": "None"
+            "throttle" : "None"
           },
-          "17": {
-            "aNode": {
-              "astNodeId": 12
+          "17" : {
+            "aNode" : {
+              "astNodeId" : 12
             },
-            "format": {
-              "prefix": "The count is ",
-              "fields": [
+            "format" : {
+              "prefix" : "The count is ",
+              "fields" : [
                 [
                   {
-                    "Default": {}
+                    "Default" : {
+                      
+                    }
                   },
                   ""
                 ]
               ]
             },
-            "throttle": "None"
+            "throttle" : "None"
           },
-          "18": {
-            "aNode": {
-              "astNodeId": 18
+          "18" : {
+            "aNode" : {
+              "astNodeId" : 18
             },
-            "format": {
-              "prefix": "Event 3 occurred",
-              "fields": []
+            "format" : {
+              "prefix" : "Event 3 occurred",
+              "fields" : [
+              ]
             },
-            "throttle": "None"
+            "throttle" : "None"
           }
         },
-        "defaultEventId": 19,
-        "paramMap": {},
-        "specPortMatchingList": [],
-        "stateMachineInstanceMap": {},
-        "portMatchingList": [],
-        "defaultParamId": 0,
-        "containerMap": {},
-        "defaultContainerId": 0,
-        "recordMap": {},
-        "defaultRecordId": 0
+        "defaultEventId" : 19,
+        "paramMap" : {
+          
+        },
+        "specPortMatchingList" : [
+        ],
+        "stateMachineInstanceMap" : {
+          
+        },
+        "portMatchingList" : [
+        ],
+        "defaultParamId" : 0,
+        "containerMap" : {
+          
+        },
+        "defaultContainerId" : 0,
+        "recordMap" : {
+          
+        },
+        "defaultRecordId" : 0
       },
-      "196": {
-        "aNode": {
-          "astNodeId": 196
+      "196" : {
+        "aNode" : {
+          "astNodeId" : 196
         },
-        "portMap": {
-          "eventOut": {
-            "Special": {
-              "aNode": {
-                "astNodeId": 138
+        "portMap" : {
+          "eventOut" : {
+            "Special" : {
+              "aNode" : {
+                "astNodeId" : 138
               },
-              "specifier": {
-                "inputKind": "None",
-                "kind": {
-                  "Event": {}
+              "specifier" : {
+                "inputKind" : "None",
+                "kind" : {
+                  "Event" : {
+                    
+                  }
                 },
-                "name": "eventOut",
-                "priority": "None",
-                "queueFull": "None"
+                "name" : "eventOut",
+                "priority" : "None",
+                "queueFull" : "None"
               },
-              "symbol": {
-                "Port": {
-                  "nodeId": 198,
-                  "unqualifiedName": "Log"
+              "symbol" : {
+                "Port" : {
+                  "nodeId" : 198,
+                  "unqualifiedName" : "Log"
                 }
               },
-              "priority": "None",
-              "queueFull": "None",
-              "importNodeIds": []
+              "priority" : "None",
+              "queueFull" : "None",
+              "importNodeIds" : [
+              ]
             }
           },
-          "textEventOut": {
-            "Special": {
-              "aNode": {
-                "astNodeId": 139
+          "textEventOut" : {
+            "Special" : {
+              "aNode" : {
+                "astNodeId" : 139
               },
-              "specifier": {
-                "inputKind": "None",
-                "kind": {
-                  "TextEvent": {}
+              "specifier" : {
+                "inputKind" : "None",
+                "kind" : {
+                  "TextEvent" : {
+                    
+                  }
                 },
-                "name": "textEventOut",
-                "priority": "None",
-                "queueFull": "None"
+                "name" : "textEventOut",
+                "priority" : "None",
+                "queueFull" : "None"
               },
-              "symbol": {
-                "Port": {
-                  "nodeId": 199,
-                  "unqualifiedName": "LogText"
+              "symbol" : {
+                "Port" : {
+                  "nodeId" : 199,
+                  "unqualifiedName" : "LogText"
                 }
               },
-              "priority": "None",
-              "queueFull": "None",
-              "importNodeIds": []
+              "priority" : "None",
+              "queueFull" : "None",
+              "importNodeIds" : [
+              ]
             }
           },
-          "timeGetOut": {
-            "Special": {
-              "aNode": {
-                "astNodeId": 140
+          "timeGetOut" : {
+            "Special" : {
+              "aNode" : {
+                "astNodeId" : 140
               },
-              "specifier": {
-                "inputKind": "None",
-                "kind": {
-                  "TimeGet": {}
+              "specifier" : {
+                "inputKind" : "None",
+                "kind" : {
+                  "TimeGet" : {
+                    
+                  }
                 },
-                "name": "timeGetOut",
-                "priority": "None",
-                "queueFull": "None"
+                "name" : "timeGetOut",
+                "priority" : "None",
+                "queueFull" : "None"
               },
-              "symbol": {
-                "Port": {
-                  "nodeId": 202,
-                  "unqualifiedName": "Time"
+              "symbol" : {
+                "Port" : {
+                  "nodeId" : 202,
+                  "unqualifiedName" : "Time"
                 }
               },
-              "priority": "None",
-              "queueFull": "None",
-              "importNodeIds": []
+              "priority" : "None",
+              "queueFull" : "None",
+              "importNodeIds" : [
+              ]
             }
           }
         },
-        "specialPortMap": {
-          "event": {
-            "aNode": {
-              "astNodeId": 138
+        "specialPortMap" : {
+          "event" : {
+            "aNode" : {
+              "astNodeId" : 138
             },
-            "specifier": {
-              "inputKind": "None",
-              "kind": {
-                "Event": {}
+            "specifier" : {
+              "inputKind" : "None",
+              "kind" : {
+                "Event" : {
+                  
+                }
               },
-              "name": "eventOut",
-              "priority": "None",
-              "queueFull": "None"
+              "name" : "eventOut",
+              "priority" : "None",
+              "queueFull" : "None"
             },
-            "symbol": {
-              "Port": {
-                "nodeId": 198,
-                "unqualifiedName": "Log"
+            "symbol" : {
+              "Port" : {
+                "nodeId" : 198,
+                "unqualifiedName" : "Log"
               }
             },
-            "priority": "None",
-            "queueFull": "None",
-            "importNodeIds": []
+            "priority" : "None",
+            "queueFull" : "None",
+            "importNodeIds" : [
+            ]
           },
-          "text event": {
-            "aNode": {
-              "astNodeId": 139
+          "text event" : {
+            "aNode" : {
+              "astNodeId" : 139
             },
-            "specifier": {
-              "inputKind": "None",
-              "kind": {
-                "TextEvent": {}
+            "specifier" : {
+              "inputKind" : "None",
+              "kind" : {
+                "TextEvent" : {
+                  
+                }
               },
-              "name": "textEventOut",
-              "priority": "None",
-              "queueFull": "None"
+              "name" : "textEventOut",
+              "priority" : "None",
+              "queueFull" : "None"
             },
-            "symbol": {
-              "Port": {
-                "nodeId": 199,
-                "unqualifiedName": "LogText"
+            "symbol" : {
+              "Port" : {
+                "nodeId" : 199,
+                "unqualifiedName" : "LogText"
               }
             },
-            "priority": "None",
-            "queueFull": "None",
-            "importNodeIds": []
+            "priority" : "None",
+            "queueFull" : "None",
+            "importNodeIds" : [
+            ]
           },
-          "time get": {
-            "aNode": {
-              "astNodeId": 140
+          "time get" : {
+            "aNode" : {
+              "astNodeId" : 140
             },
-            "specifier": {
-              "inputKind": "None",
-              "kind": {
-                "TimeGet": {}
+            "specifier" : {
+              "inputKind" : "None",
+              "kind" : {
+                "TimeGet" : {
+                  
+                }
               },
-              "name": "timeGetOut",
-              "priority": "None",
-              "queueFull": "None"
+              "name" : "timeGetOut",
+              "priority" : "None",
+              "queueFull" : "None"
             },
-            "symbol": {
-              "Port": {
-                "nodeId": 202,
-                "unqualifiedName": "Time"
+            "symbol" : {
+              "Port" : {
+                "nodeId" : 202,
+                "unqualifiedName" : "Time"
               }
             },
-            "priority": "None",
-            "queueFull": "None",
-            "importNodeIds": []
+            "priority" : "None",
+            "queueFull" : "None",
+            "importNodeIds" : [
+            ]
           }
         },
-        "commandMap": {},
-        "defaultOpcode": 0,
-        "tlmChannelMap": {},
-        "tlmChannelNameMap": {},
-        "defaultTlmChannelId": 0,
-        "eventMap": {
-          "16": {
-            "aNode": {
-              "astNodeId": 145
+        "commandMap" : {
+          
+        },
+        "defaultOpcode" : 0,
+        "tlmChannelMap" : {
+          
+        },
+        "tlmChannelNameMap" : {
+          
+        },
+        "defaultTlmChannelId" : 0,
+        "eventMap" : {
+          "16" : {
+            "aNode" : {
+              "astNodeId" : 145
             },
-            "format": {
-              "prefix": "Event 1 occurred",
-              "fields": []
+            "format" : {
+              "prefix" : "Event 1 occurred",
+              "fields" : [
+              ]
             },
-            "throttle": {
-              "Some": {
-                "count": 10,
-                "every": "None"
+            "throttle" : {
+              "Some" : {
+                "count" : 10,
+                "every" : "None"
               }
             }
           },
-          "2": {
-            "aNode": {
-              "astNodeId": 159
+          "2" : {
+            "aNode" : {
+              "astNodeId" : 159
             },
-            "format": {
-              "prefix": "Port ",
-              "fields": [
+            "format" : {
+              "prefix" : "Port ",
+              "fields" : [
                 [
                   {
-                    "Default": {}
+                    "Default" : {
+                      
+                    }
                   },
                   ""
                 ]
               ]
             },
-            "throttle": {
-              "Some": {
-                "count": 10,
-                "every": {
-                  "Some": {
-                    "seconds": 10,
-                    "useconds": 10
+            "throttle" : {
+              "Some" : {
+                "count" : 10,
+                "every" : {
+                  "Some" : {
+                    "seconds" : 10,
+                    "useconds" : 10
                   }
                 }
               }
             }
           },
-          "9": {
-            "aNode": {
-              "astNodeId": 174
+          "9" : {
+            "aNode" : {
+              "astNodeId" : 174
             },
-            "format": {
-              "prefix": "Event3 args: I32: ",
-              "fields": [
+            "format" : {
+              "prefix" : "Event3 args: I32: ",
+              "fields" : [
                 [
                   {
-                    "Default": {}
+                    "Default" : {
+                      
+                    }
                   },
                   ", F32: "
                 ],
                 [
                   {
-                    "Rational": {
-                      "precision": "None",
-                      "t": {
-                        "Fixed": {}
+                    "Rational" : {
+                      "precision" : "None",
+                      "t" : {
+                        "Fixed" : {
+                          
+                        }
                       }
                     }
                   },
@@ -436,26 +507,30 @@
                 ],
                 [
                   {
-                    "Default": {}
+                    "Default" : {
+                      
+                    }
                   },
                   ""
                 ]
               ]
             },
-            "throttle": "None"
+            "throttle" : "None"
           },
-          "6": {
-            "aNode": {
-              "astNodeId": 195
+          "6" : {
+            "aNode" : {
+              "astNodeId" : 195
             },
-            "format": {
-              "prefix": "Too many outstanding commands. opcode=0x",
-              "fields": [
+            "format" : {
+              "prefix" : "Too many outstanding commands. opcode=0x",
+              "fields" : [
                 [
                   {
-                    "Integer": {
-                      "t": {
-                        "Hexadecimal": {}
+                    "Integer" : {
+                      "t" : {
+                        "Hexadecimal" : {
+                          
+                        }
                       }
                     }
                   },
@@ -463,123 +538,139 @@
                 ]
               ]
             },
-            "throttle": "None"
+            "throttle" : "None"
           }
         },
-        "defaultEventId": 7,
-        "paramMap": {},
-        "specPortMatchingList": [],
-        "stateMachineInstanceMap": {},
-        "portMatchingList": [],
-        "defaultParamId": 0,
-        "containerMap": {},
-        "defaultContainerId": 0,
-        "recordMap": {},
-        "defaultRecordId": 0
+        "defaultEventId" : 7,
+        "paramMap" : {
+          
+        },
+        "specPortMatchingList" : [
+        ],
+        "stateMachineInstanceMap" : {
+          
+        },
+        "portMatchingList" : [
+        ],
+        "defaultParamId" : 0,
+        "containerMap" : {
+          
+        },
+        "defaultContainerId" : 0,
+        "recordMap" : {
+          
+        },
+        "defaultRecordId" : 0
       }
     },
-    "includedFileSet": [],
-    "inputFileSet": [
+    "includedFileSet" : [
+    ],
+    "inputFileSet" : [
       "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp"
     ],
-    "locationSpecifierMap": [],
-    "parentSymbolMap": {
-      "196": {
-        "Module": {
-          "nodeId": 197,
-          "unqualifiedName": "M"
+    "locationSpecifierMap" : [
+    ],
+    "parentSymbolMap" : {
+      "196" : {
+        "Module" : {
+          "nodeId" : 197,
+          "unqualifiedName" : "M"
         }
       },
-      "198": {
-        "Module": {
-          "nodeId": 203,
-          "unqualifiedName": "Fw"
+      "198" : {
+        "Module" : {
+          "nodeId" : 203,
+          "unqualifiedName" : "Fw"
         }
       },
-      "199": {
-        "Module": {
-          "nodeId": 203,
-          "unqualifiedName": "Fw"
+      "199" : {
+        "Module" : {
+          "nodeId" : 203,
+          "unqualifiedName" : "Fw"
         }
       },
-      "202": {
-        "Module": {
-          "nodeId": 203,
-          "unqualifiedName": "Fw"
+      "202" : {
+        "Module" : {
+          "nodeId" : 203,
+          "unqualifiedName" : "Fw"
         }
       }
     },
-    "symbolScopeMap": {
-      "19": {
-        "map": {}
+    "symbolScopeMap" : {
+      "19" : {
+        "map" : {
+          
+        }
       },
-      "196": {
-        "map": {}
+      "196" : {
+        "map" : {
+          
+        }
       },
-      "197": {
-        "map": {
-          "Component": {
-            "map": {
-              "EventThrottling": {
-                "Component": {
-                  "nodeId": 196,
-                  "unqualifiedName": "EventThrottling"
+      "197" : {
+        "map" : {
+          "Component" : {
+            "map" : {
+              "EventThrottling" : {
+                "Component" : {
+                  "nodeId" : 196,
+                  "unqualifiedName" : "EventThrottling"
                 }
               }
             }
           },
-          "StateMachine": {
-            "map": {
-              "EventThrottling": {
-                "Component": {
-                  "nodeId": 196,
-                  "unqualifiedName": "EventThrottling"
+          "StateMachine" : {
+            "map" : {
+              "EventThrottling" : {
+                "Component" : {
+                  "nodeId" : 196,
+                  "unqualifiedName" : "EventThrottling"
                 }
               }
             }
           },
-          "Type": {
-            "map": {
-              "EventThrottling": {
-                "Component": {
-                  "nodeId": 196,
-                  "unqualifiedName": "EventThrottling"
+          "Type" : {
+            "map" : {
+              "EventThrottling" : {
+                "Component" : {
+                  "nodeId" : 196,
+                  "unqualifiedName" : "EventThrottling"
                 }
               }
             }
           },
-          "Value": {
-            "map": {
-              "EventThrottling": {
-                "Component": {
-                  "nodeId": 196,
-                  "unqualifiedName": "EventThrottling"
+          "Value" : {
+            "map" : {
+              "EventThrottling" : {
+                "Component" : {
+                  "nodeId" : 196,
+                  "unqualifiedName" : "EventThrottling"
                 }
               }
             }
           }
         }
       },
-      "203": {
-        "map": {
-          "Port": {
-            "map": {
-              "Log": {
-                "Port": {
-                  "nodeId": 198,
-                  "unqualifiedName": "Log"
+      "203" : {
+        "map" : {
+          "Port" : {
+            "map" : {
+              "Log" : {
+                "Port" : {
+                  "nodeId" : 198,
+                  "unqualifiedName" : "Log"
                 }
               },
-              "LogText": {
-                "Port": {
-                  "nodeId": 199,
-                  "unqualifiedName": "LogText"
+              "LogText" : {
+                "Port" : {
+                  "nodeId" : 199,
+                  "unqualifiedName" : "LogText"
                 }
               },
-              "Time": {
-                "Port": {
-                  "nodeId": 202,
-                  "unqualifiedName": "Time"
+              "Time" : {
+                "Port" : {
+                  "nodeId" : 202,
+                  "unqualifiedName" : "Time"
                 }
               }
             }
@@ -587,237 +678,280 @@
         }
       }
     },
-    "topologyMap": {},
-    "typeMap": {
-      "141": {
-        "Int": {
-          "Integer": {}
+    "topologyMap" : {
+      
+    },
+    "typeMap" : {
+      "141" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "166": {
-        "Primitive": {
-          "Float": {
-            "kind": {
-              "F32": {}
+      "166" : {
+        "Primitive" : {
+          "Float" : {
+            "kind" : {
+              "F32" : {
+                
+              }
             }
           }
         }
       },
-      "155": {
-        "Int": {
-          "Integer": {}
+      "155" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "152": {
-        "Int": {
-          "Integer": {}
+      "152" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "10": {
-        "Int": {
-          "Integer": {}
+      "10" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "148": {
-        "Int": {
-          "PrimitiveInt": {
-            "kind": {
-              "I32": {}
+      "148" : {
+        "Int" : {
+          "PrimitiveInt" : {
+            "kind" : {
+              "I32" : {
+                
+              }
             }
           }
         }
       },
-      "143": {
-        "Int": {
-          "Integer": {}
+      "143" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "172": {
-        "Int": {
-          "Integer": {}
+      "172" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "157": {
-        "AnonStruct": {
-          "members": {
-            "seconds": {
-              "Int": {
-                "Integer": {}
+      "157" : {
+        "AnonStruct" : {
+          "members" : {
+            "seconds" : {
+              "Int" : {
+                "Integer" : {
+                  
+                }
               }
             },
-            "useconds": {
-              "Int": {
-                "Integer": {}
+            "useconds" : {
+              "Int" : {
+                "Integer" : {
+                  
+                }
               }
             }
           }
         }
       },
-      "193": {
-        "Int": {
-          "Integer": {}
+      "193" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "153": {
-        "Int": {
-          "Integer": {}
+      "153" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "8": {
-        "Int": {
-          "PrimitiveInt": {
-            "kind": {
-              "U32": {}
+      "8" : {
+        "Int" : {
+          "PrimitiveInt" : {
+            "kind" : {
+              "U32" : {
+                
+              }
             }
           }
         }
       },
-      "170": {
-        "Int": {
-          "PrimitiveInt": {
-            "kind": {
-              "U8": {}
+      "170" : {
+        "Int" : {
+          "PrimitiveInt" : {
+            "kind" : {
+              "U8" : {
+                
+              }
             }
           }
         }
       },
-      "162": {
-        "Int": {
-          "PrimitiveInt": {
-            "kind": {
-              "I32": {}
+      "162" : {
+        "Int" : {
+          "PrimitiveInt" : {
+            "kind" : {
+              "I32" : {
+                
+              }
             }
           }
         }
       },
-      "191": {
-        "Int": {
-          "PrimitiveInt": {
-            "kind": {
-              "U32": {}
+      "191" : {
+        "Int" : {
+          "PrimitiveInt" : {
+            "kind" : {
+              "U32" : {
+                
+              }
             }
           }
         }
       },
-      "150": {
-        "Int": {
-          "Integer": {}
+      "150" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "3": {
-        "Int": {
-          "Integer": {}
+      "3" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       }
     },
-    "useDefMap": {
-      "139": {
-        "Port": {
-          "nodeId": 199,
-          "unqualifiedName": "LogText"
+    "useDefMap" : {
+      "139" : {
+        "Port" : {
+          "nodeId" : 199,
+          "unqualifiedName" : "LogText"
         }
       },
-      "138": {
-        "Port": {
-          "nodeId": 198,
-          "unqualifiedName": "Log"
+      "138" : {
+        "Port" : {
+          "nodeId" : 198,
+          "unqualifiedName" : "Log"
         }
       },
-      "1": {
-        "Port": {
-          "nodeId": 199,
-          "unqualifiedName": "LogText"
+      "1" : {
+        "Port" : {
+          "nodeId" : 199,
+          "unqualifiedName" : "LogText"
         }
       },
-      "140": {
-        "Port": {
-          "nodeId": 202,
-          "unqualifiedName": "Time"
+      "140" : {
+        "Port" : {
+          "nodeId" : 202,
+          "unqualifiedName" : "Time"
         }
       },
-      "0": {
-        "Port": {
-          "nodeId": 198,
-          "unqualifiedName": "Log"
+      "0" : {
+        "Port" : {
+          "nodeId" : 198,
+          "unqualifiedName" : "Log"
         }
       },
-      "2": {
-        "Port": {
-          "nodeId": 202,
-          "unqualifiedName": "Time"
+      "2" : {
+        "Port" : {
+          "nodeId" : 202,
+          "unqualifiedName" : "Time"
         }
       }
     },
-    "valueMap": {
-      "141": {
-        "Integer": {
-          "value": 16
+    "valueMap" : {
+      "141" : {
+        "Integer" : {
+          "value" : 16
         }
       },
-      "155": {
-        "Integer": {
-          "value": 10
+      "155" : {
+        "Integer" : {
+          "value" : 10
         }
       },
-      "152": {
-        "Integer": {
-          "value": 10
+      "152" : {
+        "Integer" : {
+          "value" : 10
         }
       },
-      "10": {
-        "Integer": {
-          "value": 17
+      "10" : {
+        "Integer" : {
+          "value" : 17
         }
       },
-      "143": {
-        "Integer": {
-          "value": 10
+      "143" : {
+        "Integer" : {
+          "value" : 10
         }
       },
-      "172": {
-        "Integer": {
-          "value": 9
+      "172" : {
+        "Integer" : {
+          "value" : 9
         }
       },
-      "157": {
-        "AnonStruct": {
-          "members": {
-            "seconds": {
-              "Integer": {
-                "value": 10
+      "157" : {
+        "AnonStruct" : {
+          "members" : {
+            "seconds" : {
+              "Integer" : {
+                "value" : 10
               }
             },
-            "useconds": {
-              "Integer": {
-                "value": 10
+            "useconds" : {
+              "Integer" : {
+                "value" : 10
               }
             }
           }
         }
       },
-      "193": {
-        "Integer": {
-          "value": 6
+      "193" : {
+        "Integer" : {
+          "value" : 6
         }
       },
-      "153": {
-        "Integer": {
-          "value": 10
+      "153" : {
+        "Integer" : {
+          "value" : 10
         }
       },
-      "150": {
-        "Integer": {
-          "value": 2
+      "150" : {
+        "Integer" : {
+          "value" : 2
         }
       },
-      "3": {
-        "Integer": {
-          "value": 16
+      "3" : {
+        "Integer" : {
+          "value" : 16
         }
       }
     },
-    "stateMachineMap": {},
-    "dictionarySymbolSet": [],
-    "interfaceMap": {}
+    "stateMachineMap" : {
+      
+    },
+    "dictionarySymbolSet" : [
+    ],
+    "interfaceMap" : {
+      
+    }
   }
 }

--- a/tests/events/events_analysis.json
+++ b/tests/events/events_analysis.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion": "[ fpp version ]",
+  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
   "analysis": {
     "componentInstanceMap": {},
     "componentMap": {
@@ -24,7 +24,7 @@
               },
               "symbol": {
                 "Port": {
-                  "nodeId": 171,
+                  "nodeId": 198,
                   "unqualifiedName": "Log"
                 }
               },
@@ -49,7 +49,7 @@
               },
               "symbol": {
                 "Port": {
-                  "nodeId": 172,
+                  "nodeId": 199,
                   "unqualifiedName": "LogText"
                 }
               },
@@ -74,7 +74,7 @@
               },
               "symbol": {
                 "Port": {
-                  "nodeId": 175,
+                  "nodeId": 202,
                   "unqualifiedName": "Time"
                 }
               },
@@ -100,7 +100,7 @@
             },
             "symbol": {
               "Port": {
-                "nodeId": 171,
+                "nodeId": 198,
                 "unqualifiedName": "Log"
               }
             },
@@ -123,7 +123,7 @@
             },
             "symbol": {
               "Port": {
-                "nodeId": 172,
+                "nodeId": 199,
                 "unqualifiedName": "LogText"
               }
             },
@@ -146,7 +146,7 @@
             },
             "symbol": {
               "Port": {
-                "nodeId": 175,
+                "nodeId": 202,
                 "unqualifiedName": "Time"
               }
             },
@@ -210,15 +210,15 @@
         "recordMap": {},
         "defaultRecordId": 0
       },
-      "169": {
+      "196": {
         "aNode": {
-          "astNodeId": 169
+          "astNodeId": 196
         },
         "portMap": {
           "eventOut": {
             "Special": {
               "aNode": {
-                "astNodeId": 120
+                "astNodeId": 138
               },
               "specifier": {
                 "inputKind": "None",
@@ -231,7 +231,7 @@
               },
               "symbol": {
                 "Port": {
-                  "nodeId": 171,
+                  "nodeId": 198,
                   "unqualifiedName": "Log"
                 }
               },
@@ -243,7 +243,7 @@
           "textEventOut": {
             "Special": {
               "aNode": {
-                "astNodeId": 121
+                "astNodeId": 139
               },
               "specifier": {
                 "inputKind": "None",
@@ -256,7 +256,7 @@
               },
               "symbol": {
                 "Port": {
-                  "nodeId": 172,
+                  "nodeId": 199,
                   "unqualifiedName": "LogText"
                 }
               },
@@ -268,7 +268,7 @@
           "timeGetOut": {
             "Special": {
               "aNode": {
-                "astNodeId": 122
+                "astNodeId": 140
               },
               "specifier": {
                 "inputKind": "None",
@@ -281,7 +281,7 @@
               },
               "symbol": {
                 "Port": {
-                  "nodeId": 175,
+                  "nodeId": 202,
                   "unqualifiedName": "Time"
                 }
               },
@@ -294,7 +294,7 @@
         "specialPortMap": {
           "event": {
             "aNode": {
-              "astNodeId": 120
+              "astNodeId": 138
             },
             "specifier": {
               "inputKind": "None",
@@ -307,7 +307,7 @@
             },
             "symbol": {
               "Port": {
-                "nodeId": 171,
+                "nodeId": 198,
                 "unqualifiedName": "Log"
               }
             },
@@ -317,7 +317,7 @@
           },
           "text event": {
             "aNode": {
-              "astNodeId": 121
+              "astNodeId": 139
             },
             "specifier": {
               "inputKind": "None",
@@ -330,7 +330,7 @@
             },
             "symbol": {
               "Port": {
-                "nodeId": 172,
+                "nodeId": 199,
                 "unqualifiedName": "LogText"
               }
             },
@@ -340,7 +340,7 @@
           },
           "time get": {
             "aNode": {
-              "astNodeId": 122
+              "astNodeId": 140
             },
             "specifier": {
               "inputKind": "None",
@@ -353,7 +353,7 @@
             },
             "symbol": {
               "Port": {
-                "nodeId": 175,
+                "nodeId": 202,
                 "unqualifiedName": "Time"
               }
             },
@@ -370,17 +370,22 @@
         "eventMap": {
           "16": {
             "aNode": {
-              "astNodeId": 125
+              "astNodeId": 145
             },
             "format": {
               "prefix": "Event 1 occurred",
               "fields": []
             },
-            "throttle": "None"
+            "throttle": {
+              "Some": {
+                "count": 10,
+                "every": "None"
+              }
+            }
           },
           "2": {
             "aNode": {
-              "astNodeId": 132
+              "astNodeId": 159
             },
             "format": {
               "prefix": "Port ",
@@ -393,11 +398,21 @@
                 ]
               ]
             },
-            "throttle": "None"
+            "throttle": {
+              "Some": {
+                "count": 10,
+                "every": {
+                  "Some": {
+                    "seconds": 10,
+                    "useconds": 10
+                  }
+                }
+              }
+            }
           },
           "9": {
             "aNode": {
-              "astNodeId": 147
+              "astNodeId": 174
             },
             "format": {
               "prefix": "Event3 args: I32: ",
@@ -431,7 +446,7 @@
           },
           "6": {
             "aNode": {
-              "astNodeId": 168
+              "astNodeId": 195
             },
             "format": {
               "prefix": "Too many outstanding commands. opcode=0x",
@@ -469,27 +484,27 @@
     ],
     "locationSpecifierMap": [],
     "parentSymbolMap": {
-      "169": {
+      "196": {
         "Module": {
-          "nodeId": 170,
+          "nodeId": 197,
           "unqualifiedName": "M"
         }
       },
-      "171": {
+      "198": {
         "Module": {
-          "nodeId": 176,
+          "nodeId": 203,
           "unqualifiedName": "Fw"
         }
       },
-      "172": {
+      "199": {
         "Module": {
-          "nodeId": 176,
+          "nodeId": 203,
           "unqualifiedName": "Fw"
         }
       },
-      "175": {
+      "202": {
         "Module": {
-          "nodeId": 176,
+          "nodeId": 203,
           "unqualifiedName": "Fw"
         }
       }
@@ -498,16 +513,16 @@
       "19": {
         "map": {}
       },
-      "169": {
+      "196": {
         "map": {}
       },
-      "170": {
+      "197": {
         "map": {
           "Component": {
             "map": {
               "EventThrottling": {
                 "Component": {
-                  "nodeId": 169,
+                  "nodeId": 196,
                   "unqualifiedName": "EventThrottling"
                 }
               }
@@ -517,7 +532,7 @@
             "map": {
               "EventThrottling": {
                 "Component": {
-                  "nodeId": 169,
+                  "nodeId": 196,
                   "unqualifiedName": "EventThrottling"
                 }
               }
@@ -527,7 +542,7 @@
             "map": {
               "EventThrottling": {
                 "Component": {
-                  "nodeId": 169,
+                  "nodeId": 196,
                   "unqualifiedName": "EventThrottling"
                 }
               }
@@ -537,7 +552,7 @@
             "map": {
               "EventThrottling": {
                 "Component": {
-                  "nodeId": 169,
+                  "nodeId": 196,
                   "unqualifiedName": "EventThrottling"
                 }
               }
@@ -545,25 +560,25 @@
           }
         }
       },
-      "176": {
+      "203": {
         "map": {
           "Port": {
             "map": {
               "Log": {
                 "Port": {
-                  "nodeId": 171,
+                  "nodeId": 198,
                   "unqualifiedName": "Log"
                 }
               },
               "LogText": {
                 "Port": {
-                  "nodeId": 172,
+                  "nodeId": 199,
                   "unqualifiedName": "LogText"
                 }
               },
               "Time": {
                 "Port": {
-                  "nodeId": 175,
+                  "nodeId": 202,
                   "unqualifiedName": "Time"
                 }
               }
@@ -574,25 +589,12 @@
     },
     "topologyMap": {},
     "typeMap": {
-      "135": {
+      "141": {
         "Int": {
-          "PrimitiveInt": {
-            "kind": {
-              "I32": {}
-            }
-          }
+          "Integer": {}
         }
       },
-      "128": {
-        "Int": {
-          "PrimitiveInt": {
-            "kind": {
-              "I32": {}
-            }
-          }
-        }
-      },
-      "139": {
+      "166": {
         "Primitive": {
           "Float": {
             "kind": {
@@ -601,12 +603,12 @@
           }
         }
       },
-      "123": {
+      "155": {
         "Int": {
           "Integer": {}
         }
       },
-      "166": {
+      "152": {
         "Int": {
           "Integer": {}
         }
@@ -616,12 +618,47 @@
           "Integer": {}
         }
       },
-      "145": {
+      "148": {
+        "Int": {
+          "PrimitiveInt": {
+            "kind": {
+              "I32": {}
+            }
+          }
+        }
+      },
+      "143": {
         "Int": {
           "Integer": {}
         }
       },
-      "3": {
+      "172": {
+        "Int": {
+          "Integer": {}
+        }
+      },
+      "157": {
+        "AnonStruct": {
+          "members": {
+            "seconds": {
+              "Int": {
+                "Integer": {}
+              }
+            },
+            "useconds": {
+              "Int": {
+                "Integer": {}
+              }
+            }
+          }
+        }
+      },
+      "193": {
+        "Int": {
+          "Integer": {}
+        }
+      },
+      "153": {
         "Int": {
           "Integer": {}
         }
@@ -635,16 +672,7 @@
           }
         }
       },
-      "164": {
-        "Int": {
-          "PrimitiveInt": {
-            "kind": {
-              "U32": {}
-            }
-          }
-        }
-      },
-      "143": {
+      "170": {
         "Int": {
           "PrimitiveInt": {
             "kind": {
@@ -653,59 +681,87 @@
           }
         }
       },
-      "130": {
+      "162": {
+        "Int": {
+          "PrimitiveInt": {
+            "kind": {
+              "I32": {}
+            }
+          }
+        }
+      },
+      "191": {
+        "Int": {
+          "PrimitiveInt": {
+            "kind": {
+              "U32": {}
+            }
+          }
+        }
+      },
+      "150": {
+        "Int": {
+          "Integer": {}
+        }
+      },
+      "3": {
         "Int": {
           "Integer": {}
         }
       }
     },
     "useDefMap": {
-      "120": {
+      "139": {
         "Port": {
-          "nodeId": 171,
-          "unqualifiedName": "Log"
+          "nodeId": 199,
+          "unqualifiedName": "LogText"
         }
       },
-      "121": {
+      "138": {
         "Port": {
-          "nodeId": 172,
-          "unqualifiedName": "LogText"
+          "nodeId": 198,
+          "unqualifiedName": "Log"
         }
       },
       "1": {
         "Port": {
-          "nodeId": 172,
+          "nodeId": 199,
           "unqualifiedName": "LogText"
         }
       },
-      "122": {
+      "140": {
         "Port": {
-          "nodeId": 175,
+          "nodeId": 202,
           "unqualifiedName": "Time"
         }
       },
       "0": {
         "Port": {
-          "nodeId": 171,
+          "nodeId": 198,
           "unqualifiedName": "Log"
         }
       },
       "2": {
         "Port": {
-          "nodeId": 175,
+          "nodeId": 202,
           "unqualifiedName": "Time"
         }
       }
     },
     "valueMap": {
-      "123": {
+      "141": {
         "Integer": {
           "value": 16
         }
       },
-      "166": {
+      "155": {
         "Integer": {
-          "value": 6
+          "value": 10
+        }
+      },
+      "152": {
+        "Integer": {
+          "value": 10
         }
       },
       "10": {
@@ -713,12 +769,43 @@
           "value": 17
         }
       },
-      "145": {
+      "143": {
+        "Integer": {
+          "value": 10
+        }
+      },
+      "172": {
         "Integer": {
           "value": 9
         }
       },
-      "130": {
+      "157": {
+        "AnonStruct": {
+          "members": {
+            "seconds": {
+              "Integer": {
+                "value": 10
+              }
+            },
+            "useconds": {
+              "Integer": {
+                "value": 10
+              }
+            }
+          }
+        }
+      },
+      "193": {
+        "Integer": {
+          "value": 6
+        }
+      },
+      "153": {
+        "Integer": {
+          "value": 10
+        }
+      },
+      "150": {
         "Integer": {
           "value": 2
         }
@@ -730,6 +817,7 @@
       }
     },
     "stateMachineMap": {},
+    "dictionarySymbolSet": [],
     "interfaceMap": {}
   }
 }

--- a/tests/events/events_ast.json
+++ b/tests/events/events_ast.json
@@ -1,675 +1,792 @@
 {
-  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
-  "ast": [
+  "fppVersion" : "v3.1.0a10-54-g11243e778",
+  "ast" : [
     {
-      "members": [
+      "members" : [
         [
-          ["Component for illustrating event identifiers"],
+          [
+            "Component for illustrating event identifiers"
+          ],
           {
-            "DefComponent": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "kind": {
-                      "Passive": {}
+            "DefComponent" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "kind" : {
+                      "Passive" : {
+                        
+                      }
                     },
-                    "name": "EventIdentifiers",
-                    "members": [
+                    "name" : "EventIdentifiers",
+                    "members" : [
                       [
-                        ["Event port"],
+                        [
+                          "Event port"
+                        ],
                         {
-                          "SpecPortInstance": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "Special": {
-                                    "inputKind": "None",
-                                    "kind": {
-                                      "Event": {}
+                          "SpecPortInstance" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "Special" : {
+                                    "inputKind" : "None",
+                                    "kind" : {
+                                      "Event" : {
+                                        
+                                      }
                                     },
-                                    "name": "eventOut",
-                                    "priority": "None",
-                                    "queueFull": "None"
+                                    "name" : "eventOut",
+                                    "priority" : "None",
+                                    "queueFull" : "None"
                                   }
                                 },
-                                "id": 0
+                                "id" : 0
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        ["Text event port"],
+                        [
+                          "Text event port"
+                        ],
                         {
-                          "SpecPortInstance": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "Special": {
-                                    "inputKind": "None",
-                                    "kind": {
-                                      "TextEvent": {}
+                          "SpecPortInstance" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "Special" : {
+                                    "inputKind" : "None",
+                                    "kind" : {
+                                      "TextEvent" : {
+                                        
+                                      }
                                     },
-                                    "name": "textEventOut",
-                                    "priority": "None",
-                                    "queueFull": "None"
+                                    "name" : "textEventOut",
+                                    "priority" : "None",
+                                    "queueFull" : "None"
                                   }
                                 },
-                                "id": 1
+                                "id" : 1
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        ["Time get port"],
+                        [
+                          "Time get port"
+                        ],
                         {
-                          "SpecPortInstance": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "Special": {
-                                    "inputKind": "None",
-                                    "kind": {
-                                      "TimeGet": {}
+                          "SpecPortInstance" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "Special" : {
+                                    "inputKind" : "None",
+                                    "kind" : {
+                                      "TimeGet" : {
+                                        
+                                      }
                                     },
-                                    "name": "timeGetOut",
-                                    "priority": "None",
-                                    "queueFull": "None"
+                                    "name" : "timeGetOut",
+                                    "priority" : "None",
+                                    "queueFull" : "None"
                                   }
                                 },
-                                "id": 2
+                                "id" : 2
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        ["Event 1", "Its identifier is 0x00"],
+                        [
+                          "Event 1",
+                          "Its identifier is 0x00"
+                        ],
                         {
-                          "SpecEvent": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "name": "Event1",
-                                  "params": [],
-                                  "severity": {
-                                    "ActivityLow": {}
+                          "SpecEvent" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "name" : "Event1",
+                                  "params" : [
+                                  ],
+                                  "severity" : {
+                                    "ActivityLow" : {
+                                      
+                                    }
                                   },
-                                  "id": {
-                                    "Some": {
-                                      "AstNode": {
-                                        "data": {
-                                          "ExprLiteralInt": {
-                                            "value": "0x10"
+                                  "id" : {
+                                    "Some" : {
+                                      "AstNode" : {
+                                        "data" : {
+                                          "ExprLiteralInt" : {
+                                            "value" : "0x10"
                                           }
                                         },
-                                        "id": 3
+                                        "id" : 3
                                       }
                                     }
                                   },
-                                  "format": {
-                                    "AstNode": {
-                                      "data": "Event 1 occurred",
-                                      "id": 4
+                                  "format" : {
+                                    "AstNode" : {
+                                      "data" : "Event 1 occurred",
+                                      "id" : 4
                                     }
                                   },
-                                  "throttle": "None"
+                                  "throttle" : "None"
                                 },
-                                "id": 5
+                                "id" : 5
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        ["Event 2", "Its identifier is 0x10"],
+                        [
+                          "Event 2",
+                          "Its identifier is 0x10"
+                        ],
                         {
-                          "SpecEvent": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "name": "Event2",
-                                  "params": [
+                          "SpecEvent" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "name" : "Event2",
+                                  "params" : [
                                     [
-                                      [],
+                                      [
+                                      ],
                                       {
-                                        "AstNode": {
-                                          "data": {
-                                            "kind": {
-                                              "Value": {}
+                                        "AstNode" : {
+                                          "data" : {
+                                            "kind" : {
+                                              "Value" : {
+                                                
+                                              }
                                             },
-                                            "name": "count",
-                                            "typeName": {
-                                              "AstNode": {
-                                                "data": {
-                                                  "TypeNameInt": {
-                                                    "name": {
-                                                      "U32": {}
+                                            "name" : "count",
+                                            "typeName" : {
+                                              "AstNode" : {
+                                                "data" : {
+                                                  "TypeNameInt" : {
+                                                    "name" : {
+                                                      "U32" : {
+                                                        
+                                                      }
                                                     }
                                                   }
                                                 },
-                                                "id": 8
+                                                "id" : 8
                                               }
                                             }
                                           },
-                                          "id": 9
+                                          "id" : 9
                                         }
                                       },
-                                      ["The count"]
+                                      [
+                                        "The count"
+                                      ]
                                     ]
                                   ],
-                                  "severity": {
-                                    "ActivityHigh": {}
+                                  "severity" : {
+                                    "ActivityHigh" : {
+                                      
+                                    }
                                   },
-                                  "id": {
-                                    "Some": {
-                                      "AstNode": {
-                                        "data": {
-                                          "ExprLiteralInt": {
-                                            "value": "0x11"
+                                  "id" : {
+                                    "Some" : {
+                                      "AstNode" : {
+                                        "data" : {
+                                          "ExprLiteralInt" : {
+                                            "value" : "0x11"
                                           }
                                         },
-                                        "id": 10
+                                        "id" : 10
                                       }
                                     }
                                   },
-                                  "format": {
-                                    "AstNode": {
-                                      "data": "The count is {}",
-                                      "id": 11
+                                  "format" : {
+                                    "AstNode" : {
+                                      "data" : "The count is {}",
+                                      "id" : 11
                                     }
                                   },
-                                  "throttle": "None"
+                                  "throttle" : "None"
                                 },
-                                "id": 12
+                                "id" : 12
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        ["Event 3", "Its identifier is 0x11"],
+                        [
+                          "Event 3",
+                          "Its identifier is 0x11"
+                        ],
                         {
-                          "SpecEvent": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "name": "Event3",
-                                  "params": [],
-                                  "severity": {
-                                    "ActivityHigh": {}
-                                  },
-                                  "id": "None",
-                                  "format": {
-                                    "AstNode": {
-                                      "data": "Event 3 occurred",
-                                      "id": 17
+                          "SpecEvent" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "name" : "Event3",
+                                  "params" : [
+                                  ],
+                                  "severity" : {
+                                    "ActivityHigh" : {
+                                      
                                     }
                                   },
-                                  "throttle": "None"
+                                  "id" : "None",
+                                  "format" : {
+                                    "AstNode" : {
+                                      "data" : "Event 3 occurred",
+                                      "id" : 17
+                                    }
+                                  },
+                                  "throttle" : "None"
                                 },
-                                "id": 18
+                                "id" : 18
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ]
                     ]
                   },
-                  "id": 19
+                  "id" : 19
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          [],
+          [
+          ],
           {
-            "DefModule": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "M",
-                    "members": [
+            "DefModule" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "M",
+                    "members" : [
                       [
-                        ["Component for illustrating event throttling"],
+                        [
+                          "Component for illustrating event throttling"
+                        ],
                         {
-                          "DefComponent": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "kind": {
-                                    "Passive": {}
+                          "DefComponent" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "kind" : {
+                                    "Passive" : {
+                                      
+                                    }
                                   },
-                                  "name": "EventThrottling",
-                                  "members": [
+                                  "name" : "EventThrottling",
+                                  "members" : [
                                     [
-                                      ["Event port"],
+                                      [
+                                        "Event port"
+                                      ],
                                       {
-                                        "SpecPortInstance": {
-                                          "node": {
-                                            "AstNode": {
-                                              "data": {
-                                                "Special": {
-                                                  "inputKind": "None",
-                                                  "kind": {
-                                                    "Event": {}
+                                        "SpecPortInstance" : {
+                                          "node" : {
+                                            "AstNode" : {
+                                              "data" : {
+                                                "Special" : {
+                                                  "inputKind" : "None",
+                                                  "kind" : {
+                                                    "Event" : {
+                                                      
+                                                    }
                                                   },
-                                                  "name": "eventOut",
-                                                  "priority": "None",
-                                                  "queueFull": "None"
+                                                  "name" : "eventOut",
+                                                  "priority" : "None",
+                                                  "queueFull" : "None"
                                                 }
                                               },
-                                              "id": 138
+                                              "id" : 138
                                             }
                                           }
                                         }
                                       },
-                                      []
+                                      [
+                                      ]
                                     ],
                                     [
-                                      ["Text event port"],
+                                      [
+                                        "Text event port"
+                                      ],
                                       {
-                                        "SpecPortInstance": {
-                                          "node": {
-                                            "AstNode": {
-                                              "data": {
-                                                "Special": {
-                                                  "inputKind": "None",
-                                                  "kind": {
-                                                    "TextEvent": {}
+                                        "SpecPortInstance" : {
+                                          "node" : {
+                                            "AstNode" : {
+                                              "data" : {
+                                                "Special" : {
+                                                  "inputKind" : "None",
+                                                  "kind" : {
+                                                    "TextEvent" : {
+                                                      
+                                                    }
                                                   },
-                                                  "name": "textEventOut",
-                                                  "priority": "None",
-                                                  "queueFull": "None"
+                                                  "name" : "textEventOut",
+                                                  "priority" : "None",
+                                                  "queueFull" : "None"
                                                 }
                                               },
-                                              "id": 139
+                                              "id" : 139
                                             }
                                           }
                                         }
                                       },
-                                      []
+                                      [
+                                      ]
                                     ],
                                     [
-                                      ["Time get port"],
+                                      [
+                                        "Time get port"
+                                      ],
                                       {
-                                        "SpecPortInstance": {
-                                          "node": {
-                                            "AstNode": {
-                                              "data": {
-                                                "Special": {
-                                                  "inputKind": "None",
-                                                  "kind": {
-                                                    "TimeGet": {}
+                                        "SpecPortInstance" : {
+                                          "node" : {
+                                            "AstNode" : {
+                                              "data" : {
+                                                "Special" : {
+                                                  "inputKind" : "None",
+                                                  "kind" : {
+                                                    "TimeGet" : {
+                                                      
+                                                    }
                                                   },
-                                                  "name": "timeGetOut",
-                                                  "priority": "None",
-                                                  "queueFull": "None"
+                                                  "name" : "timeGetOut",
+                                                  "priority" : "None",
+                                                  "queueFull" : "None"
                                                 }
                                               },
-                                              "id": 140
+                                              "id" : 140
                                             }
                                           }
                                         }
                                       },
-                                      []
+                                      [
+                                      ]
                                     ],
                                     [
-                                      ["Event 1"],
+                                      [
+                                        "Event 1"
+                                      ],
                                       {
-                                        "SpecEvent": {
-                                          "node": {
-                                            "AstNode": {
-                                              "data": {
-                                                "name": "Event1",
-                                                "params": [],
-                                                "severity": {
-                                                  "ActivityLow": {}
+                                        "SpecEvent" : {
+                                          "node" : {
+                                            "AstNode" : {
+                                              "data" : {
+                                                "name" : "Event1",
+                                                "params" : [
+                                                ],
+                                                "severity" : {
+                                                  "ActivityLow" : {
+                                                    
+                                                  }
                                                 },
-                                                "id": {
-                                                  "Some": {
-                                                    "AstNode": {
-                                                      "data": {
-                                                        "ExprLiteralInt": {
-                                                          "value": "0x10"
+                                                "id" : {
+                                                  "Some" : {
+                                                    "AstNode" : {
+                                                      "data" : {
+                                                        "ExprLiteralInt" : {
+                                                          "value" : "0x10"
                                                         }
                                                       },
-                                                      "id": 141
+                                                      "id" : 141
                                                     }
                                                   }
                                                 },
-                                                "format": {
-                                                  "AstNode": {
-                                                    "data": "Event 1 occurred",
-                                                    "id": 142
+                                                "format" : {
+                                                  "AstNode" : {
+                                                    "data" : "Event 1 occurred",
+                                                    "id" : 142
                                                   }
                                                 },
-                                                "throttle": {
-                                                  "Some": {
-                                                    "AstNode": {
-                                                      "data": {
-                                                        "count": {
-                                                          "AstNode": {
-                                                            "data": {
-                                                              "ExprLiteralInt": {
-                                                                "value": "10"
+                                                "throttle" : {
+                                                  "Some" : {
+                                                    "AstNode" : {
+                                                      "data" : {
+                                                        "count" : {
+                                                          "AstNode" : {
+                                                            "data" : {
+                                                              "ExprLiteralInt" : {
+                                                                "value" : "10"
                                                               }
                                                             },
-                                                            "id": 143
+                                                            "id" : 143
                                                           }
                                                         },
-                                                        "every": "None"
+                                                        "every" : "None"
                                                       },
-                                                      "id": 144
+                                                      "id" : 144
                                                     }
                                                   }
                                                 }
                                               },
-                                              "id": 145
+                                              "id" : 145
                                             }
                                           }
                                         }
                                       },
-                                      []
+                                      [
+                                      ]
                                     ],
                                     [
-                                      ["Event 2"],
+                                      [
+                                        "Event 2"
+                                      ],
                                       {
-                                        "SpecEvent": {
-                                          "node": {
-                                            "AstNode": {
-                                              "data": {
-                                                "name": "Event2",
-                                                "params": [
+                                        "SpecEvent" : {
+                                          "node" : {
+                                            "AstNode" : {
+                                              "data" : {
+                                                "name" : "Event2",
+                                                "params" : [
                                                   [
-                                                    [],
+                                                    [
+                                                    ],
                                                     {
-                                                      "AstNode": {
-                                                        "data": {
-                                                          "kind": {
-                                                            "Value": {}
+                                                      "AstNode" : {
+                                                        "data" : {
+                                                          "kind" : {
+                                                            "Value" : {
+                                                              
+                                                            }
                                                           },
-                                                          "name": "port",
-                                                          "typeName": {
-                                                            "AstNode": {
-                                                              "data": {
-                                                                "TypeNameInt": {
-                                                                  "name": {
-                                                                    "I32": {}
+                                                          "name" : "port",
+                                                          "typeName" : {
+                                                            "AstNode" : {
+                                                              "data" : {
+                                                                "TypeNameInt" : {
+                                                                  "name" : {
+                                                                    "I32" : {
+                                                                      
+                                                                    }
                                                                   }
                                                                 }
                                                               },
-                                                              "id": 148
+                                                              "id" : 148
                                                             }
                                                           }
                                                         },
-                                                        "id": 149
+                                                        "id" : 149
                                                       }
                                                     },
-                                                    ["Port arg"]
+                                                    [
+                                                      "Port arg"
+                                                    ]
                                                   ]
                                                 ],
-                                                "severity": {
-                                                  "Command": {}
+                                                "severity" : {
+                                                  "Command" : {
+                                                    
+                                                  }
                                                 },
-                                                "id": {
-                                                  "Some": {
-                                                    "AstNode": {
-                                                      "data": {
-                                                        "ExprLiteralInt": {
-                                                          "value": "2"
+                                                "id" : {
+                                                  "Some" : {
+                                                    "AstNode" : {
+                                                      "data" : {
+                                                        "ExprLiteralInt" : {
+                                                          "value" : "2"
                                                         }
                                                       },
-                                                      "id": 150
+                                                      "id" : 150
                                                     }
                                                   }
                                                 },
-                                                "format": {
-                                                  "AstNode": {
-                                                    "data": "Port {}",
-                                                    "id": 151
+                                                "format" : {
+                                                  "AstNode" : {
+                                                    "data" : "Port {}",
+                                                    "id" : 151
                                                   }
                                                 },
-                                                "throttle": {
-                                                  "Some": {
-                                                    "AstNode": {
-                                                      "data": {
-                                                        "count": {
-                                                          "AstNode": {
-                                                            "data": {
-                                                              "ExprLiteralInt": {
-                                                                "value": "10"
+                                                "throttle" : {
+                                                  "Some" : {
+                                                    "AstNode" : {
+                                                      "data" : {
+                                                        "count" : {
+                                                          "AstNode" : {
+                                                            "data" : {
+                                                              "ExprLiteralInt" : {
+                                                                "value" : "10"
                                                               }
                                                             },
-                                                            "id": 152
+                                                            "id" : 152
                                                           }
                                                         },
-                                                        "every": {
-                                                          "Some": {
-                                                            "AstNode": {
-                                                              "data": {
-                                                                "ExprStruct": {
-                                                                  "members": [
+                                                        "every" : {
+                                                          "Some" : {
+                                                            "AstNode" : {
+                                                              "data" : {
+                                                                "ExprStruct" : {
+                                                                  "members" : [
                                                                     {
-                                                                      "AstNode": {
-                                                                        "data": {
-                                                                          "name": "seconds",
-                                                                          "value": {
-                                                                            "AstNode": {
-                                                                              "data": {
-                                                                                "ExprLiteralInt": {
-                                                                                  "value": "10"
+                                                                      "AstNode" : {
+                                                                        "data" : {
+                                                                          "name" : "seconds",
+                                                                          "value" : {
+                                                                            "AstNode" : {
+                                                                              "data" : {
+                                                                                "ExprLiteralInt" : {
+                                                                                  "value" : "10"
                                                                                 }
                                                                               },
-                                                                              "id": 153
+                                                                              "id" : 153
                                                                             }
                                                                           }
                                                                         },
-                                                                        "id": 154
+                                                                        "id" : 154
                                                                       }
                                                                     },
                                                                     {
-                                                                      "AstNode": {
-                                                                        "data": {
-                                                                          "name": "useconds",
-                                                                          "value": {
-                                                                            "AstNode": {
-                                                                              "data": {
-                                                                                "ExprLiteralInt": {
-                                                                                  "value": "10"
+                                                                      "AstNode" : {
+                                                                        "data" : {
+                                                                          "name" : "useconds",
+                                                                          "value" : {
+                                                                            "AstNode" : {
+                                                                              "data" : {
+                                                                                "ExprLiteralInt" : {
+                                                                                  "value" : "10"
                                                                                 }
                                                                               },
-                                                                              "id": 155
+                                                                              "id" : 155
                                                                             }
                                                                           }
                                                                         },
-                                                                        "id": 156
+                                                                        "id" : 156
                                                                       }
                                                                     }
                                                                   ]
                                                                 }
                                                               },
-                                                              "id": 157
+                                                              "id" : 157
                                                             }
                                                           }
                                                         }
                                                       },
-                                                      "id": 158
+                                                      "id" : 158
                                                     }
                                                   }
                                                 }
                                               },
-                                              "id": 159
+                                              "id" : 159
                                             }
                                           }
                                         }
                                       },
-                                      []
+                                      [
+                                      ]
                                     ],
                                     [
-                                      ["Event 3", "Event with 3 args"],
+                                      [
+                                        "Event 3",
+                                        "Event with 3 args"
+                                      ],
                                       {
-                                        "SpecEvent": {
-                                          "node": {
-                                            "AstNode": {
-                                              "data": {
-                                                "name": "Event3",
-                                                "params": [
+                                        "SpecEvent" : {
+                                          "node" : {
+                                            "AstNode" : {
+                                              "data" : {
+                                                "name" : "Event3",
+                                                "params" : [
                                                   [
-                                                    [],
+                                                    [
+                                                    ],
                                                     {
-                                                      "AstNode": {
-                                                        "data": {
-                                                          "kind": {
-                                                            "Value": {}
+                                                      "AstNode" : {
+                                                        "data" : {
+                                                          "kind" : {
+                                                            "Value" : {
+                                                              
+                                                            }
                                                           },
-                                                          "name": "arg1",
-                                                          "typeName": {
-                                                            "AstNode": {
-                                                              "data": {
-                                                                "TypeNameInt": {
-                                                                  "name": {
-                                                                    "I32": {}
+                                                          "name" : "arg1",
+                                                          "typeName" : {
+                                                            "AstNode" : {
+                                                              "data" : {
+                                                                "TypeNameInt" : {
+                                                                  "name" : {
+                                                                    "I32" : {
+                                                                      
+                                                                    }
                                                                   }
                                                                 }
                                                               },
-                                                              "id": 162
+                                                              "id" : 162
                                                             }
                                                           }
                                                         },
-                                                        "id": 163
+                                                        "id" : 163
                                                       }
                                                     },
-                                                    ["Arg1"]
+                                                    [
+                                                      "Arg1"
+                                                    ]
                                                   ],
                                                   [
-                                                    [],
+                                                    [
+                                                    ],
                                                     {
-                                                      "AstNode": {
-                                                        "data": {
-                                                          "kind": {
-                                                            "Value": {}
+                                                      "AstNode" : {
+                                                        "data" : {
+                                                          "kind" : {
+                                                            "Value" : {
+                                                              
+                                                            }
                                                           },
-                                                          "name": "arg2",
-                                                          "typeName": {
-                                                            "AstNode": {
-                                                              "data": {
-                                                                "TypeNameFloat": {
-                                                                  "name": {
-                                                                    "F32": {}
+                                                          "name" : "arg2",
+                                                          "typeName" : {
+                                                            "AstNode" : {
+                                                              "data" : {
+                                                                "TypeNameFloat" : {
+                                                                  "name" : {
+                                                                    "F32" : {
+                                                                      
+                                                                    }
                                                                   }
                                                                 }
                                                               },
-                                                              "id": 166
+                                                              "id" : 166
                                                             }
                                                           }
                                                         },
-                                                        "id": 167
+                                                        "id" : 167
                                                       }
                                                     },
-                                                    ["Arg2"]
+                                                    [
+                                                      "Arg2"
+                                                    ]
                                                   ],
                                                   [
-                                                    [],
+                                                    [
+                                                    ],
                                                     {
-                                                      "AstNode": {
-                                                        "data": {
-                                                          "kind": {
-                                                            "Value": {}
+                                                      "AstNode" : {
+                                                        "data" : {
+                                                          "kind" : {
+                                                            "Value" : {
+                                                              
+                                                            }
                                                           },
-                                                          "name": "arg3",
-                                                          "typeName": {
-                                                            "AstNode": {
-                                                              "data": {
-                                                                "TypeNameInt": {
-                                                                  "name": {
-                                                                    "U8": {}
+                                                          "name" : "arg3",
+                                                          "typeName" : {
+                                                            "AstNode" : {
+                                                              "data" : {
+                                                                "TypeNameInt" : {
+                                                                  "name" : {
+                                                                    "U8" : {
+                                                                      
+                                                                    }
                                                                   }
                                                                 }
                                                               },
-                                                              "id": 170
+                                                              "id" : 170
                                                             }
                                                           }
                                                         },
-                                                        "id": 171
+                                                        "id" : 171
                                                       }
                                                     },
-                                                    ["Arg3"]
+                                                    [
+                                                      "Arg3"
+                                                    ]
                                                   ]
                                                 ],
-                                                "severity": {
-                                                  "ActivityHigh": {}
+                                                "severity" : {
+                                                  "ActivityHigh" : {
+                                                    
+                                                  }
                                                 },
-                                                "id": {
-                                                  "Some": {
-                                                    "AstNode": {
-                                                      "data": {
-                                                        "ExprLiteralInt": {
-                                                          "value": "9"
+                                                "id" : {
+                                                  "Some" : {
+                                                    "AstNode" : {
+                                                      "data" : {
+                                                        "ExprLiteralInt" : {
+                                                          "value" : "9"
                                                         }
                                                       },
-                                                      "id": 172
+                                                      "id" : 172
                                                     }
                                                   }
                                                 },
-                                                "format": {
-                                                  "AstNode": {
-                                                    "data": "Event3 args: I32: {}, F32: {f}, U8: {}",
-                                                    "id": 173
+                                                "format" : {
+                                                  "AstNode" : {
+                                                    "data" : "Event3 args: I32: {}, F32: {f}, U8: {}",
+                                                    "id" : 173
                                                   }
                                                 },
-                                                "throttle": "None"
+                                                "throttle" : "None"
                                               },
-                                              "id": 174
+                                              "id" : 174
                                             }
                                           }
                                         }
                                       },
-                                      []
+                                      [
+                                      ]
                                     ],
                                     [
                                       [
                                         "Exceeded the number of commands that can be simultaneously executed"
                                       ],
                                       {
-                                        "SpecEvent": {
-                                          "node": {
-                                            "AstNode": {
-                                              "data": {
-                                                "name": "TooManyCommands",
-                                                "params": [
+                                        "SpecEvent" : {
+                                          "node" : {
+                                            "AstNode" : {
+                                              "data" : {
+                                                "name" : "TooManyCommands",
+                                                "params" : [
                                                   [
-                                                    [],
+                                                    [
+                                                    ],
                                                     {
-                                                      "AstNode": {
-                                                        "data": {
-                                                          "kind": {
-                                                            "Value": {}
+                                                      "AstNode" : {
+                                                        "data" : {
+                                                          "kind" : {
+                                                            "Value" : {
+                                                              
+                                                            }
                                                           },
-                                                          "name": "Opcode",
-                                                          "typeName": {
-                                                            "AstNode": {
-                                                              "data": {
-                                                                "TypeNameInt": {
-                                                                  "name": {
-                                                                    "U32": {}
+                                                          "name" : "Opcode",
+                                                          "typeName" : {
+                                                            "AstNode" : {
+                                                              "data" : {
+                                                                "TypeNameInt" : {
+                                                                  "name" : {
+                                                                    "U32" : {
+                                                                      
+                                                                    }
                                                                   }
                                                                 }
                                                               },
-                                                              "id": 191
+                                                              "id" : 191
                                                             }
                                                           }
                                                         },
-                                                        "id": 192
+                                                        "id" : 192
                                                       }
                                                     },
                                                     [
@@ -677,125 +794,141 @@
                                                     ]
                                                   ]
                                                 ],
-                                                "severity": {
-                                                  "WarningHigh": {}
+                                                "severity" : {
+                                                  "WarningHigh" : {
+                                                    
+                                                  }
                                                 },
-                                                "id": {
-                                                  "Some": {
-                                                    "AstNode": {
-                                                      "data": {
-                                                        "ExprLiteralInt": {
-                                                          "value": "6"
+                                                "id" : {
+                                                  "Some" : {
+                                                    "AstNode" : {
+                                                      "data" : {
+                                                        "ExprLiteralInt" : {
+                                                          "value" : "6"
                                                         }
                                                       },
-                                                      "id": 193
+                                                      "id" : 193
                                                     }
                                                   }
                                                 },
-                                                "format": {
-                                                  "AstNode": {
-                                                    "data": "Too many outstanding commands. opcode=0x{x}",
-                                                    "id": 194
+                                                "format" : {
+                                                  "AstNode" : {
+                                                    "data" : "Too many outstanding commands. opcode=0x{x}",
+                                                    "id" : 194
                                                   }
                                                 },
-                                                "throttle": "None"
+                                                "throttle" : "None"
                                               },
-                                              "id": 195
+                                              "id" : 195
                                             }
                                           }
                                         }
                                       },
-                                      []
+                                      [
+                                      ]
                                     ]
                                   ]
                                 },
-                                "id": 196
+                                "id" : 196
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ]
                     ]
                   },
-                  "id": 197
+                  "id" : 197
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          [],
+          [
+          ],
           {
-            "DefModule": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "Fw",
-                    "members": [
+            "DefModule" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "Fw",
+                    "members" : [
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "DefPort": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "name": "Log",
-                                  "params": [],
-                                  "returnType": "None"
+                          "DefPort" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "name" : "Log",
+                                  "params" : [
+                                  ],
+                                  "returnType" : "None"
                                 },
-                                "id": 198
+                                "id" : 198
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "DefPort": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "name": "LogText",
-                                  "params": [],
-                                  "returnType": "None"
+                          "DefPort" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "name" : "LogText",
+                                  "params" : [
+                                  ],
+                                  "returnType" : "None"
                                 },
-                                "id": 199
+                                "id" : 199
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "DefPort": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "name": "Time",
-                                  "params": [],
-                                  "returnType": "None"
+                          "DefPort" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "name" : "Time",
+                                  "params" : [
+                                  ],
+                                  "returnType" : "None"
                                 },
-                                "id": 202
+                                "id" : 202
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ]
                     ]
                   },
-                  "id": 203
+                  "id" : 203
                 }
               }
             }
           },
-          []
+          [
+          ]
         ]
       ]
     }

--- a/tests/events/events_ast.json
+++ b/tests/events/events_ast.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion": "[ fpp version ]",
+  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
   "ast": [
     {
       "members": [
@@ -268,7 +268,7 @@
                                                   "queueFull": "None"
                                                 }
                                               },
-                                              "id": 120
+                                              "id": 138
                                             }
                                           }
                                         }
@@ -292,7 +292,7 @@
                                                   "queueFull": "None"
                                                 }
                                               },
-                                              "id": 121
+                                              "id": 139
                                             }
                                           }
                                         }
@@ -316,7 +316,7 @@
                                                   "queueFull": "None"
                                                 }
                                               },
-                                              "id": 122
+                                              "id": 140
                                             }
                                           }
                                         }
@@ -343,19 +343,38 @@
                                                           "value": "0x10"
                                                         }
                                                       },
-                                                      "id": 123
+                                                      "id": 141
                                                     }
                                                   }
                                                 },
                                                 "format": {
                                                   "AstNode": {
                                                     "data": "Event 1 occurred",
-                                                    "id": 124
+                                                    "id": 142
                                                   }
                                                 },
-                                                "throttle": "None"
+                                                "throttle": {
+                                                  "Some": {
+                                                    "AstNode": {
+                                                      "data": {
+                                                        "count": {
+                                                          "AstNode": {
+                                                            "data": {
+                                                              "ExprLiteralInt": {
+                                                                "value": "10"
+                                                              }
+                                                            },
+                                                            "id": 143
+                                                          }
+                                                        },
+                                                        "every": "None"
+                                                      },
+                                                      "id": 144
+                                                    }
+                                                  }
+                                                }
                                               },
-                                              "id": 125
+                                              "id": 145
                                             }
                                           }
                                         }
@@ -389,11 +408,11 @@
                                                                   }
                                                                 }
                                                               },
-                                                              "id": 128
+                                                              "id": 148
                                                             }
                                                           }
                                                         },
-                                                        "id": 129
+                                                        "id": 149
                                                       }
                                                     },
                                                     ["Port arg"]
@@ -410,19 +429,86 @@
                                                           "value": "2"
                                                         }
                                                       },
-                                                      "id": 130
+                                                      "id": 150
                                                     }
                                                   }
                                                 },
                                                 "format": {
                                                   "AstNode": {
                                                     "data": "Port {}",
-                                                    "id": 131
+                                                    "id": 151
                                                   }
                                                 },
-                                                "throttle": "None"
+                                                "throttle": {
+                                                  "Some": {
+                                                    "AstNode": {
+                                                      "data": {
+                                                        "count": {
+                                                          "AstNode": {
+                                                            "data": {
+                                                              "ExprLiteralInt": {
+                                                                "value": "10"
+                                                              }
+                                                            },
+                                                            "id": 152
+                                                          }
+                                                        },
+                                                        "every": {
+                                                          "Some": {
+                                                            "AstNode": {
+                                                              "data": {
+                                                                "ExprStruct": {
+                                                                  "members": [
+                                                                    {
+                                                                      "AstNode": {
+                                                                        "data": {
+                                                                          "name": "seconds",
+                                                                          "value": {
+                                                                            "AstNode": {
+                                                                              "data": {
+                                                                                "ExprLiteralInt": {
+                                                                                  "value": "10"
+                                                                                }
+                                                                              },
+                                                                              "id": 153
+                                                                            }
+                                                                          }
+                                                                        },
+                                                                        "id": 154
+                                                                      }
+                                                                    },
+                                                                    {
+                                                                      "AstNode": {
+                                                                        "data": {
+                                                                          "name": "useconds",
+                                                                          "value": {
+                                                                            "AstNode": {
+                                                                              "data": {
+                                                                                "ExprLiteralInt": {
+                                                                                  "value": "10"
+                                                                                }
+                                                                              },
+                                                                              "id": 155
+                                                                            }
+                                                                          }
+                                                                        },
+                                                                        "id": 156
+                                                                      }
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              },
+                                                              "id": 157
+                                                            }
+                                                          }
+                                                        }
+                                                      },
+                                                      "id": 158
+                                                    }
+                                                  }
+                                                }
                                               },
-                                              "id": 132
+                                              "id": 159
                                             }
                                           }
                                         }
@@ -456,11 +542,11 @@
                                                                   }
                                                                 }
                                                               },
-                                                              "id": 135
+                                                              "id": 162
                                                             }
                                                           }
                                                         },
-                                                        "id": 136
+                                                        "id": 163
                                                       }
                                                     },
                                                     ["Arg1"]
@@ -483,11 +569,11 @@
                                                                   }
                                                                 }
                                                               },
-                                                              "id": 139
+                                                              "id": 166
                                                             }
                                                           }
                                                         },
-                                                        "id": 140
+                                                        "id": 167
                                                       }
                                                     },
                                                     ["Arg2"]
@@ -510,11 +596,11 @@
                                                                   }
                                                                 }
                                                               },
-                                                              "id": 143
+                                                              "id": 170
                                                             }
                                                           }
                                                         },
-                                                        "id": 144
+                                                        "id": 171
                                                       }
                                                     },
                                                     ["Arg3"]
@@ -531,19 +617,19 @@
                                                           "value": "9"
                                                         }
                                                       },
-                                                      "id": 145
+                                                      "id": 172
                                                     }
                                                   }
                                                 },
                                                 "format": {
                                                   "AstNode": {
                                                     "data": "Event3 args: I32: {}, F32: {f}, U8: {}",
-                                                    "id": 146
+                                                    "id": 173
                                                   }
                                                 },
                                                 "throttle": "None"
                                               },
-                                              "id": 147
+                                              "id": 174
                                             }
                                           }
                                         }
@@ -579,11 +665,11 @@
                                                                   }
                                                                 }
                                                               },
-                                                              "id": 164
+                                                              "id": 191
                                                             }
                                                           }
                                                         },
-                                                        "id": 165
+                                                        "id": 192
                                                       }
                                                     },
                                                     [
@@ -602,19 +688,19 @@
                                                           "value": "6"
                                                         }
                                                       },
-                                                      "id": 166
+                                                      "id": 193
                                                     }
                                                   }
                                                 },
                                                 "format": {
                                                   "AstNode": {
                                                     "data": "Too many outstanding commands. opcode=0x{x}",
-                                                    "id": 167
+                                                    "id": 194
                                                   }
                                                 },
                                                 "throttle": "None"
                                               },
-                                              "id": 168
+                                              "id": 195
                                             }
                                           }
                                         }
@@ -623,7 +709,7 @@
                                     ]
                                   ]
                                 },
-                                "id": 169
+                                "id": 196
                               }
                             }
                           }
@@ -632,7 +718,7 @@
                       ]
                     ]
                   },
-                  "id": 170
+                  "id": 197
                 }
               }
             }
@@ -659,7 +745,7 @@
                                   "params": [],
                                   "returnType": "None"
                                 },
-                                "id": 171
+                                "id": 198
                               }
                             }
                           }
@@ -677,7 +763,7 @@
                                   "params": [],
                                   "returnType": "None"
                                 },
-                                "id": 172
+                                "id": 199
                               }
                             }
                           }
@@ -695,7 +781,7 @@
                                   "params": [],
                                   "returnType": "None"
                                 },
-                                "id": 175
+                                "id": 202
                               }
                             }
                           }
@@ -704,7 +790,7 @@
                       ]
                     ]
                   },
-                  "id": 176
+                  "id": 203
                 }
               }
             }

--- a/tests/events/events_locations.json
+++ b/tests/events/events_locations.json
@@ -1,1025 +1,1025 @@
 {
-  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
-  "locationMap": {
-    "0": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "9.3",
-      "includingLoc": "None"
-    },
-    "1": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "12.3",
-      "includingLoc": "None"
-    },
-    "2": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "15.3",
-      "includingLoc": "None"
-    },
-    "3": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "24.8",
-      "includingLoc": "None"
-    },
-    "4": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "25.12",
-      "includingLoc": "None"
-    },
-    "5": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "23.3",
-      "includingLoc": "None"
-    },
-    "6": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "30.12",
-      "includingLoc": "None"
-    },
-    "7": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "30.5",
-      "includingLoc": "None"
-    },
-    "8": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "30.12",
-      "includingLoc": "None"
-    },
-    "9": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "30.5",
-      "includingLoc": "None"
-    },
-    "10": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "33.8",
-      "includingLoc": "None"
-    },
-    "11": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "34.12",
-      "includingLoc": "None"
-    },
-    "12": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "29.3",
-      "includingLoc": "None"
-    },
-    "13": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "39.12",
-      "includingLoc": "None"
-    },
-    "14": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "38.3",
-      "includingLoc": "None"
-    },
-    "15": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "39.12",
-      "includingLoc": "None"
-    },
-    "16": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "38.3",
-      "includingLoc": "None"
-    },
-    "17": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "39.12",
-      "includingLoc": "None"
-    },
-    "18": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "38.3",
-      "includingLoc": "None"
-    },
-    "19": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "2.1",
-      "includingLoc": "None"
-    },
-    "20": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "52.5",
-      "includingLoc": "None"
-    },
-    "21": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "55.5",
-      "includingLoc": "None"
-    },
-    "22": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "58.5",
-      "includingLoc": "None"
-    },
-    "23": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "66.10",
-      "includingLoc": "None"
-    },
-    "24": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "67.14",
-      "includingLoc": "None"
-    },
-    "25": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "68.16",
-      "includingLoc": "None"
-    },
-    "26": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "68.7",
-      "includingLoc": "None"
-    },
-    "27": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "65.5",
-      "includingLoc": "None"
-    },
-    "28": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "72.14",
-      "includingLoc": "None"
-    },
-    "29": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "72.7",
-      "includingLoc": "None"
-    },
-    "30": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "72.14",
-      "includingLoc": "None"
-    },
-    "31": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "72.7",
-      "includingLoc": "None"
-    },
-    "32": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "75.10",
-      "includingLoc": "None"
-    },
-    "33": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "76.14",
-      "includingLoc": "None"
-    },
-    "34": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "77.16",
-      "includingLoc": "None"
-    },
-    "35": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "78.22",
-      "includingLoc": "None"
-    },
-    "36": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "78.14",
-      "includingLoc": "None"
-    },
-    "37": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "78.34",
-      "includingLoc": "None"
-    },
-    "38": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "78.25",
-      "includingLoc": "None"
-    },
-    "39": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "78.13",
-      "includingLoc": "None"
-    },
-    "40": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "77.7",
-      "includingLoc": "None"
-    },
-    "41": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "71.5",
-      "includingLoc": "None"
-    },
-    "42": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "83.13",
-      "includingLoc": "None"
-    },
-    "43": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "83.7",
-      "includingLoc": "None"
-    },
-    "44": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "83.13",
-      "includingLoc": "None"
-    },
-    "45": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "83.7",
-      "includingLoc": "None"
-    },
-    "46": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "84.13",
-      "includingLoc": "None"
-    },
-    "47": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "84.7",
-      "includingLoc": "None"
-    },
-    "48": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "84.13",
-      "includingLoc": "None"
-    },
-    "49": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "84.7",
-      "includingLoc": "None"
-    },
-    "50": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "85.13",
-      "includingLoc": "None"
-    },
-    "51": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "85.7",
-      "includingLoc": "None"
-    },
-    "52": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "85.13",
-      "includingLoc": "None"
-    },
-    "53": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "85.7",
-      "includingLoc": "None"
-    },
-    "54": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "88.10",
-      "includingLoc": "None"
-    },
-    "55": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "89.14",
-      "includingLoc": "None"
-    },
-    "56": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "82.5",
-      "includingLoc": "None"
-    },
-    "57": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "93.17",
-      "includingLoc": "None"
-    },
-    "58": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "93.9",
-      "includingLoc": "None"
-    },
-    "59": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "93.17",
-      "includingLoc": "None"
-    },
-    "60": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "93.9",
-      "includingLoc": "None"
-    },
-    "61": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "96.10",
-      "includingLoc": "None"
-    },
-    "62": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "97.14",
-      "includingLoc": "None"
-    },
-    "63": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "92.5",
-      "includingLoc": "None"
-    },
-    "64": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "93.17",
-      "includingLoc": "None"
-    },
-    "65": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "93.9",
-      "includingLoc": "None"
-    },
-    "66": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "93.17",
-      "includingLoc": "None"
-    },
-    "67": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "93.9",
-      "includingLoc": "None"
-    },
-    "68": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "96.10",
-      "includingLoc": "None"
-    },
-    "69": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "97.14",
-      "includingLoc": "None"
-    },
-    "70": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "92.5",
-      "includingLoc": "None"
-    },
-    "71": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "93.17",
-      "includingLoc": "None"
-    },
-    "72": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "93.9",
-      "includingLoc": "None"
-    },
-    "73": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "93.17",
-      "includingLoc": "None"
-    },
-    "74": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "93.9",
-      "includingLoc": "None"
-    },
-    "75": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "96.10",
-      "includingLoc": "None"
-    },
-    "76": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "97.14",
-      "includingLoc": "None"
-    },
-    "77": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "92.5",
-      "includingLoc": "None"
-    },
-    "78": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "45.3",
-      "includingLoc": "None"
-    },
-    "79": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "52.5",
-      "includingLoc": "None"
-    },
-    "80": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "55.5",
-      "includingLoc": "None"
-    },
-    "81": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "58.5",
-      "includingLoc": "None"
-    },
-    "82": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "66.10",
-      "includingLoc": "None"
-    },
-    "83": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "67.14",
-      "includingLoc": "None"
-    },
-    "84": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "68.16",
-      "includingLoc": "None"
-    },
-    "85": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "68.7",
-      "includingLoc": "None"
-    },
-    "86": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "65.5",
-      "includingLoc": "None"
-    },
-    "87": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "72.14",
-      "includingLoc": "None"
-    },
-    "88": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "72.7",
-      "includingLoc": "None"
-    },
-    "89": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "72.14",
-      "includingLoc": "None"
-    },
-    "90": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "72.7",
-      "includingLoc": "None"
-    },
-    "91": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "75.10",
-      "includingLoc": "None"
-    },
-    "92": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "76.14",
-      "includingLoc": "None"
-    },
-    "93": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "77.16",
-      "includingLoc": "None"
-    },
-    "94": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "78.22",
-      "includingLoc": "None"
-    },
-    "95": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "78.14",
-      "includingLoc": "None"
-    },
-    "96": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "78.34",
-      "includingLoc": "None"
-    },
-    "97": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "78.25",
-      "includingLoc": "None"
-    },
-    "98": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "78.13",
-      "includingLoc": "None"
-    },
-    "99": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "77.7",
-      "includingLoc": "None"
-    },
-    "100": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "71.5",
-      "includingLoc": "None"
-    },
-    "101": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "83.13",
-      "includingLoc": "None"
-    },
-    "102": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "83.7",
-      "includingLoc": "None"
-    },
-    "103": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "83.13",
-      "includingLoc": "None"
-    },
-    "104": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "83.7",
-      "includingLoc": "None"
-    },
-    "105": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "84.13",
-      "includingLoc": "None"
-    },
-    "106": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "84.7",
-      "includingLoc": "None"
-    },
-    "107": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "84.13",
-      "includingLoc": "None"
-    },
-    "108": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "84.7",
-      "includingLoc": "None"
-    },
-    "109": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "85.13",
-      "includingLoc": "None"
-    },
-    "110": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "85.7",
-      "includingLoc": "None"
-    },
-    "111": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "85.13",
-      "includingLoc": "None"
-    },
-    "112": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "85.7",
-      "includingLoc": "None"
-    },
-    "113": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "88.10",
-      "includingLoc": "None"
-    },
-    "114": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "89.14",
-      "includingLoc": "None"
-    },
-    "115": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "82.5",
-      "includingLoc": "None"
-    },
-    "116": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "93.17",
-      "includingLoc": "None"
-    },
-    "117": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "93.9",
-      "includingLoc": "None"
-    },
-    "118": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "93.17",
-      "includingLoc": "None"
-    },
-    "119": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "93.9",
-      "includingLoc": "None"
-    },
-    "120": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "96.10",
-      "includingLoc": "None"
-    },
-    "121": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "97.14",
-      "includingLoc": "None"
-    },
-    "122": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "92.5",
-      "includingLoc": "None"
-    },
-    "123": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "93.17",
-      "includingLoc": "None"
-    },
-    "124": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "93.9",
-      "includingLoc": "None"
-    },
-    "125": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "93.17",
-      "includingLoc": "None"
-    },
-    "126": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "93.9",
-      "includingLoc": "None"
-    },
-    "127": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "96.10",
-      "includingLoc": "None"
-    },
-    "128": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "97.14",
-      "includingLoc": "None"
-    },
-    "129": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "92.5",
-      "includingLoc": "None"
-    },
-    "130": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "93.17",
-      "includingLoc": "None"
-    },
-    "131": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "93.9",
-      "includingLoc": "None"
-    },
-    "132": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "93.17",
-      "includingLoc": "None"
-    },
-    "133": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "93.9",
-      "includingLoc": "None"
-    },
-    "134": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "96.10",
-      "includingLoc": "None"
-    },
-    "135": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "97.14",
-      "includingLoc": "None"
-    },
-    "136": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "92.5",
-      "includingLoc": "None"
-    },
-    "137": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "45.3",
-      "includingLoc": "None"
-    },
-    "138": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "52.5",
-      "includingLoc": "None"
-    },
-    "139": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "55.5",
-      "includingLoc": "None"
-    },
-    "140": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "58.5",
-      "includingLoc": "None"
-    },
-    "141": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "66.10",
-      "includingLoc": "None"
-    },
-    "142": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "67.14",
-      "includingLoc": "None"
-    },
-    "143": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "68.16",
-      "includingLoc": "None"
-    },
-    "144": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "68.7",
-      "includingLoc": "None"
-    },
-    "145": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "65.5",
-      "includingLoc": "None"
-    },
-    "146": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "72.14",
-      "includingLoc": "None"
-    },
-    "147": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "72.7",
-      "includingLoc": "None"
-    },
-    "148": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "72.14",
-      "includingLoc": "None"
-    },
-    "149": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "72.7",
-      "includingLoc": "None"
-    },
-    "150": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "75.10",
-      "includingLoc": "None"
-    },
-    "151": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "76.14",
-      "includingLoc": "None"
-    },
-    "152": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "77.16",
-      "includingLoc": "None"
-    },
-    "153": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "78.22",
-      "includingLoc": "None"
-    },
-    "154": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "78.14",
-      "includingLoc": "None"
-    },
-    "155": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "78.34",
-      "includingLoc": "None"
-    },
-    "156": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "78.25",
-      "includingLoc": "None"
-    },
-    "157": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "78.13",
-      "includingLoc": "None"
-    },
-    "158": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "77.7",
-      "includingLoc": "None"
-    },
-    "159": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "71.5",
-      "includingLoc": "None"
-    },
-    "160": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "83.13",
-      "includingLoc": "None"
-    },
-    "161": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "83.7",
-      "includingLoc": "None"
-    },
-    "162": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "83.13",
-      "includingLoc": "None"
-    },
-    "163": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "83.7",
-      "includingLoc": "None"
-    },
-    "164": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "84.13",
-      "includingLoc": "None"
-    },
-    "165": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "84.7",
-      "includingLoc": "None"
-    },
-    "166": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "84.13",
-      "includingLoc": "None"
-    },
-    "167": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "84.7",
-      "includingLoc": "None"
-    },
-    "168": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "85.13",
-      "includingLoc": "None"
-    },
-    "169": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "85.7",
-      "includingLoc": "None"
-    },
-    "170": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "85.13",
-      "includingLoc": "None"
-    },
-    "171": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "85.7",
-      "includingLoc": "None"
-    },
-    "172": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "88.10",
-      "includingLoc": "None"
-    },
-    "173": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "89.14",
-      "includingLoc": "None"
-    },
-    "174": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "82.5",
-      "includingLoc": "None"
-    },
-    "175": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "93.17",
-      "includingLoc": "None"
-    },
-    "176": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "93.9",
-      "includingLoc": "None"
-    },
-    "177": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "93.17",
-      "includingLoc": "None"
-    },
-    "178": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "93.9",
-      "includingLoc": "None"
-    },
-    "179": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "96.10",
-      "includingLoc": "None"
-    },
-    "180": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "97.14",
-      "includingLoc": "None"
-    },
-    "181": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "92.5",
-      "includingLoc": "None"
-    },
-    "182": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "93.17",
-      "includingLoc": "None"
-    },
-    "183": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "93.9",
-      "includingLoc": "None"
-    },
-    "184": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "93.17",
-      "includingLoc": "None"
-    },
-    "185": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "93.9",
-      "includingLoc": "None"
-    },
-    "186": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "96.10",
-      "includingLoc": "None"
-    },
-    "187": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "97.14",
-      "includingLoc": "None"
-    },
-    "188": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "92.5",
-      "includingLoc": "None"
-    },
-    "189": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "93.17",
-      "includingLoc": "None"
-    },
-    "190": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "93.9",
-      "includingLoc": "None"
-    },
-    "191": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "93.17",
-      "includingLoc": "None"
-    },
-    "192": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "93.9",
-      "includingLoc": "None"
-    },
-    "193": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "96.10",
-      "includingLoc": "None"
-    },
-    "194": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "97.14",
-      "includingLoc": "None"
-    },
-    "195": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "92.5",
-      "includingLoc": "None"
-    },
-    "196": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "45.3",
-      "includingLoc": "None"
-    },
-    "197": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "43.1",
-      "includingLoc": "None"
-    },
-    "198": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "103.3",
-      "includingLoc": "None"
-    },
-    "199": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "104.3",
-      "includingLoc": "None"
-    },
-    "200": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "105.3",
-      "includingLoc": "None"
-    },
-    "201": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "105.3",
-      "includingLoc": "None"
-    },
-    "202": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "105.3",
-      "includingLoc": "None"
-    },
-    "203": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "102.1",
-      "includingLoc": "None"
+  "fppVersion" : "v3.1.0a10-54-g11243e778",
+  "locationMap" : {
+    "0" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "9.3",
+      "includingLoc" : "None"
+    },
+    "1" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "12.3",
+      "includingLoc" : "None"
+    },
+    "2" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "15.3",
+      "includingLoc" : "None"
+    },
+    "3" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "24.8",
+      "includingLoc" : "None"
+    },
+    "4" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "25.12",
+      "includingLoc" : "None"
+    },
+    "5" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "23.3",
+      "includingLoc" : "None"
+    },
+    "6" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "30.12",
+      "includingLoc" : "None"
+    },
+    "7" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "30.5",
+      "includingLoc" : "None"
+    },
+    "8" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "30.12",
+      "includingLoc" : "None"
+    },
+    "9" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "30.5",
+      "includingLoc" : "None"
+    },
+    "10" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "33.8",
+      "includingLoc" : "None"
+    },
+    "11" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "34.12",
+      "includingLoc" : "None"
+    },
+    "12" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "29.3",
+      "includingLoc" : "None"
+    },
+    "13" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "39.12",
+      "includingLoc" : "None"
+    },
+    "14" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "38.3",
+      "includingLoc" : "None"
+    },
+    "15" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "39.12",
+      "includingLoc" : "None"
+    },
+    "16" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "38.3",
+      "includingLoc" : "None"
+    },
+    "17" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "39.12",
+      "includingLoc" : "None"
+    },
+    "18" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "38.3",
+      "includingLoc" : "None"
+    },
+    "19" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "2.1",
+      "includingLoc" : "None"
+    },
+    "20" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "52.5",
+      "includingLoc" : "None"
+    },
+    "21" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "55.5",
+      "includingLoc" : "None"
+    },
+    "22" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "58.5",
+      "includingLoc" : "None"
+    },
+    "23" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "66.10",
+      "includingLoc" : "None"
+    },
+    "24" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "67.14",
+      "includingLoc" : "None"
+    },
+    "25" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "68.16",
+      "includingLoc" : "None"
+    },
+    "26" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "68.7",
+      "includingLoc" : "None"
+    },
+    "27" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "65.5",
+      "includingLoc" : "None"
+    },
+    "28" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "72.14",
+      "includingLoc" : "None"
+    },
+    "29" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "72.7",
+      "includingLoc" : "None"
+    },
+    "30" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "72.14",
+      "includingLoc" : "None"
+    },
+    "31" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "72.7",
+      "includingLoc" : "None"
+    },
+    "32" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "75.10",
+      "includingLoc" : "None"
+    },
+    "33" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "76.14",
+      "includingLoc" : "None"
+    },
+    "34" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "77.16",
+      "includingLoc" : "None"
+    },
+    "35" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "78.22",
+      "includingLoc" : "None"
+    },
+    "36" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "78.14",
+      "includingLoc" : "None"
+    },
+    "37" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "78.34",
+      "includingLoc" : "None"
+    },
+    "38" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "78.25",
+      "includingLoc" : "None"
+    },
+    "39" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "78.13",
+      "includingLoc" : "None"
+    },
+    "40" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "77.7",
+      "includingLoc" : "None"
+    },
+    "41" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "71.5",
+      "includingLoc" : "None"
+    },
+    "42" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "83.13",
+      "includingLoc" : "None"
+    },
+    "43" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "83.7",
+      "includingLoc" : "None"
+    },
+    "44" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "83.13",
+      "includingLoc" : "None"
+    },
+    "45" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "83.7",
+      "includingLoc" : "None"
+    },
+    "46" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "84.13",
+      "includingLoc" : "None"
+    },
+    "47" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "84.7",
+      "includingLoc" : "None"
+    },
+    "48" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "84.13",
+      "includingLoc" : "None"
+    },
+    "49" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "84.7",
+      "includingLoc" : "None"
+    },
+    "50" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "85.13",
+      "includingLoc" : "None"
+    },
+    "51" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "85.7",
+      "includingLoc" : "None"
+    },
+    "52" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "85.13",
+      "includingLoc" : "None"
+    },
+    "53" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "85.7",
+      "includingLoc" : "None"
+    },
+    "54" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "88.10",
+      "includingLoc" : "None"
+    },
+    "55" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "89.14",
+      "includingLoc" : "None"
+    },
+    "56" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "82.5",
+      "includingLoc" : "None"
+    },
+    "57" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "93.17",
+      "includingLoc" : "None"
+    },
+    "58" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "93.9",
+      "includingLoc" : "None"
+    },
+    "59" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "93.17",
+      "includingLoc" : "None"
+    },
+    "60" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "93.9",
+      "includingLoc" : "None"
+    },
+    "61" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "96.10",
+      "includingLoc" : "None"
+    },
+    "62" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "97.14",
+      "includingLoc" : "None"
+    },
+    "63" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "92.5",
+      "includingLoc" : "None"
+    },
+    "64" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "93.17",
+      "includingLoc" : "None"
+    },
+    "65" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "93.9",
+      "includingLoc" : "None"
+    },
+    "66" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "93.17",
+      "includingLoc" : "None"
+    },
+    "67" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "93.9",
+      "includingLoc" : "None"
+    },
+    "68" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "96.10",
+      "includingLoc" : "None"
+    },
+    "69" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "97.14",
+      "includingLoc" : "None"
+    },
+    "70" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "92.5",
+      "includingLoc" : "None"
+    },
+    "71" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "93.17",
+      "includingLoc" : "None"
+    },
+    "72" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "93.9",
+      "includingLoc" : "None"
+    },
+    "73" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "93.17",
+      "includingLoc" : "None"
+    },
+    "74" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "93.9",
+      "includingLoc" : "None"
+    },
+    "75" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "96.10",
+      "includingLoc" : "None"
+    },
+    "76" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "97.14",
+      "includingLoc" : "None"
+    },
+    "77" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "92.5",
+      "includingLoc" : "None"
+    },
+    "78" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "45.3",
+      "includingLoc" : "None"
+    },
+    "79" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "52.5",
+      "includingLoc" : "None"
+    },
+    "80" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "55.5",
+      "includingLoc" : "None"
+    },
+    "81" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "58.5",
+      "includingLoc" : "None"
+    },
+    "82" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "66.10",
+      "includingLoc" : "None"
+    },
+    "83" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "67.14",
+      "includingLoc" : "None"
+    },
+    "84" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "68.16",
+      "includingLoc" : "None"
+    },
+    "85" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "68.7",
+      "includingLoc" : "None"
+    },
+    "86" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "65.5",
+      "includingLoc" : "None"
+    },
+    "87" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "72.14",
+      "includingLoc" : "None"
+    },
+    "88" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "72.7",
+      "includingLoc" : "None"
+    },
+    "89" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "72.14",
+      "includingLoc" : "None"
+    },
+    "90" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "72.7",
+      "includingLoc" : "None"
+    },
+    "91" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "75.10",
+      "includingLoc" : "None"
+    },
+    "92" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "76.14",
+      "includingLoc" : "None"
+    },
+    "93" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "77.16",
+      "includingLoc" : "None"
+    },
+    "94" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "78.22",
+      "includingLoc" : "None"
+    },
+    "95" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "78.14",
+      "includingLoc" : "None"
+    },
+    "96" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "78.34",
+      "includingLoc" : "None"
+    },
+    "97" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "78.25",
+      "includingLoc" : "None"
+    },
+    "98" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "78.13",
+      "includingLoc" : "None"
+    },
+    "99" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "77.7",
+      "includingLoc" : "None"
+    },
+    "100" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "71.5",
+      "includingLoc" : "None"
+    },
+    "101" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "83.13",
+      "includingLoc" : "None"
+    },
+    "102" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "83.7",
+      "includingLoc" : "None"
+    },
+    "103" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "83.13",
+      "includingLoc" : "None"
+    },
+    "104" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "83.7",
+      "includingLoc" : "None"
+    },
+    "105" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "84.13",
+      "includingLoc" : "None"
+    },
+    "106" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "84.7",
+      "includingLoc" : "None"
+    },
+    "107" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "84.13",
+      "includingLoc" : "None"
+    },
+    "108" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "84.7",
+      "includingLoc" : "None"
+    },
+    "109" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "85.13",
+      "includingLoc" : "None"
+    },
+    "110" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "85.7",
+      "includingLoc" : "None"
+    },
+    "111" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "85.13",
+      "includingLoc" : "None"
+    },
+    "112" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "85.7",
+      "includingLoc" : "None"
+    },
+    "113" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "88.10",
+      "includingLoc" : "None"
+    },
+    "114" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "89.14",
+      "includingLoc" : "None"
+    },
+    "115" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "82.5",
+      "includingLoc" : "None"
+    },
+    "116" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "93.17",
+      "includingLoc" : "None"
+    },
+    "117" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "93.9",
+      "includingLoc" : "None"
+    },
+    "118" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "93.17",
+      "includingLoc" : "None"
+    },
+    "119" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "93.9",
+      "includingLoc" : "None"
+    },
+    "120" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "96.10",
+      "includingLoc" : "None"
+    },
+    "121" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "97.14",
+      "includingLoc" : "None"
+    },
+    "122" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "92.5",
+      "includingLoc" : "None"
+    },
+    "123" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "93.17",
+      "includingLoc" : "None"
+    },
+    "124" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "93.9",
+      "includingLoc" : "None"
+    },
+    "125" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "93.17",
+      "includingLoc" : "None"
+    },
+    "126" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "93.9",
+      "includingLoc" : "None"
+    },
+    "127" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "96.10",
+      "includingLoc" : "None"
+    },
+    "128" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "97.14",
+      "includingLoc" : "None"
+    },
+    "129" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "92.5",
+      "includingLoc" : "None"
+    },
+    "130" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "93.17",
+      "includingLoc" : "None"
+    },
+    "131" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "93.9",
+      "includingLoc" : "None"
+    },
+    "132" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "93.17",
+      "includingLoc" : "None"
+    },
+    "133" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "93.9",
+      "includingLoc" : "None"
+    },
+    "134" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "96.10",
+      "includingLoc" : "None"
+    },
+    "135" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "97.14",
+      "includingLoc" : "None"
+    },
+    "136" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "92.5",
+      "includingLoc" : "None"
+    },
+    "137" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "45.3",
+      "includingLoc" : "None"
+    },
+    "138" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "52.5",
+      "includingLoc" : "None"
+    },
+    "139" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "55.5",
+      "includingLoc" : "None"
+    },
+    "140" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "58.5",
+      "includingLoc" : "None"
+    },
+    "141" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "66.10",
+      "includingLoc" : "None"
+    },
+    "142" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "67.14",
+      "includingLoc" : "None"
+    },
+    "143" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "68.16",
+      "includingLoc" : "None"
+    },
+    "144" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "68.7",
+      "includingLoc" : "None"
+    },
+    "145" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "65.5",
+      "includingLoc" : "None"
+    },
+    "146" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "72.14",
+      "includingLoc" : "None"
+    },
+    "147" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "72.7",
+      "includingLoc" : "None"
+    },
+    "148" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "72.14",
+      "includingLoc" : "None"
+    },
+    "149" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "72.7",
+      "includingLoc" : "None"
+    },
+    "150" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "75.10",
+      "includingLoc" : "None"
+    },
+    "151" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "76.14",
+      "includingLoc" : "None"
+    },
+    "152" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "77.16",
+      "includingLoc" : "None"
+    },
+    "153" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "78.22",
+      "includingLoc" : "None"
+    },
+    "154" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "78.14",
+      "includingLoc" : "None"
+    },
+    "155" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "78.34",
+      "includingLoc" : "None"
+    },
+    "156" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "78.25",
+      "includingLoc" : "None"
+    },
+    "157" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "78.13",
+      "includingLoc" : "None"
+    },
+    "158" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "77.7",
+      "includingLoc" : "None"
+    },
+    "159" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "71.5",
+      "includingLoc" : "None"
+    },
+    "160" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "83.13",
+      "includingLoc" : "None"
+    },
+    "161" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "83.7",
+      "includingLoc" : "None"
+    },
+    "162" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "83.13",
+      "includingLoc" : "None"
+    },
+    "163" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "83.7",
+      "includingLoc" : "None"
+    },
+    "164" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "84.13",
+      "includingLoc" : "None"
+    },
+    "165" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "84.7",
+      "includingLoc" : "None"
+    },
+    "166" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "84.13",
+      "includingLoc" : "None"
+    },
+    "167" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "84.7",
+      "includingLoc" : "None"
+    },
+    "168" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "85.13",
+      "includingLoc" : "None"
+    },
+    "169" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "85.7",
+      "includingLoc" : "None"
+    },
+    "170" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "85.13",
+      "includingLoc" : "None"
+    },
+    "171" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "85.7",
+      "includingLoc" : "None"
+    },
+    "172" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "88.10",
+      "includingLoc" : "None"
+    },
+    "173" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "89.14",
+      "includingLoc" : "None"
+    },
+    "174" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "82.5",
+      "includingLoc" : "None"
+    },
+    "175" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "93.17",
+      "includingLoc" : "None"
+    },
+    "176" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "93.9",
+      "includingLoc" : "None"
+    },
+    "177" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "93.17",
+      "includingLoc" : "None"
+    },
+    "178" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "93.9",
+      "includingLoc" : "None"
+    },
+    "179" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "96.10",
+      "includingLoc" : "None"
+    },
+    "180" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "97.14",
+      "includingLoc" : "None"
+    },
+    "181" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "92.5",
+      "includingLoc" : "None"
+    },
+    "182" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "93.17",
+      "includingLoc" : "None"
+    },
+    "183" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "93.9",
+      "includingLoc" : "None"
+    },
+    "184" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "93.17",
+      "includingLoc" : "None"
+    },
+    "185" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "93.9",
+      "includingLoc" : "None"
+    },
+    "186" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "96.10",
+      "includingLoc" : "None"
+    },
+    "187" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "97.14",
+      "includingLoc" : "None"
+    },
+    "188" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "92.5",
+      "includingLoc" : "None"
+    },
+    "189" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "93.17",
+      "includingLoc" : "None"
+    },
+    "190" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "93.9",
+      "includingLoc" : "None"
+    },
+    "191" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "93.17",
+      "includingLoc" : "None"
+    },
+    "192" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "93.9",
+      "includingLoc" : "None"
+    },
+    "193" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "96.10",
+      "includingLoc" : "None"
+    },
+    "194" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "97.14",
+      "includingLoc" : "None"
+    },
+    "195" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "92.5",
+      "includingLoc" : "None"
+    },
+    "196" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "45.3",
+      "includingLoc" : "None"
+    },
+    "197" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "43.1",
+      "includingLoc" : "None"
+    },
+    "198" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "103.3",
+      "includingLoc" : "None"
+    },
+    "199" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "104.3",
+      "includingLoc" : "None"
+    },
+    "200" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "105.3",
+      "includingLoc" : "None"
+    },
+    "201" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "105.3",
+      "includingLoc" : "None"
+    },
+    "202" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "105.3",
+      "includingLoc" : "None"
+    },
+    "203" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos" : "102.1",
+      "includingLoc" : "None"
     }
   }
 }

--- a/tests/events/events_locations.json
+++ b/tests/events/events_locations.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion": "[ fpp version ]",
+  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
   "locationMap": {
     "0": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
@@ -128,762 +128,897 @@
     },
     "25": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "65.5",
+      "pos": "68.16",
       "includingLoc": "None"
     },
     "26": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "71.14",
+      "pos": "68.7",
       "includingLoc": "None"
     },
     "27": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "71.7",
+      "pos": "65.5",
       "includingLoc": "None"
     },
     "28": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "71.14",
+      "pos": "72.14",
       "includingLoc": "None"
     },
     "29": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "71.7",
+      "pos": "72.7",
       "includingLoc": "None"
     },
     "30": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "74.10",
+      "pos": "72.14",
       "includingLoc": "None"
     },
     "31": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "75.14",
+      "pos": "72.7",
       "includingLoc": "None"
     },
     "32": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "70.5",
+      "pos": "75.10",
       "includingLoc": "None"
     },
     "33": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "80.13",
+      "pos": "76.14",
       "includingLoc": "None"
     },
     "34": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "80.7",
+      "pos": "77.16",
       "includingLoc": "None"
     },
     "35": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "80.13",
+      "pos": "78.22",
       "includingLoc": "None"
     },
     "36": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "80.7",
+      "pos": "78.14",
       "includingLoc": "None"
     },
     "37": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "81.13",
+      "pos": "78.34",
       "includingLoc": "None"
     },
     "38": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "81.7",
+      "pos": "78.25",
       "includingLoc": "None"
     },
     "39": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "81.13",
+      "pos": "78.13",
       "includingLoc": "None"
     },
     "40": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "81.7",
+      "pos": "77.7",
       "includingLoc": "None"
     },
     "41": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "82.13",
+      "pos": "71.5",
       "includingLoc": "None"
     },
     "42": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "82.7",
+      "pos": "83.13",
       "includingLoc": "None"
     },
     "43": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "82.13",
+      "pos": "83.7",
       "includingLoc": "None"
     },
     "44": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "82.7",
+      "pos": "83.13",
       "includingLoc": "None"
     },
     "45": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "85.10",
+      "pos": "83.7",
       "includingLoc": "None"
     },
     "46": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "86.14",
+      "pos": "84.13",
       "includingLoc": "None"
     },
     "47": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "79.5",
+      "pos": "84.7",
       "includingLoc": "None"
     },
     "48": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "90.17",
+      "pos": "84.13",
       "includingLoc": "None"
     },
     "49": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "90.9",
+      "pos": "84.7",
       "includingLoc": "None"
     },
     "50": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "90.17",
+      "pos": "85.13",
       "includingLoc": "None"
     },
     "51": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "90.9",
+      "pos": "85.7",
       "includingLoc": "None"
     },
     "52": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "93.10",
+      "pos": "85.13",
       "includingLoc": "None"
     },
     "53": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "94.14",
+      "pos": "85.7",
       "includingLoc": "None"
     },
     "54": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "89.5",
+      "pos": "88.10",
       "includingLoc": "None"
     },
     "55": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "90.17",
+      "pos": "89.14",
       "includingLoc": "None"
     },
     "56": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "90.9",
+      "pos": "82.5",
       "includingLoc": "None"
     },
     "57": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "90.17",
+      "pos": "93.17",
       "includingLoc": "None"
     },
     "58": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "90.9",
+      "pos": "93.9",
       "includingLoc": "None"
     },
     "59": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "93.10",
+      "pos": "93.17",
       "includingLoc": "None"
     },
     "60": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "94.14",
+      "pos": "93.9",
       "includingLoc": "None"
     },
     "61": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "89.5",
+      "pos": "96.10",
       "includingLoc": "None"
     },
     "62": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "90.17",
+      "pos": "97.14",
       "includingLoc": "None"
     },
     "63": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "90.9",
+      "pos": "92.5",
       "includingLoc": "None"
     },
     "64": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "90.17",
+      "pos": "93.17",
       "includingLoc": "None"
     },
     "65": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "90.9",
+      "pos": "93.9",
       "includingLoc": "None"
     },
     "66": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "93.10",
+      "pos": "93.17",
       "includingLoc": "None"
     },
     "67": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "94.14",
+      "pos": "93.9",
       "includingLoc": "None"
     },
     "68": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "89.5",
+      "pos": "96.10",
       "includingLoc": "None"
     },
     "69": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "45.3",
+      "pos": "97.14",
       "includingLoc": "None"
     },
     "70": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "52.5",
+      "pos": "92.5",
       "includingLoc": "None"
     },
     "71": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "55.5",
+      "pos": "93.17",
       "includingLoc": "None"
     },
     "72": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "58.5",
+      "pos": "93.9",
       "includingLoc": "None"
     },
     "73": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "66.10",
+      "pos": "93.17",
       "includingLoc": "None"
     },
     "74": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "67.14",
+      "pos": "93.9",
       "includingLoc": "None"
     },
     "75": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "65.5",
+      "pos": "96.10",
       "includingLoc": "None"
     },
     "76": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "71.14",
+      "pos": "97.14",
       "includingLoc": "None"
     },
     "77": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "71.7",
+      "pos": "92.5",
       "includingLoc": "None"
     },
     "78": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "71.14",
+      "pos": "45.3",
       "includingLoc": "None"
     },
     "79": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "71.7",
+      "pos": "52.5",
       "includingLoc": "None"
     },
     "80": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "74.10",
+      "pos": "55.5",
       "includingLoc": "None"
     },
     "81": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "75.14",
+      "pos": "58.5",
       "includingLoc": "None"
     },
     "82": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "70.5",
+      "pos": "66.10",
       "includingLoc": "None"
     },
     "83": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "80.13",
+      "pos": "67.14",
       "includingLoc": "None"
     },
     "84": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "80.7",
+      "pos": "68.16",
       "includingLoc": "None"
     },
     "85": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "80.13",
+      "pos": "68.7",
       "includingLoc": "None"
     },
     "86": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "80.7",
+      "pos": "65.5",
       "includingLoc": "None"
     },
     "87": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "81.13",
+      "pos": "72.14",
       "includingLoc": "None"
     },
     "88": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "81.7",
+      "pos": "72.7",
       "includingLoc": "None"
     },
     "89": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "81.13",
+      "pos": "72.14",
       "includingLoc": "None"
     },
     "90": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "81.7",
+      "pos": "72.7",
       "includingLoc": "None"
     },
     "91": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "82.13",
+      "pos": "75.10",
       "includingLoc": "None"
     },
     "92": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "82.7",
+      "pos": "76.14",
       "includingLoc": "None"
     },
     "93": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "82.13",
+      "pos": "77.16",
       "includingLoc": "None"
     },
     "94": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "82.7",
+      "pos": "78.22",
       "includingLoc": "None"
     },
     "95": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "85.10",
+      "pos": "78.14",
       "includingLoc": "None"
     },
     "96": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "86.14",
+      "pos": "78.34",
       "includingLoc": "None"
     },
     "97": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "79.5",
+      "pos": "78.25",
       "includingLoc": "None"
     },
     "98": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "90.17",
+      "pos": "78.13",
       "includingLoc": "None"
     },
     "99": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "90.9",
+      "pos": "77.7",
       "includingLoc": "None"
     },
     "100": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "90.17",
+      "pos": "71.5",
       "includingLoc": "None"
     },
     "101": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "90.9",
+      "pos": "83.13",
       "includingLoc": "None"
     },
     "102": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "93.10",
+      "pos": "83.7",
       "includingLoc": "None"
     },
     "103": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "94.14",
+      "pos": "83.13",
       "includingLoc": "None"
     },
     "104": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "89.5",
+      "pos": "83.7",
       "includingLoc": "None"
     },
     "105": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "90.17",
+      "pos": "84.13",
       "includingLoc": "None"
     },
     "106": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "90.9",
+      "pos": "84.7",
       "includingLoc": "None"
     },
     "107": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "90.17",
+      "pos": "84.13",
       "includingLoc": "None"
     },
     "108": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "90.9",
+      "pos": "84.7",
       "includingLoc": "None"
     },
     "109": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "93.10",
+      "pos": "85.13",
       "includingLoc": "None"
     },
     "110": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "94.14",
+      "pos": "85.7",
       "includingLoc": "None"
     },
     "111": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "89.5",
+      "pos": "85.13",
       "includingLoc": "None"
     },
     "112": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "90.17",
+      "pos": "85.7",
       "includingLoc": "None"
     },
     "113": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "90.9",
+      "pos": "88.10",
       "includingLoc": "None"
     },
     "114": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "90.17",
+      "pos": "89.14",
       "includingLoc": "None"
     },
     "115": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "90.9",
+      "pos": "82.5",
       "includingLoc": "None"
     },
     "116": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "93.10",
+      "pos": "93.17",
       "includingLoc": "None"
     },
     "117": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "94.14",
+      "pos": "93.9",
       "includingLoc": "None"
     },
     "118": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "89.5",
+      "pos": "93.17",
       "includingLoc": "None"
     },
     "119": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "45.3",
+      "pos": "93.9",
       "includingLoc": "None"
     },
     "120": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "52.5",
+      "pos": "96.10",
       "includingLoc": "None"
     },
     "121": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "55.5",
+      "pos": "97.14",
       "includingLoc": "None"
     },
     "122": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "58.5",
+      "pos": "92.5",
       "includingLoc": "None"
     },
     "123": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "66.10",
+      "pos": "93.17",
       "includingLoc": "None"
     },
     "124": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "67.14",
+      "pos": "93.9",
       "includingLoc": "None"
     },
     "125": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "65.5",
+      "pos": "93.17",
       "includingLoc": "None"
     },
     "126": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "71.14",
+      "pos": "93.9",
       "includingLoc": "None"
     },
     "127": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "71.7",
+      "pos": "96.10",
       "includingLoc": "None"
     },
     "128": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "71.14",
+      "pos": "97.14",
       "includingLoc": "None"
     },
     "129": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "71.7",
+      "pos": "92.5",
       "includingLoc": "None"
     },
     "130": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "74.10",
+      "pos": "93.17",
       "includingLoc": "None"
     },
     "131": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "75.14",
+      "pos": "93.9",
       "includingLoc": "None"
     },
     "132": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "70.5",
+      "pos": "93.17",
       "includingLoc": "None"
     },
     "133": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "80.13",
+      "pos": "93.9",
       "includingLoc": "None"
     },
     "134": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "80.7",
+      "pos": "96.10",
       "includingLoc": "None"
     },
     "135": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "80.13",
+      "pos": "97.14",
       "includingLoc": "None"
     },
     "136": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "80.7",
+      "pos": "92.5",
       "includingLoc": "None"
     },
     "137": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "81.13",
+      "pos": "45.3",
       "includingLoc": "None"
     },
     "138": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "81.7",
+      "pos": "52.5",
       "includingLoc": "None"
     },
     "139": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "81.13",
+      "pos": "55.5",
       "includingLoc": "None"
     },
     "140": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "81.7",
+      "pos": "58.5",
       "includingLoc": "None"
     },
     "141": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "82.13",
+      "pos": "66.10",
       "includingLoc": "None"
     },
     "142": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "82.7",
+      "pos": "67.14",
       "includingLoc": "None"
     },
     "143": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "82.13",
+      "pos": "68.16",
       "includingLoc": "None"
     },
     "144": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "82.7",
+      "pos": "68.7",
       "includingLoc": "None"
     },
     "145": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "85.10",
+      "pos": "65.5",
       "includingLoc": "None"
     },
     "146": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "86.14",
+      "pos": "72.14",
       "includingLoc": "None"
     },
     "147": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "79.5",
+      "pos": "72.7",
       "includingLoc": "None"
     },
     "148": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "90.17",
+      "pos": "72.14",
       "includingLoc": "None"
     },
     "149": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "90.9",
+      "pos": "72.7",
       "includingLoc": "None"
     },
     "150": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "90.17",
+      "pos": "75.10",
       "includingLoc": "None"
     },
     "151": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "90.9",
+      "pos": "76.14",
       "includingLoc": "None"
     },
     "152": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "93.10",
+      "pos": "77.16",
       "includingLoc": "None"
     },
     "153": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "94.14",
+      "pos": "78.22",
       "includingLoc": "None"
     },
     "154": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "89.5",
+      "pos": "78.14",
       "includingLoc": "None"
     },
     "155": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "90.17",
+      "pos": "78.34",
       "includingLoc": "None"
     },
     "156": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "90.9",
+      "pos": "78.25",
       "includingLoc": "None"
     },
     "157": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "90.17",
+      "pos": "78.13",
       "includingLoc": "None"
     },
     "158": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "90.9",
+      "pos": "77.7",
       "includingLoc": "None"
     },
     "159": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "93.10",
+      "pos": "71.5",
       "includingLoc": "None"
     },
     "160": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "94.14",
+      "pos": "83.13",
       "includingLoc": "None"
     },
     "161": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "89.5",
+      "pos": "83.7",
       "includingLoc": "None"
     },
     "162": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "90.17",
+      "pos": "83.13",
       "includingLoc": "None"
     },
     "163": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "90.9",
+      "pos": "83.7",
       "includingLoc": "None"
     },
     "164": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "90.17",
+      "pos": "84.13",
       "includingLoc": "None"
     },
     "165": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "90.9",
+      "pos": "84.7",
       "includingLoc": "None"
     },
     "166": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "93.10",
+      "pos": "84.13",
       "includingLoc": "None"
     },
     "167": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "94.14",
+      "pos": "84.7",
       "includingLoc": "None"
     },
     "168": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "89.5",
+      "pos": "85.13",
       "includingLoc": "None"
     },
     "169": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "45.3",
+      "pos": "85.7",
       "includingLoc": "None"
     },
     "170": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "43.1",
+      "pos": "85.13",
       "includingLoc": "None"
     },
     "171": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "100.3",
+      "pos": "85.7",
       "includingLoc": "None"
     },
     "172": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "101.3",
+      "pos": "88.10",
       "includingLoc": "None"
     },
     "173": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "102.3",
+      "pos": "89.14",
       "includingLoc": "None"
     },
     "174": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "102.3",
+      "pos": "82.5",
       "includingLoc": "None"
     },
     "175": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "102.3",
+      "pos": "93.17",
       "includingLoc": "None"
     },
     "176": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
-      "pos": "99.1",
+      "pos": "93.9",
+      "includingLoc": "None"
+    },
+    "177": {
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos": "93.17",
+      "includingLoc": "None"
+    },
+    "178": {
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos": "93.9",
+      "includingLoc": "None"
+    },
+    "179": {
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos": "96.10",
+      "includingLoc": "None"
+    },
+    "180": {
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos": "97.14",
+      "includingLoc": "None"
+    },
+    "181": {
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos": "92.5",
+      "includingLoc": "None"
+    },
+    "182": {
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos": "93.17",
+      "includingLoc": "None"
+    },
+    "183": {
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos": "93.9",
+      "includingLoc": "None"
+    },
+    "184": {
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos": "93.17",
+      "includingLoc": "None"
+    },
+    "185": {
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos": "93.9",
+      "includingLoc": "None"
+    },
+    "186": {
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos": "96.10",
+      "includingLoc": "None"
+    },
+    "187": {
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos": "97.14",
+      "includingLoc": "None"
+    },
+    "188": {
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos": "92.5",
+      "includingLoc": "None"
+    },
+    "189": {
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos": "93.17",
+      "includingLoc": "None"
+    },
+    "190": {
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos": "93.9",
+      "includingLoc": "None"
+    },
+    "191": {
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos": "93.17",
+      "includingLoc": "None"
+    },
+    "192": {
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos": "93.9",
+      "includingLoc": "None"
+    },
+    "193": {
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos": "96.10",
+      "includingLoc": "None"
+    },
+    "194": {
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos": "97.14",
+      "includingLoc": "None"
+    },
+    "195": {
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos": "92.5",
+      "includingLoc": "None"
+    },
+    "196": {
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos": "45.3",
+      "includingLoc": "None"
+    },
+    "197": {
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos": "43.1",
+      "includingLoc": "None"
+    },
+    "198": {
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos": "103.3",
+      "includingLoc": "None"
+    },
+    "199": {
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos": "104.3",
+      "includingLoc": "None"
+    },
+    "200": {
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos": "105.3",
+      "includingLoc": "None"
+    },
+    "201": {
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos": "105.3",
+      "includingLoc": "None"
+    },
+    "202": {
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos": "105.3",
+      "includingLoc": "None"
+    },
+    "203": {
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",
+      "pos": "102.1",
       "includingLoc": "None"
     }
   }

--- a/tests/generate_ref_files.py
+++ b/tests/generate_ref_files.py
@@ -31,7 +31,7 @@ test_name_map = {
 }
 
 # fpp-to-json tests that are located in different tool directories and might included input files
-# List of tuples with the following format: (location of test, test name, input file)
+# Dictionary with test name keys and tuple values with the following format: (location of test, input file)
 additional_tests = {
     "state_machine": ("compiler/tools/fpp-syntax/test/state-machine.fpp", None),
     "patterned_connections": (

--- a/tests/generate_ref_files.py
+++ b/tests/generate_ref_files.py
@@ -5,11 +5,11 @@ import sys
 import os
 import re
 from fprime_python_model.fpp_version import check_version
-from typing import Optional
+from typing import Optional, Dict, Tuple, List
 
 # fpp-to-json tests (with no input files)
 # Mapping of fprime-python-model test names to fpp-to-json test names
-test_name_map = {
+test_name_map: Dict[str, str] = {
     "active_component": "activeComponents",
     "commands": "commands",
     "constants": "constants",
@@ -32,7 +32,7 @@ test_name_map = {
 
 # fpp-to-json tests that are located in different tool directories and might included input files
 # Dictionary with test name keys and tuple values with the following format: (location of test, input file)
-additional_tests = {
+additional_tests: Dict[str, Tuple[str, Optional[str]]] = {
     "state_machine": ("compiler/tools/fpp-syntax/test/state-machine.fpp", None),
     "patterned_connections": (
         "compiler/tools/fpp-to-json/test/patternedConnections.fpp",
@@ -68,7 +68,7 @@ def create_model_ref_file(
     input_file: Optional[str] = None,
 ):
     test_fpp_ref_name = f"tests/{test_name}/{test_name}.fpp"
-    fpp_format_cmd = [fpp_format, fpp_ref_model]
+    fpp_format_cmd: List = [fpp_format, fpp_ref_model]
     if input_file:
         fpp_format_cmd = [fpp_format, fpp_ref_model, input_file]
     # Run fpp-format on reference model and save output to test case directory
@@ -87,9 +87,9 @@ def create_json_ref_files(
     test_name: str,
     input_file: Optional[str] = None,
 ):
-    fpp_to_json_cmd = [fpp_to_json, fpp_ref_model]
+    fpp_to_json_cmd: List[str] = [str(fpp_to_json), fpp_ref_model]
     if input_file:
-        fpp_to_json_cmd = [fpp_to_json, fpp_ref_model, input_file]
+        fpp_to_json_cmd = [str(fpp_to_json), fpp_ref_model, input_file]
     # Run fpp-to-json on reference model and save output to test case directory
     result = subprocess.run(fpp_to_json_cmd)
     if result.returncode != 0:
@@ -166,22 +166,22 @@ def main():
     clean()
 
     for test_name, fpp_to_json_test_name in test_name_map.items():
-        fpp_ref_model = f"{str(fpp_to_json_tests_path)}/{fpp_to_json_test_name}.fpp"
+        fpp_ref_model: str = f"{str(fpp_to_json_tests_path)}/{fpp_to_json_test_name}.fpp"
         create_model_ref_file(fpp_format, fpp_ref_model, test_name)
         create_json_ref_files(fpp_to_json, str(fpp_ref_model), test_name)
 
     for test_name, (test_location, input_file) in additional_tests.items():
-        fpp_ref_model = fpp_repo_path / test_location
+        fpp_ref = str(fpp_repo_path / test_location)
 
-        input_file_path = None
+        input_file_path: Optional[str] = None
         if input_file:
-            input_file_path = fpp_repo_path / input_file
+            input_file_path = str(fpp_repo_path / input_file)
 
         create_model_ref_file(
-            fpp_format, str(fpp_ref_model), test_name, input_file_path
+            fpp_format, fpp_ref, test_name, input_file_path
         )
         create_json_ref_files(
-            fpp_to_json, str(fpp_ref_model), test_name, input_file_path
+            fpp_to_json, fpp_ref, test_name, input_file_path
         )
 
 

--- a/tests/generate_ref_files.py
+++ b/tests/generate_ref_files.py
@@ -1,0 +1,189 @@
+import subprocess
+import argparse
+from pathlib import Path
+import sys
+import os
+import re
+from fprime_python_model.fpp_version import check_version
+from typing import Optional
+
+# fpp-to-json tests (with no input files)
+# Mapping of fprime-python-model test names to fpp-to-json test names
+test_name_map = {
+    "active_component": "activeComponents",
+    "commands": "commands",
+    "constants": "constants",
+    "data_products": "dataProducts",
+    "events": "events",
+    "imported_topology": "importedTopologies",
+    "interfaces": "interfaces",
+    "internal_ports": "internalPorts",
+    "matched_ports": "matchedPorts",
+    "parameters": "parameters",
+    "passive_component": "passiveComponent",
+    "ports": "ports",
+    "queued_component": "queuedComponents",
+    "special_ports": "specialPorts",
+    "telemetry": "telemetry",
+    "telemetry_packets": "telemetryPackets",
+    "topology": "simpleTopology",
+    "types": "types",
+}
+
+# fpp-to-json tests that are located in different tool directories and might included input files
+# List of tuples with the following format: (location of test, test name, input file)
+additional_tests = {
+    "state_machine": ("compiler/tools/fpp-syntax/test/state-machine.fpp", None),
+    "patterned_connections": (
+        "compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+        "compiler/tools/fpp-to-json/test/fprime/defs.fpp",
+    ),
+    "location_specifier": (
+        "compiler/tools/fpp-depend/test/dictionary_no_top.fpp",
+        None,
+    ),
+    "command_patterned_connections": (
+        "compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+        None,
+    ),
+}
+
+
+def clean():
+    def remove_file(file_path: str):
+        if os.path.exists(file_path):
+            os.remove(file_path)
+
+    for test_name in list(test_name_map.keys()) + list(additional_tests.keys()):
+        remove_file(f"tests/{test_name}/{test_name}_ast.json")
+        remove_file(f"tests/{test_name}/{test_name}_locations.json")
+        remove_file(f"tests/{test_name}/{test_name}_analysis.json")
+        remove_file(f"tests/{test_name}/{test_name}.fpp")
+
+
+def create_model_ref_file(
+    fpp_format: Path,
+    fpp_ref_model: str,
+    test_name: str,
+    input_file: Optional[str] = None,
+):
+    test_fpp_ref_name = f"tests/{test_name}/{test_name}.fpp"
+    fpp_format_cmd = [fpp_format, fpp_ref_model]
+    if input_file:
+        fpp_format_cmd = [fpp_format, fpp_ref_model, input_file]
+    # Run fpp-format on reference model and save output to test case directory
+    try:
+        with open(test_fpp_ref_name, "w") as f:
+            subprocess.run(fpp_format_cmd, stdout=f, check=True, text=True)
+    except subprocess.CalledProcessError as e:
+        print(
+            f"Failed to run fpp-format for test case {test_name}. Reference FPP model has not been updated. Error: {e}"
+        )
+
+
+def create_json_ref_files(
+    fpp_to_json: Path,
+    fpp_ref_model: str,
+    test_name: str,
+    input_file: Optional[str] = None,
+):
+    fpp_to_json_cmd = [fpp_to_json, fpp_ref_model]
+    if input_file:
+        fpp_to_json_cmd = [fpp_to_json, fpp_ref_model, input_file]
+    # Run fpp-to-json on reference model and save output to test case directory
+    result = subprocess.run(fpp_to_json_cmd)
+    if result.returncode != 0:
+        print(f"Encountered an error when running fpp-to-json on {test_name}.fpp")
+    else:
+        # Define the old and new paths
+        old_ast_path = "fpp-ast.json"
+        new_ast_path = f"tests/{test_name}/{test_name}_ast.json"
+
+        old_analysis_path = "fpp-analysis.json"
+        new_analysis_path = f"tests/{test_name}/{test_name}_analysis.json"
+
+        old_loc_path = "fpp-loc-map.json"
+        new_loc_path = f"tests/{test_name}/{test_name}_locations.json"
+
+        path_start = "/".join(str(fpp_to_json).split("/")[:-3])
+        for old_file, new_file in [
+            (old_ast_path, new_ast_path),
+            (old_analysis_path, new_analysis_path),
+            (old_loc_path, new_loc_path),
+        ]:
+            content = ""
+            with open(old_file, "r") as f:
+                content = f.read()
+            # Replace paths with placeholder
+            updated_content = content.replace(path_start, "[ local path prefix ]")
+            with open(new_file, "w") as f:
+                f.write(updated_content)
+
+
+def main():
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "fpp_repo_path",
+        type=Path,
+        help="Location of FPP repo. Note: FPP tools must be installed at compiler/bin",
+    )
+    args = parser.parse_args()
+
+    fpp_repo_path: Path = args.fpp_repo_path
+    fpp_to_json: Path = fpp_repo_path / "compiler/bin/fpp-to-json"
+    fpp_format: Path = fpp_repo_path / "compiler/bin/fpp-format"
+    fpp_to_json_tests_path: Path = fpp_repo_path / "compiler/tools/fpp-to-json/test"
+
+    if not fpp_repo_path.exists():
+        print("FPP repo path does not exist, exiting...")
+        sys.exit(1)
+
+    if not fpp_to_json.exists():
+        print(f"fpp-to-json is not installed at {fpp_to_json}, exiting...")
+        sys.exit(1)
+
+    if not fpp_format.exists():
+        print(f"fpp-format is not installed at {fpp_format}, exiting...")
+        sys.exit(1)
+
+    if not fpp_to_json_tests_path.exists():
+        print(
+            f"Could not find fpp-to-json tests at {fpp_to_json_tests_path}, exiting..."
+        )
+        sys.exit(1)
+
+    help_res = subprocess.run([fpp_to_json, "-h"], capture_output=True)
+    match = re.search(r"v(\d+\.\d+\.\d+[a-zA-Z0-9]*)", help_res.stdout.decode())
+    if match:
+        version = match.group(1)
+        check_version(str(version), f"FPP version ({version}) is incompatible.")
+    else:
+        print("Could not verify FPP tool version, exiting...")
+        sys.exit(1)
+
+    # Delete old ref files
+    clean()
+
+    for test_name, fpp_to_json_test_name in test_name_map.items():
+        fpp_ref_model = f"{str(fpp_to_json_tests_path)}/{fpp_to_json_test_name}.fpp"
+        create_model_ref_file(fpp_format, fpp_ref_model, test_name)
+        create_json_ref_files(fpp_to_json, str(fpp_ref_model), test_name)
+
+    for test_name, (test_location, input_file) in additional_tests.items():
+        fpp_ref_model = fpp_repo_path / test_location
+
+        input_file_path = None
+        if input_file:
+            input_file_path = fpp_repo_path / input_file
+
+        create_model_ref_file(
+            fpp_format, str(fpp_ref_model), test_name, input_file_path
+        )
+        create_json_ref_files(
+            fpp_to_json, str(fpp_ref_model), test_name, input_file_path
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/imported_topology/imported_topology_analysis.json
+++ b/tests/imported_topology/imported_topology_analysis.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion": "[ fpp version ]",
+  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
   "analysis": {
     "componentInstanceMap": {
       "17": {

--- a/tests/imported_topology/imported_topology_analysis.json
+++ b/tests/imported_topology/imported_topology_analysis.json
@@ -1,6172 +1,6785 @@
 {
-  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
-  "analysis": {
-    "componentInstanceMap": {
-      "17": {
-        "aNode": {
-          "astNodeId": 17
+  "fppVersion" : "v3.1.0a10-54-g11243e778",
+  "analysis" : {
+    "componentInstanceMap" : {
+      "17" : {
+        "aNode" : {
+          "astNodeId" : 17
         },
-        "qualifiedName": {
-          "qualifier": [],
-          "base": "c1"
+        "qualifiedName" : {
+          "qualifier" : [
+          ],
+          "base" : "c1"
         },
-        "component": {
-          "astNodeId": 13
+        "component" : {
+          "astNodeId" : 13
         },
-        "baseId": 256,
-        "maxId": 255,
-        "file": "None",
-        "queueSize": "None",
-        "stackSize": "None",
-        "priority": "None",
-        "cpu": "None",
-        "initSpecifierMap": {}
+        "baseId" : 256,
+        "maxId" : 255,
+        "file" : "None",
+        "queueSize" : "None",
+        "stackSize" : "None",
+        "priority" : "None",
+        "cpu" : "None",
+        "initSpecifierMap" : {
+          
+        }
       },
-      "21": {
-        "aNode": {
-          "astNodeId": 21
+      "21" : {
+        "aNode" : {
+          "astNodeId" : 21
         },
-        "qualifiedName": {
-          "qualifier": [],
-          "base": "c2"
+        "qualifiedName" : {
+          "qualifier" : [
+          ],
+          "base" : "c2"
         },
-        "component": {
-          "astNodeId": 13
+        "component" : {
+          "astNodeId" : 13
         },
-        "baseId": 512,
-        "maxId": 511,
-        "file": "None",
-        "queueSize": "None",
-        "stackSize": "None",
-        "priority": "None",
-        "cpu": "None",
-        "initSpecifierMap": {}
+        "baseId" : 512,
+        "maxId" : 511,
+        "file" : "None",
+        "queueSize" : "None",
+        "stackSize" : "None",
+        "priority" : "None",
+        "cpu" : "None",
+        "initSpecifierMap" : {
+          
+        }
       },
-      "25": {
-        "aNode": {
-          "astNodeId": 25
+      "25" : {
+        "aNode" : {
+          "astNodeId" : 25
         },
-        "qualifiedName": {
-          "qualifier": [],
-          "base": "c3"
+        "qualifiedName" : {
+          "qualifier" : [
+          ],
+          "base" : "c3"
         },
-        "component": {
-          "astNodeId": 13
+        "component" : {
+          "astNodeId" : 13
         },
-        "baseId": 768,
-        "maxId": 767,
-        "file": "None",
-        "queueSize": "None",
-        "stackSize": "None",
-        "priority": "None",
-        "cpu": "None",
-        "initSpecifierMap": {}
+        "baseId" : 768,
+        "maxId" : 767,
+        "file" : "None",
+        "queueSize" : "None",
+        "stackSize" : "None",
+        "priority" : "None",
+        "cpu" : "None",
+        "initSpecifierMap" : {
+          
+        }
       },
-      "29": {
-        "aNode": {
-          "astNodeId": 29
+      "29" : {
+        "aNode" : {
+          "astNodeId" : 29
         },
-        "qualifiedName": {
-          "qualifier": [],
-          "base": "c4"
+        "qualifiedName" : {
+          "qualifier" : [
+          ],
+          "base" : "c4"
         },
-        "component": {
-          "astNodeId": 13
+        "component" : {
+          "astNodeId" : 13
         },
-        "baseId": 1024,
-        "maxId": 1023,
-        "file": "None",
-        "queueSize": "None",
-        "stackSize": "None",
-        "priority": "None",
-        "cpu": "None",
-        "initSpecifierMap": {}
+        "baseId" : 1024,
+        "maxId" : 1023,
+        "file" : "None",
+        "queueSize" : "None",
+        "stackSize" : "None",
+        "priority" : "None",
+        "cpu" : "None",
+        "initSpecifierMap" : {
+          
+        }
       }
     },
-    "componentMap": {
-      "13": {
-        "aNode": {
-          "astNodeId": 13
+    "componentMap" : {
+      "13" : {
+        "aNode" : {
+          "astNodeId" : 13
         },
-        "portMap": {
-          "pIn": {
-            "General": {
-              "aNode": {
-                "astNodeId": 3
+        "portMap" : {
+          "pIn" : {
+            "General" : {
+              "aNode" : {
+                "astNodeId" : 3
               },
-              "specifier": {
-                "kind": {
-                  "SyncInput": {}
-                },
-                "name": "pIn",
-                "size": "None",
-                "port": {
-                  "Some": {
-                    "astNodeId": 2
+              "specifier" : {
+                "kind" : {
+                  "SyncInput" : {
+                    
                   }
                 },
-                "priority": "None",
-                "queueFull": "None"
+                "name" : "pIn",
+                "size" : "None",
+                "port" : {
+                  "Some" : {
+                    "astNodeId" : 2
+                  }
+                },
+                "priority" : "None",
+                "queueFull" : "None"
               },
-              "kind": "SyncInput",
-              "size": 1,
-              "ty": {
-                "DefPort": {
-                  "symbol": {
-                    "Port": {
-                      "nodeId": 0,
-                      "unqualifiedName": "P"
+              "kind" : "SyncInput",
+              "size" : 1,
+              "ty" : {
+                "DefPort" : {
+                  "symbol" : {
+                    "Port" : {
+                      "nodeId" : 0,
+                      "unqualifiedName" : "P"
                     }
                   }
                 }
               },
-              "importNodeIds": []
+              "importNodeIds" : [
+              ]
             }
           },
-          "pOut": {
-            "General": {
-              "aNode": {
-                "astNodeId": 12
+          "pOut" : {
+            "General" : {
+              "aNode" : {
+                "astNodeId" : 12
               },
-              "specifier": {
-                "kind": {
-                  "Output": {}
-                },
-                "name": "pOut",
-                "size": "None",
-                "port": {
-                  "Some": {
-                    "astNodeId": 11
+              "specifier" : {
+                "kind" : {
+                  "Output" : {
+                    
                   }
                 },
-                "priority": "None",
-                "queueFull": "None"
+                "name" : "pOut",
+                "size" : "None",
+                "port" : {
+                  "Some" : {
+                    "astNodeId" : 11
+                  }
+                },
+                "priority" : "None",
+                "queueFull" : "None"
               },
-              "kind": "Output",
-              "size": 1,
-              "ty": {
-                "DefPort": {
-                  "symbol": {
-                    "Port": {
-                      "nodeId": 0,
-                      "unqualifiedName": "P"
+              "kind" : "Output",
+              "size" : 1,
+              "ty" : {
+                "DefPort" : {
+                  "symbol" : {
+                    "Port" : {
+                      "nodeId" : 0,
+                      "unqualifiedName" : "P"
                     }
                   }
                 }
               },
-              "importNodeIds": []
+              "importNodeIds" : [
+              ]
             }
           }
         },
-        "specialPortMap": {},
-        "commandMap": {},
-        "defaultOpcode": 0,
-        "tlmChannelMap": {},
-        "tlmChannelNameMap": {},
-        "defaultTlmChannelId": 0,
-        "eventMap": {},
-        "defaultEventId": 0,
-        "paramMap": {},
-        "specPortMatchingList": [],
-        "stateMachineInstanceMap": {},
-        "portMatchingList": [],
-        "defaultParamId": 0,
-        "containerMap": {},
-        "defaultContainerId": 0,
-        "recordMap": {},
-        "defaultRecordId": 0
+        "specialPortMap" : {
+          
+        },
+        "commandMap" : {
+          
+        },
+        "defaultOpcode" : 0,
+        "tlmChannelMap" : {
+          
+        },
+        "tlmChannelNameMap" : {
+          
+        },
+        "defaultTlmChannelId" : 0,
+        "eventMap" : {
+          
+        },
+        "defaultEventId" : 0,
+        "paramMap" : {
+          
+        },
+        "specPortMatchingList" : [
+        ],
+        "stateMachineInstanceMap" : {
+          
+        },
+        "portMatchingList" : [
+        ],
+        "defaultParamId" : 0,
+        "containerMap" : {
+          
+        },
+        "defaultContainerId" : 0,
+        "recordMap" : {
+          
+        },
+        "defaultRecordId" : 0
       }
     },
-    "includedFileSet": [],
-    "inputFileSet": [
+    "includedFileSet" : [
+    ],
+    "inputFileSet" : [
       "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp"
     ],
-    "locationSpecifierMap": [],
-    "parentSymbolMap": {},
-    "symbolScopeMap": {
-      "13": {
-        "map": {}
+    "locationSpecifierMap" : [
+    ],
+    "parentSymbolMap" : {
+      
+    },
+    "symbolScopeMap" : {
+      "13" : {
+        "map" : {
+          
+        }
       }
     },
-    "topologyMap": {
-      "72": {
-        "aNode": {
-          "astNodeId": 72
+    "topologyMap" : {
+      "72" : {
+        "aNode" : {
+          "astNodeId" : 72
         },
-        "directImportMap": {},
-        "transitiveImportSet": [],
-        "instanceMap": [
+        "directImportMap" : {
+          
+        },
+        "transitiveImportSet" : [
+        ],
+        "instanceMap" : [
           [
             {
-              "aNode": {
-                "astNodeId": 17
+              "aNode" : {
+                "astNodeId" : 17
               },
-              "qualifiedName": {
-                "qualifier": [],
-                "base": "c1"
+              "qualifiedName" : {
+                "qualifier" : [
+                ],
+                "base" : "c1"
               },
-              "component": {
-                "astNodeId": 13
+              "component" : {
+                "astNodeId" : 13
               },
-              "baseId": 256,
-              "maxId": 255,
-              "file": "None",
-              "queueSize": "None",
-              "stackSize": "None",
-              "priority": "None",
-              "cpu": "None",
-              "initSpecifierMap": {}
+              "baseId" : 256,
+              "maxId" : 255,
+              "file" : "None",
+              "queueSize" : "None",
+              "stackSize" : "None",
+              "priority" : "None",
+              "cpu" : "None",
+              "initSpecifierMap" : {
+                
+              }
             },
             [
               {
-                "Public": {}
+                "Public" : {
+                  
+                }
               },
               {
-                "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                "pos": "17.3",
-                "includingLoc": "None"
+                "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                "pos" : "17.3",
+                "includingLoc" : "None"
               }
             ]
           ],
           [
             {
-              "aNode": {
-                "astNodeId": 21
+              "aNode" : {
+                "astNodeId" : 21
               },
-              "qualifiedName": {
-                "qualifier": [],
-                "base": "c2"
+              "qualifiedName" : {
+                "qualifier" : [
+                ],
+                "base" : "c2"
               },
-              "component": {
-                "astNodeId": 13
+              "component" : {
+                "astNodeId" : 13
               },
-              "baseId": 512,
-              "maxId": 511,
-              "file": "None",
-              "queueSize": "None",
-              "stackSize": "None",
-              "priority": "None",
-              "cpu": "None",
-              "initSpecifierMap": {}
+              "baseId" : 512,
+              "maxId" : 511,
+              "file" : "None",
+              "queueSize" : "None",
+              "stackSize" : "None",
+              "priority" : "None",
+              "cpu" : "None",
+              "initSpecifierMap" : {
+                
+              }
             },
             [
               {
-                "Private": {}
+                "Private" : {
+                  
+                }
               },
               {
-                "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                "pos": "19.3",
-                "includingLoc": "None"
+                "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                "pos" : "19.3",
+                "includingLoc" : "None"
               }
             ]
           ]
         ],
-        "patternMap": {},
-        "connectionMap": {
-          "C1": [
-            {
-              "from": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                  "pos": "23.5",
-                  "includingLoc": "None"
-                },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 17
-                    },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c1"
-                    },
-                    "component": {
-                      "astNodeId": 13
-                    },
-                    "baseId": 256,
-                    "maxId": 255,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
-                  },
-                  "portInstance": {
-                    "General": {
-                      "aNode": {
-                        "astNodeId": 12
-                      },
-                      "specifier": {
-                        "kind": {
-                          "Output": {}
-                        },
-                        "name": "pOut",
-                        "size": "None",
-                        "port": {
-                          "Some": {
-                            "astNodeId": 11
-                          }
-                        },
-                        "priority": "None",
-                        "queueFull": "None"
-                      },
-                      "kind": "Output",
-                      "size": 1,
-                      "ty": {
-                        "DefPort": {
-                          "symbol": {
-                            "Port": {
-                              "nodeId": 0,
-                              "unqualifiedName": "P"
-                            }
-                          }
-                        }
-                      },
-                      "importNodeIds": []
-                    }
-                  }
-                },
-                "portNumber": "None"
-              },
-              "to": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                  "pos": "23.16",
-                  "includingLoc": "None"
-                },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 21
-                    },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c2"
-                    },
-                    "component": {
-                      "astNodeId": 13
-                    },
-                    "baseId": 512,
-                    "maxId": 511,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
-                  },
-                  "portInstance": {
-                    "General": {
-                      "aNode": {
-                        "astNodeId": 3
-                      },
-                      "specifier": {
-                        "kind": {
-                          "SyncInput": {}
-                        },
-                        "name": "pIn",
-                        "size": "None",
-                        "port": {
-                          "Some": {
-                            "astNodeId": 2
-                          }
-                        },
-                        "priority": "None",
-                        "queueFull": "None"
-                      },
-                      "kind": "SyncInput",
-                      "size": 1,
-                      "ty": {
-                        "DefPort": {
-                          "symbol": {
-                            "Port": {
-                              "nodeId": 0,
-                              "unqualifiedName": "P"
-                            }
-                          }
-                        }
-                      },
-                      "importNodeIds": []
-                    }
-                  }
-                },
-                "portNumber": "None"
-              },
-              "isUnmatched": false
-            }
-          ],
-          "C2": [
-            {
-              "from": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                  "pos": "28.5",
-                  "includingLoc": "None"
-                },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 21
-                    },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c2"
-                    },
-                    "component": {
-                      "astNodeId": 13
-                    },
-                    "baseId": 512,
-                    "maxId": 511,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
-                  },
-                  "portInstance": {
-                    "General": {
-                      "aNode": {
-                        "astNodeId": 12
-                      },
-                      "specifier": {
-                        "kind": {
-                          "Output": {}
-                        },
-                        "name": "pOut",
-                        "size": "None",
-                        "port": {
-                          "Some": {
-                            "astNodeId": 11
-                          }
-                        },
-                        "priority": "None",
-                        "queueFull": "None"
-                      },
-                      "kind": "Output",
-                      "size": 1,
-                      "ty": {
-                        "DefPort": {
-                          "symbol": {
-                            "Port": {
-                              "nodeId": 0,
-                              "unqualifiedName": "P"
-                            }
-                          }
-                        }
-                      },
-                      "importNodeIds": []
-                    }
-                  }
-                },
-                "portNumber": "None"
-              },
-              "to": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                  "pos": "28.16",
-                  "includingLoc": "None"
-                },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 17
-                    },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c1"
-                    },
-                    "component": {
-                      "astNodeId": 13
-                    },
-                    "baseId": 256,
-                    "maxId": 255,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
-                  },
-                  "portInstance": {
-                    "General": {
-                      "aNode": {
-                        "astNodeId": 3
-                      },
-                      "specifier": {
-                        "kind": {
-                          "SyncInput": {}
-                        },
-                        "name": "pIn",
-                        "size": "None",
-                        "port": {
-                          "Some": {
-                            "astNodeId": 2
-                          }
-                        },
-                        "priority": "None",
-                        "queueFull": "None"
-                      },
-                      "kind": "SyncInput",
-                      "size": 1,
-                      "ty": {
-                        "DefPort": {
-                          "symbol": {
-                            "Port": {
-                              "nodeId": 0,
-                              "unqualifiedName": "P"
-                            }
-                          }
-                        }
-                      },
-                      "importNodeIds": []
-                    }
-                  }
-                },
-                "portNumber": "None"
-              },
-              "isUnmatched": false
-            }
-          ]
+        "patternMap" : {
+          
         },
-        "localConnectionMap": {
-          "C1": [
+        "connectionMap" : {
+          "C1" : [
             {
-              "from": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                  "pos": "23.5",
-                  "includingLoc": "None"
+              "from" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                  "pos" : "23.5",
+                  "includingLoc" : "None"
                 },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 17
+                "port" : {
+                  "componentInstance" : {
+                    "aNode" : {
+                      "astNodeId" : 17
                     },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c1"
+                    "qualifiedName" : {
+                      "qualifier" : [
+                      ],
+                      "base" : "c1"
                     },
-                    "component": {
-                      "astNodeId": 13
+                    "component" : {
+                      "astNodeId" : 13
                     },
-                    "baseId": 256,
-                    "maxId": 255,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
+                    "baseId" : 256,
+                    "maxId" : 255,
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecifierMap" : {
+                      
+                    }
                   },
-                  "portInstance": {
-                    "General": {
-                      "aNode": {
-                        "astNodeId": 12
+                  "portInstance" : {
+                    "General" : {
+                      "aNode" : {
+                        "astNodeId" : 12
                       },
-                      "specifier": {
-                        "kind": {
-                          "Output": {}
-                        },
-                        "name": "pOut",
-                        "size": "None",
-                        "port": {
-                          "Some": {
-                            "astNodeId": 11
+                      "specifier" : {
+                        "kind" : {
+                          "Output" : {
+                            
                           }
                         },
-                        "priority": "None",
-                        "queueFull": "None"
+                        "name" : "pOut",
+                        "size" : "None",
+                        "port" : {
+                          "Some" : {
+                            "astNodeId" : 11
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None"
                       },
-                      "kind": "Output",
-                      "size": 1,
-                      "ty": {
-                        "DefPort": {
-                          "symbol": {
-                            "Port": {
-                              "nodeId": 0,
-                              "unqualifiedName": "P"
+                      "kind" : "Output",
+                      "size" : 1,
+                      "ty" : {
+                        "DefPort" : {
+                          "symbol" : {
+                            "Port" : {
+                              "nodeId" : 0,
+                              "unqualifiedName" : "P"
                             }
                           }
                         }
                       },
-                      "importNodeIds": []
+                      "importNodeIds" : [
+                      ]
                     }
                   }
                 },
-                "portNumber": "None"
+                "portNumber" : "None"
               },
-              "to": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                  "pos": "23.16",
-                  "includingLoc": "None"
+              "to" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                  "pos" : "23.16",
+                  "includingLoc" : "None"
                 },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 21
+                "port" : {
+                  "componentInstance" : {
+                    "aNode" : {
+                      "astNodeId" : 21
                     },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c2"
+                    "qualifiedName" : {
+                      "qualifier" : [
+                      ],
+                      "base" : "c2"
                     },
-                    "component": {
-                      "astNodeId": 13
+                    "component" : {
+                      "astNodeId" : 13
                     },
-                    "baseId": 512,
-                    "maxId": 511,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
+                    "baseId" : 512,
+                    "maxId" : 511,
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecifierMap" : {
+                      
+                    }
                   },
-                  "portInstance": {
-                    "General": {
-                      "aNode": {
-                        "astNodeId": 3
+                  "portInstance" : {
+                    "General" : {
+                      "aNode" : {
+                        "astNodeId" : 3
                       },
-                      "specifier": {
-                        "kind": {
-                          "SyncInput": {}
-                        },
-                        "name": "pIn",
-                        "size": "None",
-                        "port": {
-                          "Some": {
-                            "astNodeId": 2
+                      "specifier" : {
+                        "kind" : {
+                          "SyncInput" : {
+                            
                           }
                         },
-                        "priority": "None",
-                        "queueFull": "None"
+                        "name" : "pIn",
+                        "size" : "None",
+                        "port" : {
+                          "Some" : {
+                            "astNodeId" : 2
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None"
                       },
-                      "kind": "SyncInput",
-                      "size": 1,
-                      "ty": {
-                        "DefPort": {
-                          "symbol": {
-                            "Port": {
-                              "nodeId": 0,
-                              "unqualifiedName": "P"
+                      "kind" : "SyncInput",
+                      "size" : 1,
+                      "ty" : {
+                        "DefPort" : {
+                          "symbol" : {
+                            "Port" : {
+                              "nodeId" : 0,
+                              "unqualifiedName" : "P"
                             }
                           }
                         }
                       },
-                      "importNodeIds": []
+                      "importNodeIds" : [
+                      ]
                     }
                   }
                 },
-                "portNumber": "None"
+                "portNumber" : "None"
               },
-              "isUnmatched": false
+              "isUnmatched" : false
             }
           ],
-          "C2": [
+          "C2" : [
             {
-              "from": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                  "pos": "28.5",
-                  "includingLoc": "None"
+              "from" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                  "pos" : "28.5",
+                  "includingLoc" : "None"
                 },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 21
+                "port" : {
+                  "componentInstance" : {
+                    "aNode" : {
+                      "astNodeId" : 21
                     },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c2"
+                    "qualifiedName" : {
+                      "qualifier" : [
+                      ],
+                      "base" : "c2"
                     },
-                    "component": {
-                      "astNodeId": 13
+                    "component" : {
+                      "astNodeId" : 13
                     },
-                    "baseId": 512,
-                    "maxId": 511,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
+                    "baseId" : 512,
+                    "maxId" : 511,
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecifierMap" : {
+                      
+                    }
                   },
-                  "portInstance": {
-                    "General": {
-                      "aNode": {
-                        "astNodeId": 12
+                  "portInstance" : {
+                    "General" : {
+                      "aNode" : {
+                        "astNodeId" : 12
                       },
-                      "specifier": {
-                        "kind": {
-                          "Output": {}
-                        },
-                        "name": "pOut",
-                        "size": "None",
-                        "port": {
-                          "Some": {
-                            "astNodeId": 11
+                      "specifier" : {
+                        "kind" : {
+                          "Output" : {
+                            
                           }
                         },
-                        "priority": "None",
-                        "queueFull": "None"
+                        "name" : "pOut",
+                        "size" : "None",
+                        "port" : {
+                          "Some" : {
+                            "astNodeId" : 11
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None"
                       },
-                      "kind": "Output",
-                      "size": 1,
-                      "ty": {
-                        "DefPort": {
-                          "symbol": {
-                            "Port": {
-                              "nodeId": 0,
-                              "unqualifiedName": "P"
+                      "kind" : "Output",
+                      "size" : 1,
+                      "ty" : {
+                        "DefPort" : {
+                          "symbol" : {
+                            "Port" : {
+                              "nodeId" : 0,
+                              "unqualifiedName" : "P"
                             }
                           }
                         }
                       },
-                      "importNodeIds": []
+                      "importNodeIds" : [
+                      ]
                     }
                   }
                 },
-                "portNumber": "None"
+                "portNumber" : "None"
               },
-              "to": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                  "pos": "28.16",
-                  "includingLoc": "None"
+              "to" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                  "pos" : "28.16",
+                  "includingLoc" : "None"
                 },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 17
+                "port" : {
+                  "componentInstance" : {
+                    "aNode" : {
+                      "astNodeId" : 17
                     },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c1"
+                    "qualifiedName" : {
+                      "qualifier" : [
+                      ],
+                      "base" : "c1"
                     },
-                    "component": {
-                      "astNodeId": 13
+                    "component" : {
+                      "astNodeId" : 13
                     },
-                    "baseId": 256,
-                    "maxId": 255,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
+                    "baseId" : 256,
+                    "maxId" : 255,
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecifierMap" : {
+                      
+                    }
                   },
-                  "portInstance": {
-                    "General": {
-                      "aNode": {
-                        "astNodeId": 3
+                  "portInstance" : {
+                    "General" : {
+                      "aNode" : {
+                        "astNodeId" : 3
                       },
-                      "specifier": {
-                        "kind": {
-                          "SyncInput": {}
-                        },
-                        "name": "pIn",
-                        "size": "None",
-                        "port": {
-                          "Some": {
-                            "astNodeId": 2
+                      "specifier" : {
+                        "kind" : {
+                          "SyncInput" : {
+                            
                           }
                         },
-                        "priority": "None",
-                        "queueFull": "None"
+                        "name" : "pIn",
+                        "size" : "None",
+                        "port" : {
+                          "Some" : {
+                            "astNodeId" : 2
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None"
                       },
-                      "kind": "SyncInput",
-                      "size": 1,
-                      "ty": {
-                        "DefPort": {
-                          "symbol": {
-                            "Port": {
-                              "nodeId": 0,
-                              "unqualifiedName": "P"
+                      "kind" : "SyncInput",
+                      "size" : 1,
+                      "ty" : {
+                        "DefPort" : {
+                          "symbol" : {
+                            "Port" : {
+                              "nodeId" : 0,
+                              "unqualifiedName" : "P"
                             }
                           }
                         }
                       },
-                      "importNodeIds": []
+                      "importNodeIds" : [
+                      ]
                     }
                   }
                 },
-                "portNumber": "None"
+                "portNumber" : "None"
               },
-              "isUnmatched": false
+              "isUnmatched" : false
             }
           ]
         },
-        "outputConnectionMap": [
+        "localConnectionMap" : {
+          "C1" : [
+            {
+              "from" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                  "pos" : "23.5",
+                  "includingLoc" : "None"
+                },
+                "port" : {
+                  "componentInstance" : {
+                    "aNode" : {
+                      "astNodeId" : 17
+                    },
+                    "qualifiedName" : {
+                      "qualifier" : [
+                      ],
+                      "base" : "c1"
+                    },
+                    "component" : {
+                      "astNodeId" : 13
+                    },
+                    "baseId" : 256,
+                    "maxId" : 255,
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecifierMap" : {
+                      
+                    }
+                  },
+                  "portInstance" : {
+                    "General" : {
+                      "aNode" : {
+                        "astNodeId" : 12
+                      },
+                      "specifier" : {
+                        "kind" : {
+                          "Output" : {
+                            
+                          }
+                        },
+                        "name" : "pOut",
+                        "size" : "None",
+                        "port" : {
+                          "Some" : {
+                            "astNodeId" : 11
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None"
+                      },
+                      "kind" : "Output",
+                      "size" : 1,
+                      "ty" : {
+                        "DefPort" : {
+                          "symbol" : {
+                            "Port" : {
+                              "nodeId" : 0,
+                              "unqualifiedName" : "P"
+                            }
+                          }
+                        }
+                      },
+                      "importNodeIds" : [
+                      ]
+                    }
+                  }
+                },
+                "portNumber" : "None"
+              },
+              "to" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                  "pos" : "23.16",
+                  "includingLoc" : "None"
+                },
+                "port" : {
+                  "componentInstance" : {
+                    "aNode" : {
+                      "astNodeId" : 21
+                    },
+                    "qualifiedName" : {
+                      "qualifier" : [
+                      ],
+                      "base" : "c2"
+                    },
+                    "component" : {
+                      "astNodeId" : 13
+                    },
+                    "baseId" : 512,
+                    "maxId" : 511,
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecifierMap" : {
+                      
+                    }
+                  },
+                  "portInstance" : {
+                    "General" : {
+                      "aNode" : {
+                        "astNodeId" : 3
+                      },
+                      "specifier" : {
+                        "kind" : {
+                          "SyncInput" : {
+                            
+                          }
+                        },
+                        "name" : "pIn",
+                        "size" : "None",
+                        "port" : {
+                          "Some" : {
+                            "astNodeId" : 2
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None"
+                      },
+                      "kind" : "SyncInput",
+                      "size" : 1,
+                      "ty" : {
+                        "DefPort" : {
+                          "symbol" : {
+                            "Port" : {
+                              "nodeId" : 0,
+                              "unqualifiedName" : "P"
+                            }
+                          }
+                        }
+                      },
+                      "importNodeIds" : [
+                      ]
+                    }
+                  }
+                },
+                "portNumber" : "None"
+              },
+              "isUnmatched" : false
+            }
+          ],
+          "C2" : [
+            {
+              "from" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                  "pos" : "28.5",
+                  "includingLoc" : "None"
+                },
+                "port" : {
+                  "componentInstance" : {
+                    "aNode" : {
+                      "astNodeId" : 21
+                    },
+                    "qualifiedName" : {
+                      "qualifier" : [
+                      ],
+                      "base" : "c2"
+                    },
+                    "component" : {
+                      "astNodeId" : 13
+                    },
+                    "baseId" : 512,
+                    "maxId" : 511,
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecifierMap" : {
+                      
+                    }
+                  },
+                  "portInstance" : {
+                    "General" : {
+                      "aNode" : {
+                        "astNodeId" : 12
+                      },
+                      "specifier" : {
+                        "kind" : {
+                          "Output" : {
+                            
+                          }
+                        },
+                        "name" : "pOut",
+                        "size" : "None",
+                        "port" : {
+                          "Some" : {
+                            "astNodeId" : 11
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None"
+                      },
+                      "kind" : "Output",
+                      "size" : 1,
+                      "ty" : {
+                        "DefPort" : {
+                          "symbol" : {
+                            "Port" : {
+                              "nodeId" : 0,
+                              "unqualifiedName" : "P"
+                            }
+                          }
+                        }
+                      },
+                      "importNodeIds" : [
+                      ]
+                    }
+                  }
+                },
+                "portNumber" : "None"
+              },
+              "to" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                  "pos" : "28.16",
+                  "includingLoc" : "None"
+                },
+                "port" : {
+                  "componentInstance" : {
+                    "aNode" : {
+                      "astNodeId" : 17
+                    },
+                    "qualifiedName" : {
+                      "qualifier" : [
+                      ],
+                      "base" : "c1"
+                    },
+                    "component" : {
+                      "astNodeId" : 13
+                    },
+                    "baseId" : 256,
+                    "maxId" : 255,
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecifierMap" : {
+                      
+                    }
+                  },
+                  "portInstance" : {
+                    "General" : {
+                      "aNode" : {
+                        "astNodeId" : 3
+                      },
+                      "specifier" : {
+                        "kind" : {
+                          "SyncInput" : {
+                            
+                          }
+                        },
+                        "name" : "pIn",
+                        "size" : "None",
+                        "port" : {
+                          "Some" : {
+                            "astNodeId" : 2
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None"
+                      },
+                      "kind" : "SyncInput",
+                      "size" : 1,
+                      "ty" : {
+                        "DefPort" : {
+                          "symbol" : {
+                            "Port" : {
+                              "nodeId" : 0,
+                              "unqualifiedName" : "P"
+                            }
+                          }
+                        }
+                      },
+                      "importNodeIds" : [
+                      ]
+                    }
+                  }
+                },
+                "portNumber" : "None"
+              },
+              "isUnmatched" : false
+            }
+          ]
+        },
+        "outputConnectionMap" : [
           [
             {
-              "componentInstance": {
-                "aNode": {
-                  "astNodeId": 17
+              "componentInstance" : {
+                "aNode" : {
+                  "astNodeId" : 17
                 },
-                "qualifiedName": {
-                  "qualifier": [],
-                  "base": "c1"
+                "qualifiedName" : {
+                  "qualifier" : [
+                  ],
+                  "base" : "c1"
                 },
-                "component": {
-                  "astNodeId": 13
+                "component" : {
+                  "astNodeId" : 13
                 },
-                "baseId": 256,
-                "maxId": 255,
-                "file": "None",
-                "queueSize": "None",
-                "stackSize": "None",
-                "priority": "None",
-                "cpu": "None",
-                "initSpecifierMap": {}
+                "baseId" : 256,
+                "maxId" : 255,
+                "file" : "None",
+                "queueSize" : "None",
+                "stackSize" : "None",
+                "priority" : "None",
+                "cpu" : "None",
+                "initSpecifierMap" : {
+                  
+                }
               },
-              "portInstance": {
-                "General": {
-                  "aNode": {
-                    "astNodeId": 12
+              "portInstance" : {
+                "General" : {
+                  "aNode" : {
+                    "astNodeId" : 12
                   },
-                  "specifier": {
-                    "kind": {
-                      "Output": {}
-                    },
-                    "name": "pOut",
-                    "size": "None",
-                    "port": {
-                      "Some": {
-                        "astNodeId": 11
+                  "specifier" : {
+                    "kind" : {
+                      "Output" : {
+                        
                       }
                     },
-                    "priority": "None",
-                    "queueFull": "None"
+                    "name" : "pOut",
+                    "size" : "None",
+                    "port" : {
+                      "Some" : {
+                        "astNodeId" : 11
+                      }
+                    },
+                    "priority" : "None",
+                    "queueFull" : "None"
                   },
-                  "kind": "Output",
-                  "size": 1,
-                  "ty": {
-                    "DefPort": {
-                      "symbol": {
-                        "Port": {
-                          "nodeId": 0,
-                          "unqualifiedName": "P"
+                  "kind" : "Output",
+                  "size" : 1,
+                  "ty" : {
+                    "DefPort" : {
+                      "symbol" : {
+                        "Port" : {
+                          "nodeId" : 0,
+                          "unqualifiedName" : "P"
                         }
                       }
                     }
                   },
-                  "importNodeIds": []
+                  "importNodeIds" : [
+                  ]
                 }
               }
             },
             [
               {
-                "from": {
-                  "loc": {
-                    "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                    "pos": "23.5",
-                    "includingLoc": "None"
+                "from" : {
+                  "loc" : {
+                    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                    "pos" : "23.5",
+                    "includingLoc" : "None"
                   },
-                  "port": {
-                    "componentInstance": {
-                      "aNode": {
-                        "astNodeId": 17
+                  "port" : {
+                    "componentInstance" : {
+                      "aNode" : {
+                        "astNodeId" : 17
                       },
-                      "qualifiedName": {
-                        "qualifier": [],
-                        "base": "c1"
+                      "qualifiedName" : {
+                        "qualifier" : [
+                        ],
+                        "base" : "c1"
                       },
-                      "component": {
-                        "astNodeId": 13
+                      "component" : {
+                        "astNodeId" : 13
                       },
-                      "baseId": 256,
-                      "maxId": 255,
-                      "file": "None",
-                      "queueSize": "None",
-                      "stackSize": "None",
-                      "priority": "None",
-                      "cpu": "None",
-                      "initSpecifierMap": {}
+                      "baseId" : 256,
+                      "maxId" : 255,
+                      "file" : "None",
+                      "queueSize" : "None",
+                      "stackSize" : "None",
+                      "priority" : "None",
+                      "cpu" : "None",
+                      "initSpecifierMap" : {
+                        
+                      }
                     },
-                    "portInstance": {
-                      "General": {
-                        "aNode": {
-                          "astNodeId": 12
+                    "portInstance" : {
+                      "General" : {
+                        "aNode" : {
+                          "astNodeId" : 12
                         },
-                        "specifier": {
-                          "kind": {
-                            "Output": {}
-                          },
-                          "name": "pOut",
-                          "size": "None",
-                          "port": {
-                            "Some": {
-                              "astNodeId": 11
+                        "specifier" : {
+                          "kind" : {
+                            "Output" : {
+                              
                             }
                           },
-                          "priority": "None",
-                          "queueFull": "None"
+                          "name" : "pOut",
+                          "size" : "None",
+                          "port" : {
+                            "Some" : {
+                              "astNodeId" : 11
+                            }
+                          },
+                          "priority" : "None",
+                          "queueFull" : "None"
                         },
-                        "kind": "Output",
-                        "size": 1,
-                        "ty": {
-                          "DefPort": {
-                            "symbol": {
-                              "Port": {
-                                "nodeId": 0,
-                                "unqualifiedName": "P"
+                        "kind" : "Output",
+                        "size" : 1,
+                        "ty" : {
+                          "DefPort" : {
+                            "symbol" : {
+                              "Port" : {
+                                "nodeId" : 0,
+                                "unqualifiedName" : "P"
                               }
                             }
                           }
                         },
-                        "importNodeIds": []
+                        "importNodeIds" : [
+                        ]
                       }
                     }
                   },
-                  "portNumber": "None"
+                  "portNumber" : "None"
                 },
-                "to": {
-                  "loc": {
-                    "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                    "pos": "23.16",
-                    "includingLoc": "None"
+                "to" : {
+                  "loc" : {
+                    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                    "pos" : "23.16",
+                    "includingLoc" : "None"
                   },
-                  "port": {
-                    "componentInstance": {
-                      "aNode": {
-                        "astNodeId": 21
+                  "port" : {
+                    "componentInstance" : {
+                      "aNode" : {
+                        "astNodeId" : 21
                       },
-                      "qualifiedName": {
-                        "qualifier": [],
-                        "base": "c2"
+                      "qualifiedName" : {
+                        "qualifier" : [
+                        ],
+                        "base" : "c2"
                       },
-                      "component": {
-                        "astNodeId": 13
+                      "component" : {
+                        "astNodeId" : 13
                       },
-                      "baseId": 512,
-                      "maxId": 511,
-                      "file": "None",
-                      "queueSize": "None",
-                      "stackSize": "None",
-                      "priority": "None",
-                      "cpu": "None",
-                      "initSpecifierMap": {}
+                      "baseId" : 512,
+                      "maxId" : 511,
+                      "file" : "None",
+                      "queueSize" : "None",
+                      "stackSize" : "None",
+                      "priority" : "None",
+                      "cpu" : "None",
+                      "initSpecifierMap" : {
+                        
+                      }
                     },
-                    "portInstance": {
-                      "General": {
-                        "aNode": {
-                          "astNodeId": 3
+                    "portInstance" : {
+                      "General" : {
+                        "aNode" : {
+                          "astNodeId" : 3
                         },
-                        "specifier": {
-                          "kind": {
-                            "SyncInput": {}
-                          },
-                          "name": "pIn",
-                          "size": "None",
-                          "port": {
-                            "Some": {
-                              "astNodeId": 2
+                        "specifier" : {
+                          "kind" : {
+                            "SyncInput" : {
+                              
                             }
                           },
-                          "priority": "None",
-                          "queueFull": "None"
+                          "name" : "pIn",
+                          "size" : "None",
+                          "port" : {
+                            "Some" : {
+                              "astNodeId" : 2
+                            }
+                          },
+                          "priority" : "None",
+                          "queueFull" : "None"
                         },
-                        "kind": "SyncInput",
-                        "size": 1,
-                        "ty": {
-                          "DefPort": {
-                            "symbol": {
-                              "Port": {
-                                "nodeId": 0,
-                                "unqualifiedName": "P"
+                        "kind" : "SyncInput",
+                        "size" : 1,
+                        "ty" : {
+                          "DefPort" : {
+                            "symbol" : {
+                              "Port" : {
+                                "nodeId" : 0,
+                                "unqualifiedName" : "P"
                               }
                             }
                           }
                         },
-                        "importNodeIds": []
+                        "importNodeIds" : [
+                        ]
                       }
                     }
                   },
-                  "portNumber": "None"
+                  "portNumber" : "None"
                 },
-                "isUnmatched": false
+                "isUnmatched" : false
               }
             ]
           ],
           [
             {
-              "componentInstance": {
-                "aNode": {
-                  "astNodeId": 21
+              "componentInstance" : {
+                "aNode" : {
+                  "astNodeId" : 21
                 },
-                "qualifiedName": {
-                  "qualifier": [],
-                  "base": "c2"
+                "qualifiedName" : {
+                  "qualifier" : [
+                  ],
+                  "base" : "c2"
                 },
-                "component": {
-                  "astNodeId": 13
+                "component" : {
+                  "astNodeId" : 13
                 },
-                "baseId": 512,
-                "maxId": 511,
-                "file": "None",
-                "queueSize": "None",
-                "stackSize": "None",
-                "priority": "None",
-                "cpu": "None",
-                "initSpecifierMap": {}
+                "baseId" : 512,
+                "maxId" : 511,
+                "file" : "None",
+                "queueSize" : "None",
+                "stackSize" : "None",
+                "priority" : "None",
+                "cpu" : "None",
+                "initSpecifierMap" : {
+                  
+                }
               },
-              "portInstance": {
-                "General": {
-                  "aNode": {
-                    "astNodeId": 12
+              "portInstance" : {
+                "General" : {
+                  "aNode" : {
+                    "astNodeId" : 12
                   },
-                  "specifier": {
-                    "kind": {
-                      "Output": {}
-                    },
-                    "name": "pOut",
-                    "size": "None",
-                    "port": {
-                      "Some": {
-                        "astNodeId": 11
+                  "specifier" : {
+                    "kind" : {
+                      "Output" : {
+                        
                       }
                     },
-                    "priority": "None",
-                    "queueFull": "None"
+                    "name" : "pOut",
+                    "size" : "None",
+                    "port" : {
+                      "Some" : {
+                        "astNodeId" : 11
+                      }
+                    },
+                    "priority" : "None",
+                    "queueFull" : "None"
                   },
-                  "kind": "Output",
-                  "size": 1,
-                  "ty": {
-                    "DefPort": {
-                      "symbol": {
-                        "Port": {
-                          "nodeId": 0,
-                          "unqualifiedName": "P"
+                  "kind" : "Output",
+                  "size" : 1,
+                  "ty" : {
+                    "DefPort" : {
+                      "symbol" : {
+                        "Port" : {
+                          "nodeId" : 0,
+                          "unqualifiedName" : "P"
                         }
                       }
                     }
                   },
-                  "importNodeIds": []
+                  "importNodeIds" : [
+                  ]
                 }
               }
             },
             [
               {
-                "from": {
-                  "loc": {
-                    "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                    "pos": "28.5",
-                    "includingLoc": "None"
+                "from" : {
+                  "loc" : {
+                    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                    "pos" : "28.5",
+                    "includingLoc" : "None"
                   },
-                  "port": {
-                    "componentInstance": {
-                      "aNode": {
-                        "astNodeId": 21
+                  "port" : {
+                    "componentInstance" : {
+                      "aNode" : {
+                        "astNodeId" : 21
                       },
-                      "qualifiedName": {
-                        "qualifier": [],
-                        "base": "c2"
+                      "qualifiedName" : {
+                        "qualifier" : [
+                        ],
+                        "base" : "c2"
                       },
-                      "component": {
-                        "astNodeId": 13
+                      "component" : {
+                        "astNodeId" : 13
                       },
-                      "baseId": 512,
-                      "maxId": 511,
-                      "file": "None",
-                      "queueSize": "None",
-                      "stackSize": "None",
-                      "priority": "None",
-                      "cpu": "None",
-                      "initSpecifierMap": {}
+                      "baseId" : 512,
+                      "maxId" : 511,
+                      "file" : "None",
+                      "queueSize" : "None",
+                      "stackSize" : "None",
+                      "priority" : "None",
+                      "cpu" : "None",
+                      "initSpecifierMap" : {
+                        
+                      }
                     },
-                    "portInstance": {
-                      "General": {
-                        "aNode": {
-                          "astNodeId": 12
+                    "portInstance" : {
+                      "General" : {
+                        "aNode" : {
+                          "astNodeId" : 12
                         },
-                        "specifier": {
-                          "kind": {
-                            "Output": {}
-                          },
-                          "name": "pOut",
-                          "size": "None",
-                          "port": {
-                            "Some": {
-                              "astNodeId": 11
+                        "specifier" : {
+                          "kind" : {
+                            "Output" : {
+                              
                             }
                           },
-                          "priority": "None",
-                          "queueFull": "None"
+                          "name" : "pOut",
+                          "size" : "None",
+                          "port" : {
+                            "Some" : {
+                              "astNodeId" : 11
+                            }
+                          },
+                          "priority" : "None",
+                          "queueFull" : "None"
                         },
-                        "kind": "Output",
-                        "size": 1,
-                        "ty": {
-                          "DefPort": {
-                            "symbol": {
-                              "Port": {
-                                "nodeId": 0,
-                                "unqualifiedName": "P"
+                        "kind" : "Output",
+                        "size" : 1,
+                        "ty" : {
+                          "DefPort" : {
+                            "symbol" : {
+                              "Port" : {
+                                "nodeId" : 0,
+                                "unqualifiedName" : "P"
                               }
                             }
                           }
                         },
-                        "importNodeIds": []
+                        "importNodeIds" : [
+                        ]
                       }
                     }
                   },
-                  "portNumber": "None"
+                  "portNumber" : "None"
                 },
-                "to": {
-                  "loc": {
-                    "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                    "pos": "28.16",
-                    "includingLoc": "None"
+                "to" : {
+                  "loc" : {
+                    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                    "pos" : "28.16",
+                    "includingLoc" : "None"
                   },
-                  "port": {
-                    "componentInstance": {
-                      "aNode": {
-                        "astNodeId": 17
+                  "port" : {
+                    "componentInstance" : {
+                      "aNode" : {
+                        "astNodeId" : 17
                       },
-                      "qualifiedName": {
-                        "qualifier": [],
-                        "base": "c1"
+                      "qualifiedName" : {
+                        "qualifier" : [
+                        ],
+                        "base" : "c1"
                       },
-                      "component": {
-                        "astNodeId": 13
+                      "component" : {
+                        "astNodeId" : 13
                       },
-                      "baseId": 256,
-                      "maxId": 255,
-                      "file": "None",
-                      "queueSize": "None",
-                      "stackSize": "None",
-                      "priority": "None",
-                      "cpu": "None",
-                      "initSpecifierMap": {}
+                      "baseId" : 256,
+                      "maxId" : 255,
+                      "file" : "None",
+                      "queueSize" : "None",
+                      "stackSize" : "None",
+                      "priority" : "None",
+                      "cpu" : "None",
+                      "initSpecifierMap" : {
+                        
+                      }
                     },
-                    "portInstance": {
-                      "General": {
-                        "aNode": {
-                          "astNodeId": 3
+                    "portInstance" : {
+                      "General" : {
+                        "aNode" : {
+                          "astNodeId" : 3
                         },
-                        "specifier": {
-                          "kind": {
-                            "SyncInput": {}
-                          },
-                          "name": "pIn",
-                          "size": "None",
-                          "port": {
-                            "Some": {
-                              "astNodeId": 2
+                        "specifier" : {
+                          "kind" : {
+                            "SyncInput" : {
+                              
                             }
                           },
-                          "priority": "None",
-                          "queueFull": "None"
+                          "name" : "pIn",
+                          "size" : "None",
+                          "port" : {
+                            "Some" : {
+                              "astNodeId" : 2
+                            }
+                          },
+                          "priority" : "None",
+                          "queueFull" : "None"
                         },
-                        "kind": "SyncInput",
-                        "size": 1,
-                        "ty": {
-                          "DefPort": {
-                            "symbol": {
-                              "Port": {
-                                "nodeId": 0,
-                                "unqualifiedName": "P"
+                        "kind" : "SyncInput",
+                        "size" : 1,
+                        "ty" : {
+                          "DefPort" : {
+                            "symbol" : {
+                              "Port" : {
+                                "nodeId" : 0,
+                                "unqualifiedName" : "P"
                               }
                             }
                           }
                         },
-                        "importNodeIds": []
+                        "importNodeIds" : [
+                        ]
                       }
                     }
                   },
-                  "portNumber": "None"
+                  "portNumber" : "None"
                 },
-                "isUnmatched": false
+                "isUnmatched" : false
               }
             ]
           ]
         ],
-        "inputConnectionMap": [
+        "inputConnectionMap" : [
           [
             {
-              "componentInstance": {
-                "aNode": {
-                  "astNodeId": 21
+              "componentInstance" : {
+                "aNode" : {
+                  "astNodeId" : 21
                 },
-                "qualifiedName": {
-                  "qualifier": [],
-                  "base": "c2"
+                "qualifiedName" : {
+                  "qualifier" : [
+                  ],
+                  "base" : "c2"
                 },
-                "component": {
-                  "astNodeId": 13
+                "component" : {
+                  "astNodeId" : 13
                 },
-                "baseId": 512,
-                "maxId": 511,
-                "file": "None",
-                "queueSize": "None",
-                "stackSize": "None",
-                "priority": "None",
-                "cpu": "None",
-                "initSpecifierMap": {}
+                "baseId" : 512,
+                "maxId" : 511,
+                "file" : "None",
+                "queueSize" : "None",
+                "stackSize" : "None",
+                "priority" : "None",
+                "cpu" : "None",
+                "initSpecifierMap" : {
+                  
+                }
               },
-              "portInstance": {
-                "General": {
-                  "aNode": {
-                    "astNodeId": 3
+              "portInstance" : {
+                "General" : {
+                  "aNode" : {
+                    "astNodeId" : 3
                   },
-                  "specifier": {
-                    "kind": {
-                      "SyncInput": {}
-                    },
-                    "name": "pIn",
-                    "size": "None",
-                    "port": {
-                      "Some": {
-                        "astNodeId": 2
+                  "specifier" : {
+                    "kind" : {
+                      "SyncInput" : {
+                        
                       }
                     },
-                    "priority": "None",
-                    "queueFull": "None"
+                    "name" : "pIn",
+                    "size" : "None",
+                    "port" : {
+                      "Some" : {
+                        "astNodeId" : 2
+                      }
+                    },
+                    "priority" : "None",
+                    "queueFull" : "None"
                   },
-                  "kind": "SyncInput",
-                  "size": 1,
-                  "ty": {
-                    "DefPort": {
-                      "symbol": {
-                        "Port": {
-                          "nodeId": 0,
-                          "unqualifiedName": "P"
+                  "kind" : "SyncInput",
+                  "size" : 1,
+                  "ty" : {
+                    "DefPort" : {
+                      "symbol" : {
+                        "Port" : {
+                          "nodeId" : 0,
+                          "unqualifiedName" : "P"
                         }
                       }
                     }
                   },
-                  "importNodeIds": []
+                  "importNodeIds" : [
+                  ]
                 }
               }
             },
             [
               {
-                "from": {
-                  "loc": {
-                    "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                    "pos": "23.5",
-                    "includingLoc": "None"
+                "from" : {
+                  "loc" : {
+                    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                    "pos" : "23.5",
+                    "includingLoc" : "None"
                   },
-                  "port": {
-                    "componentInstance": {
-                      "aNode": {
-                        "astNodeId": 17
+                  "port" : {
+                    "componentInstance" : {
+                      "aNode" : {
+                        "astNodeId" : 17
                       },
-                      "qualifiedName": {
-                        "qualifier": [],
-                        "base": "c1"
+                      "qualifiedName" : {
+                        "qualifier" : [
+                        ],
+                        "base" : "c1"
                       },
-                      "component": {
-                        "astNodeId": 13
+                      "component" : {
+                        "astNodeId" : 13
                       },
-                      "baseId": 256,
-                      "maxId": 255,
-                      "file": "None",
-                      "queueSize": "None",
-                      "stackSize": "None",
-                      "priority": "None",
-                      "cpu": "None",
-                      "initSpecifierMap": {}
+                      "baseId" : 256,
+                      "maxId" : 255,
+                      "file" : "None",
+                      "queueSize" : "None",
+                      "stackSize" : "None",
+                      "priority" : "None",
+                      "cpu" : "None",
+                      "initSpecifierMap" : {
+                        
+                      }
                     },
-                    "portInstance": {
-                      "General": {
-                        "aNode": {
-                          "astNodeId": 12
+                    "portInstance" : {
+                      "General" : {
+                        "aNode" : {
+                          "astNodeId" : 12
                         },
-                        "specifier": {
-                          "kind": {
-                            "Output": {}
-                          },
-                          "name": "pOut",
-                          "size": "None",
-                          "port": {
-                            "Some": {
-                              "astNodeId": 11
+                        "specifier" : {
+                          "kind" : {
+                            "Output" : {
+                              
                             }
                           },
-                          "priority": "None",
-                          "queueFull": "None"
+                          "name" : "pOut",
+                          "size" : "None",
+                          "port" : {
+                            "Some" : {
+                              "astNodeId" : 11
+                            }
+                          },
+                          "priority" : "None",
+                          "queueFull" : "None"
                         },
-                        "kind": "Output",
-                        "size": 1,
-                        "ty": {
-                          "DefPort": {
-                            "symbol": {
-                              "Port": {
-                                "nodeId": 0,
-                                "unqualifiedName": "P"
+                        "kind" : "Output",
+                        "size" : 1,
+                        "ty" : {
+                          "DefPort" : {
+                            "symbol" : {
+                              "Port" : {
+                                "nodeId" : 0,
+                                "unqualifiedName" : "P"
                               }
                             }
                           }
                         },
-                        "importNodeIds": []
+                        "importNodeIds" : [
+                        ]
                       }
                     }
                   },
-                  "portNumber": "None"
+                  "portNumber" : "None"
                 },
-                "to": {
-                  "loc": {
-                    "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                    "pos": "23.16",
-                    "includingLoc": "None"
+                "to" : {
+                  "loc" : {
+                    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                    "pos" : "23.16",
+                    "includingLoc" : "None"
                   },
-                  "port": {
-                    "componentInstance": {
-                      "aNode": {
-                        "astNodeId": 21
+                  "port" : {
+                    "componentInstance" : {
+                      "aNode" : {
+                        "astNodeId" : 21
                       },
-                      "qualifiedName": {
-                        "qualifier": [],
-                        "base": "c2"
+                      "qualifiedName" : {
+                        "qualifier" : [
+                        ],
+                        "base" : "c2"
                       },
-                      "component": {
-                        "astNodeId": 13
+                      "component" : {
+                        "astNodeId" : 13
                       },
-                      "baseId": 512,
-                      "maxId": 511,
-                      "file": "None",
-                      "queueSize": "None",
-                      "stackSize": "None",
-                      "priority": "None",
-                      "cpu": "None",
-                      "initSpecifierMap": {}
+                      "baseId" : 512,
+                      "maxId" : 511,
+                      "file" : "None",
+                      "queueSize" : "None",
+                      "stackSize" : "None",
+                      "priority" : "None",
+                      "cpu" : "None",
+                      "initSpecifierMap" : {
+                        
+                      }
                     },
-                    "portInstance": {
-                      "General": {
-                        "aNode": {
-                          "astNodeId": 3
+                    "portInstance" : {
+                      "General" : {
+                        "aNode" : {
+                          "astNodeId" : 3
                         },
-                        "specifier": {
-                          "kind": {
-                            "SyncInput": {}
-                          },
-                          "name": "pIn",
-                          "size": "None",
-                          "port": {
-                            "Some": {
-                              "astNodeId": 2
+                        "specifier" : {
+                          "kind" : {
+                            "SyncInput" : {
+                              
                             }
                           },
-                          "priority": "None",
-                          "queueFull": "None"
+                          "name" : "pIn",
+                          "size" : "None",
+                          "port" : {
+                            "Some" : {
+                              "astNodeId" : 2
+                            }
+                          },
+                          "priority" : "None",
+                          "queueFull" : "None"
                         },
-                        "kind": "SyncInput",
-                        "size": 1,
-                        "ty": {
-                          "DefPort": {
-                            "symbol": {
-                              "Port": {
-                                "nodeId": 0,
-                                "unqualifiedName": "P"
+                        "kind" : "SyncInput",
+                        "size" : 1,
+                        "ty" : {
+                          "DefPort" : {
+                            "symbol" : {
+                              "Port" : {
+                                "nodeId" : 0,
+                                "unqualifiedName" : "P"
                               }
                             }
                           }
                         },
-                        "importNodeIds": []
+                        "importNodeIds" : [
+                        ]
                       }
                     }
                   },
-                  "portNumber": "None"
+                  "portNumber" : "None"
                 },
-                "isUnmatched": false
+                "isUnmatched" : false
               }
             ]
           ],
           [
             {
-              "componentInstance": {
-                "aNode": {
-                  "astNodeId": 17
+              "componentInstance" : {
+                "aNode" : {
+                  "astNodeId" : 17
                 },
-                "qualifiedName": {
-                  "qualifier": [],
-                  "base": "c1"
+                "qualifiedName" : {
+                  "qualifier" : [
+                  ],
+                  "base" : "c1"
                 },
-                "component": {
-                  "astNodeId": 13
+                "component" : {
+                  "astNodeId" : 13
                 },
-                "baseId": 256,
-                "maxId": 255,
-                "file": "None",
-                "queueSize": "None",
-                "stackSize": "None",
-                "priority": "None",
-                "cpu": "None",
-                "initSpecifierMap": {}
+                "baseId" : 256,
+                "maxId" : 255,
+                "file" : "None",
+                "queueSize" : "None",
+                "stackSize" : "None",
+                "priority" : "None",
+                "cpu" : "None",
+                "initSpecifierMap" : {
+                  
+                }
               },
-              "portInstance": {
-                "General": {
-                  "aNode": {
-                    "astNodeId": 3
+              "portInstance" : {
+                "General" : {
+                  "aNode" : {
+                    "astNodeId" : 3
                   },
-                  "specifier": {
-                    "kind": {
-                      "SyncInput": {}
-                    },
-                    "name": "pIn",
-                    "size": "None",
-                    "port": {
-                      "Some": {
-                        "astNodeId": 2
+                  "specifier" : {
+                    "kind" : {
+                      "SyncInput" : {
+                        
                       }
                     },
-                    "priority": "None",
-                    "queueFull": "None"
+                    "name" : "pIn",
+                    "size" : "None",
+                    "port" : {
+                      "Some" : {
+                        "astNodeId" : 2
+                      }
+                    },
+                    "priority" : "None",
+                    "queueFull" : "None"
                   },
-                  "kind": "SyncInput",
-                  "size": 1,
-                  "ty": {
-                    "DefPort": {
-                      "symbol": {
-                        "Port": {
-                          "nodeId": 0,
-                          "unqualifiedName": "P"
+                  "kind" : "SyncInput",
+                  "size" : 1,
+                  "ty" : {
+                    "DefPort" : {
+                      "symbol" : {
+                        "Port" : {
+                          "nodeId" : 0,
+                          "unqualifiedName" : "P"
                         }
                       }
                     }
                   },
-                  "importNodeIds": []
+                  "importNodeIds" : [
+                  ]
                 }
               }
             },
             [
               {
-                "from": {
-                  "loc": {
-                    "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                    "pos": "28.5",
-                    "includingLoc": "None"
+                "from" : {
+                  "loc" : {
+                    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                    "pos" : "28.5",
+                    "includingLoc" : "None"
                   },
-                  "port": {
-                    "componentInstance": {
-                      "aNode": {
-                        "astNodeId": 21
+                  "port" : {
+                    "componentInstance" : {
+                      "aNode" : {
+                        "astNodeId" : 21
                       },
-                      "qualifiedName": {
-                        "qualifier": [],
-                        "base": "c2"
+                      "qualifiedName" : {
+                        "qualifier" : [
+                        ],
+                        "base" : "c2"
                       },
-                      "component": {
-                        "astNodeId": 13
+                      "component" : {
+                        "astNodeId" : 13
                       },
-                      "baseId": 512,
-                      "maxId": 511,
-                      "file": "None",
-                      "queueSize": "None",
-                      "stackSize": "None",
-                      "priority": "None",
-                      "cpu": "None",
-                      "initSpecifierMap": {}
+                      "baseId" : 512,
+                      "maxId" : 511,
+                      "file" : "None",
+                      "queueSize" : "None",
+                      "stackSize" : "None",
+                      "priority" : "None",
+                      "cpu" : "None",
+                      "initSpecifierMap" : {
+                        
+                      }
                     },
-                    "portInstance": {
-                      "General": {
-                        "aNode": {
-                          "astNodeId": 12
+                    "portInstance" : {
+                      "General" : {
+                        "aNode" : {
+                          "astNodeId" : 12
                         },
-                        "specifier": {
-                          "kind": {
-                            "Output": {}
-                          },
-                          "name": "pOut",
-                          "size": "None",
-                          "port": {
-                            "Some": {
-                              "astNodeId": 11
+                        "specifier" : {
+                          "kind" : {
+                            "Output" : {
+                              
                             }
                           },
-                          "priority": "None",
-                          "queueFull": "None"
+                          "name" : "pOut",
+                          "size" : "None",
+                          "port" : {
+                            "Some" : {
+                              "astNodeId" : 11
+                            }
+                          },
+                          "priority" : "None",
+                          "queueFull" : "None"
                         },
-                        "kind": "Output",
-                        "size": 1,
-                        "ty": {
-                          "DefPort": {
-                            "symbol": {
-                              "Port": {
-                                "nodeId": 0,
-                                "unqualifiedName": "P"
+                        "kind" : "Output",
+                        "size" : 1,
+                        "ty" : {
+                          "DefPort" : {
+                            "symbol" : {
+                              "Port" : {
+                                "nodeId" : 0,
+                                "unqualifiedName" : "P"
                               }
                             }
                           }
                         },
-                        "importNodeIds": []
+                        "importNodeIds" : [
+                        ]
                       }
                     }
                   },
-                  "portNumber": "None"
+                  "portNumber" : "None"
                 },
-                "to": {
-                  "loc": {
-                    "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                    "pos": "28.16",
-                    "includingLoc": "None"
+                "to" : {
+                  "loc" : {
+                    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                    "pos" : "28.16",
+                    "includingLoc" : "None"
                   },
-                  "port": {
-                    "componentInstance": {
-                      "aNode": {
-                        "astNodeId": 17
+                  "port" : {
+                    "componentInstance" : {
+                      "aNode" : {
+                        "astNodeId" : 17
                       },
-                      "qualifiedName": {
-                        "qualifier": [],
-                        "base": "c1"
+                      "qualifiedName" : {
+                        "qualifier" : [
+                        ],
+                        "base" : "c1"
                       },
-                      "component": {
-                        "astNodeId": 13
+                      "component" : {
+                        "astNodeId" : 13
                       },
-                      "baseId": 256,
-                      "maxId": 255,
-                      "file": "None",
-                      "queueSize": "None",
-                      "stackSize": "None",
-                      "priority": "None",
-                      "cpu": "None",
-                      "initSpecifierMap": {}
+                      "baseId" : 256,
+                      "maxId" : 255,
+                      "file" : "None",
+                      "queueSize" : "None",
+                      "stackSize" : "None",
+                      "priority" : "None",
+                      "cpu" : "None",
+                      "initSpecifierMap" : {
+                        
+                      }
                     },
-                    "portInstance": {
-                      "General": {
-                        "aNode": {
-                          "astNodeId": 3
+                    "portInstance" : {
+                      "General" : {
+                        "aNode" : {
+                          "astNodeId" : 3
                         },
-                        "specifier": {
-                          "kind": {
-                            "SyncInput": {}
-                          },
-                          "name": "pIn",
-                          "size": "None",
-                          "port": {
-                            "Some": {
-                              "astNodeId": 2
+                        "specifier" : {
+                          "kind" : {
+                            "SyncInput" : {
+                              
                             }
                           },
-                          "priority": "None",
-                          "queueFull": "None"
+                          "name" : "pIn",
+                          "size" : "None",
+                          "port" : {
+                            "Some" : {
+                              "astNodeId" : 2
+                            }
+                          },
+                          "priority" : "None",
+                          "queueFull" : "None"
                         },
-                        "kind": "SyncInput",
-                        "size": 1,
-                        "ty": {
-                          "DefPort": {
-                            "symbol": {
-                              "Port": {
-                                "nodeId": 0,
-                                "unqualifiedName": "P"
+                        "kind" : "SyncInput",
+                        "size" : 1,
+                        "ty" : {
+                          "DefPort" : {
+                            "symbol" : {
+                              "Port" : {
+                                "nodeId" : 0,
+                                "unqualifiedName" : "P"
                               }
                             }
                           }
                         },
-                        "importNodeIds": []
+                        "importNodeIds" : [
+                        ]
                       }
                     }
                   },
-                  "portNumber": "None"
+                  "portNumber" : "None"
                 },
-                "isUnmatched": false
+                "isUnmatched" : false
               }
             ]
           ]
         ],
-        "fromPortNumberMap": [
+        "fromPortNumberMap" : [
           [
             {
-              "from": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                  "pos": "23.5",
-                  "includingLoc": "None"
+              "from" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                  "pos" : "23.5",
+                  "includingLoc" : "None"
                 },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 17
+                "port" : {
+                  "componentInstance" : {
+                    "aNode" : {
+                      "astNodeId" : 17
                     },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c1"
+                    "qualifiedName" : {
+                      "qualifier" : [
+                      ],
+                      "base" : "c1"
                     },
-                    "component": {
-                      "astNodeId": 13
+                    "component" : {
+                      "astNodeId" : 13
                     },
-                    "baseId": 256,
-                    "maxId": 255,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
+                    "baseId" : 256,
+                    "maxId" : 255,
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecifierMap" : {
+                      
+                    }
                   },
-                  "portInstance": {
-                    "General": {
-                      "aNode": {
-                        "astNodeId": 12
+                  "portInstance" : {
+                    "General" : {
+                      "aNode" : {
+                        "astNodeId" : 12
                       },
-                      "specifier": {
-                        "kind": {
-                          "Output": {}
-                        },
-                        "name": "pOut",
-                        "size": "None",
-                        "port": {
-                          "Some": {
-                            "astNodeId": 11
+                      "specifier" : {
+                        "kind" : {
+                          "Output" : {
+                            
                           }
                         },
-                        "priority": "None",
-                        "queueFull": "None"
+                        "name" : "pOut",
+                        "size" : "None",
+                        "port" : {
+                          "Some" : {
+                            "astNodeId" : 11
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None"
                       },
-                      "kind": "Output",
-                      "size": 1,
-                      "ty": {
-                        "DefPort": {
-                          "symbol": {
-                            "Port": {
-                              "nodeId": 0,
-                              "unqualifiedName": "P"
+                      "kind" : "Output",
+                      "size" : 1,
+                      "ty" : {
+                        "DefPort" : {
+                          "symbol" : {
+                            "Port" : {
+                              "nodeId" : 0,
+                              "unqualifiedName" : "P"
                             }
                           }
                         }
                       },
-                      "importNodeIds": []
+                      "importNodeIds" : [
+                      ]
                     }
                   }
                 },
-                "portNumber": "None"
+                "portNumber" : "None"
               },
-              "to": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                  "pos": "23.16",
-                  "includingLoc": "None"
+              "to" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                  "pos" : "23.16",
+                  "includingLoc" : "None"
                 },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 21
+                "port" : {
+                  "componentInstance" : {
+                    "aNode" : {
+                      "astNodeId" : 21
                     },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c2"
+                    "qualifiedName" : {
+                      "qualifier" : [
+                      ],
+                      "base" : "c2"
                     },
-                    "component": {
-                      "astNodeId": 13
+                    "component" : {
+                      "astNodeId" : 13
                     },
-                    "baseId": 512,
-                    "maxId": 511,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
+                    "baseId" : 512,
+                    "maxId" : 511,
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecifierMap" : {
+                      
+                    }
                   },
-                  "portInstance": {
-                    "General": {
-                      "aNode": {
-                        "astNodeId": 3
+                  "portInstance" : {
+                    "General" : {
+                      "aNode" : {
+                        "astNodeId" : 3
                       },
-                      "specifier": {
-                        "kind": {
-                          "SyncInput": {}
-                        },
-                        "name": "pIn",
-                        "size": "None",
-                        "port": {
-                          "Some": {
-                            "astNodeId": 2
+                      "specifier" : {
+                        "kind" : {
+                          "SyncInput" : {
+                            
                           }
                         },
-                        "priority": "None",
-                        "queueFull": "None"
+                        "name" : "pIn",
+                        "size" : "None",
+                        "port" : {
+                          "Some" : {
+                            "astNodeId" : 2
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None"
                       },
-                      "kind": "SyncInput",
-                      "size": 1,
-                      "ty": {
-                        "DefPort": {
-                          "symbol": {
-                            "Port": {
-                              "nodeId": 0,
-                              "unqualifiedName": "P"
+                      "kind" : "SyncInput",
+                      "size" : 1,
+                      "ty" : {
+                        "DefPort" : {
+                          "symbol" : {
+                            "Port" : {
+                              "nodeId" : 0,
+                              "unqualifiedName" : "P"
                             }
                           }
                         }
                       },
-                      "importNodeIds": []
+                      "importNodeIds" : [
+                      ]
                     }
                   }
                 },
-                "portNumber": "None"
+                "portNumber" : "None"
               },
-              "isUnmatched": false
+              "isUnmatched" : false
             },
             0
           ],
           [
             {
-              "from": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                  "pos": "28.5",
-                  "includingLoc": "None"
+              "from" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                  "pos" : "28.5",
+                  "includingLoc" : "None"
                 },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 21
+                "port" : {
+                  "componentInstance" : {
+                    "aNode" : {
+                      "astNodeId" : 21
                     },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c2"
+                    "qualifiedName" : {
+                      "qualifier" : [
+                      ],
+                      "base" : "c2"
                     },
-                    "component": {
-                      "astNodeId": 13
+                    "component" : {
+                      "astNodeId" : 13
                     },
-                    "baseId": 512,
-                    "maxId": 511,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
+                    "baseId" : 512,
+                    "maxId" : 511,
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecifierMap" : {
+                      
+                    }
                   },
-                  "portInstance": {
-                    "General": {
-                      "aNode": {
-                        "astNodeId": 12
+                  "portInstance" : {
+                    "General" : {
+                      "aNode" : {
+                        "astNodeId" : 12
                       },
-                      "specifier": {
-                        "kind": {
-                          "Output": {}
-                        },
-                        "name": "pOut",
-                        "size": "None",
-                        "port": {
-                          "Some": {
-                            "astNodeId": 11
+                      "specifier" : {
+                        "kind" : {
+                          "Output" : {
+                            
                           }
                         },
-                        "priority": "None",
-                        "queueFull": "None"
+                        "name" : "pOut",
+                        "size" : "None",
+                        "port" : {
+                          "Some" : {
+                            "astNodeId" : 11
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None"
                       },
-                      "kind": "Output",
-                      "size": 1,
-                      "ty": {
-                        "DefPort": {
-                          "symbol": {
-                            "Port": {
-                              "nodeId": 0,
-                              "unqualifiedName": "P"
+                      "kind" : "Output",
+                      "size" : 1,
+                      "ty" : {
+                        "DefPort" : {
+                          "symbol" : {
+                            "Port" : {
+                              "nodeId" : 0,
+                              "unqualifiedName" : "P"
                             }
                           }
                         }
                       },
-                      "importNodeIds": []
+                      "importNodeIds" : [
+                      ]
                     }
                   }
                 },
-                "portNumber": "None"
+                "portNumber" : "None"
               },
-              "to": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                  "pos": "28.16",
-                  "includingLoc": "None"
+              "to" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                  "pos" : "28.16",
+                  "includingLoc" : "None"
                 },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 17
+                "port" : {
+                  "componentInstance" : {
+                    "aNode" : {
+                      "astNodeId" : 17
                     },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c1"
+                    "qualifiedName" : {
+                      "qualifier" : [
+                      ],
+                      "base" : "c1"
                     },
-                    "component": {
-                      "astNodeId": 13
+                    "component" : {
+                      "astNodeId" : 13
                     },
-                    "baseId": 256,
-                    "maxId": 255,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
+                    "baseId" : 256,
+                    "maxId" : 255,
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecifierMap" : {
+                      
+                    }
                   },
-                  "portInstance": {
-                    "General": {
-                      "aNode": {
-                        "astNodeId": 3
+                  "portInstance" : {
+                    "General" : {
+                      "aNode" : {
+                        "astNodeId" : 3
                       },
-                      "specifier": {
-                        "kind": {
-                          "SyncInput": {}
-                        },
-                        "name": "pIn",
-                        "size": "None",
-                        "port": {
-                          "Some": {
-                            "astNodeId": 2
+                      "specifier" : {
+                        "kind" : {
+                          "SyncInput" : {
+                            
                           }
                         },
-                        "priority": "None",
-                        "queueFull": "None"
+                        "name" : "pIn",
+                        "size" : "None",
+                        "port" : {
+                          "Some" : {
+                            "astNodeId" : 2
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None"
                       },
-                      "kind": "SyncInput",
-                      "size": 1,
-                      "ty": {
-                        "DefPort": {
-                          "symbol": {
-                            "Port": {
-                              "nodeId": 0,
-                              "unqualifiedName": "P"
+                      "kind" : "SyncInput",
+                      "size" : 1,
+                      "ty" : {
+                        "DefPort" : {
+                          "symbol" : {
+                            "Port" : {
+                              "nodeId" : 0,
+                              "unqualifiedName" : "P"
                             }
                           }
                         }
                       },
-                      "importNodeIds": []
+                      "importNodeIds" : [
+                      ]
                     }
                   }
                 },
-                "portNumber": "None"
+                "portNumber" : "None"
               },
-              "isUnmatched": false
+              "isUnmatched" : false
             },
             0
           ]
         ],
-        "toPortNumberMap": [
+        "toPortNumberMap" : [
           [
             {
-              "from": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                  "pos": "28.5",
-                  "includingLoc": "None"
+              "from" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                  "pos" : "28.5",
+                  "includingLoc" : "None"
                 },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 21
+                "port" : {
+                  "componentInstance" : {
+                    "aNode" : {
+                      "astNodeId" : 21
                     },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c2"
+                    "qualifiedName" : {
+                      "qualifier" : [
+                      ],
+                      "base" : "c2"
                     },
-                    "component": {
-                      "astNodeId": 13
+                    "component" : {
+                      "astNodeId" : 13
                     },
-                    "baseId": 512,
-                    "maxId": 511,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
+                    "baseId" : 512,
+                    "maxId" : 511,
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecifierMap" : {
+                      
+                    }
                   },
-                  "portInstance": {
-                    "General": {
-                      "aNode": {
-                        "astNodeId": 12
+                  "portInstance" : {
+                    "General" : {
+                      "aNode" : {
+                        "astNodeId" : 12
                       },
-                      "specifier": {
-                        "kind": {
-                          "Output": {}
-                        },
-                        "name": "pOut",
-                        "size": "None",
-                        "port": {
-                          "Some": {
-                            "astNodeId": 11
+                      "specifier" : {
+                        "kind" : {
+                          "Output" : {
+                            
                           }
                         },
-                        "priority": "None",
-                        "queueFull": "None"
+                        "name" : "pOut",
+                        "size" : "None",
+                        "port" : {
+                          "Some" : {
+                            "astNodeId" : 11
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None"
                       },
-                      "kind": "Output",
-                      "size": 1,
-                      "ty": {
-                        "DefPort": {
-                          "symbol": {
-                            "Port": {
-                              "nodeId": 0,
-                              "unqualifiedName": "P"
+                      "kind" : "Output",
+                      "size" : 1,
+                      "ty" : {
+                        "DefPort" : {
+                          "symbol" : {
+                            "Port" : {
+                              "nodeId" : 0,
+                              "unqualifiedName" : "P"
                             }
                           }
                         }
                       },
-                      "importNodeIds": []
+                      "importNodeIds" : [
+                      ]
                     }
                   }
                 },
-                "portNumber": "None"
+                "portNumber" : "None"
               },
-              "to": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                  "pos": "28.16",
-                  "includingLoc": "None"
+              "to" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                  "pos" : "28.16",
+                  "includingLoc" : "None"
                 },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 17
+                "port" : {
+                  "componentInstance" : {
+                    "aNode" : {
+                      "astNodeId" : 17
                     },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c1"
+                    "qualifiedName" : {
+                      "qualifier" : [
+                      ],
+                      "base" : "c1"
                     },
-                    "component": {
-                      "astNodeId": 13
+                    "component" : {
+                      "astNodeId" : 13
                     },
-                    "baseId": 256,
-                    "maxId": 255,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
+                    "baseId" : 256,
+                    "maxId" : 255,
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecifierMap" : {
+                      
+                    }
                   },
-                  "portInstance": {
-                    "General": {
-                      "aNode": {
-                        "astNodeId": 3
+                  "portInstance" : {
+                    "General" : {
+                      "aNode" : {
+                        "astNodeId" : 3
                       },
-                      "specifier": {
-                        "kind": {
-                          "SyncInput": {}
-                        },
-                        "name": "pIn",
-                        "size": "None",
-                        "port": {
-                          "Some": {
-                            "astNodeId": 2
+                      "specifier" : {
+                        "kind" : {
+                          "SyncInput" : {
+                            
                           }
                         },
-                        "priority": "None",
-                        "queueFull": "None"
+                        "name" : "pIn",
+                        "size" : "None",
+                        "port" : {
+                          "Some" : {
+                            "astNodeId" : 2
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None"
                       },
-                      "kind": "SyncInput",
-                      "size": 1,
-                      "ty": {
-                        "DefPort": {
-                          "symbol": {
-                            "Port": {
-                              "nodeId": 0,
-                              "unqualifiedName": "P"
+                      "kind" : "SyncInput",
+                      "size" : 1,
+                      "ty" : {
+                        "DefPort" : {
+                          "symbol" : {
+                            "Port" : {
+                              "nodeId" : 0,
+                              "unqualifiedName" : "P"
                             }
                           }
                         }
                       },
-                      "importNodeIds": []
+                      "importNodeIds" : [
+                      ]
                     }
                   }
                 },
-                "portNumber": "None"
+                "portNumber" : "None"
               },
-              "isUnmatched": false
+              "isUnmatched" : false
             },
             0
           ],
           [
             {
-              "from": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                  "pos": "23.5",
-                  "includingLoc": "None"
+              "from" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                  "pos" : "23.5",
+                  "includingLoc" : "None"
                 },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 17
+                "port" : {
+                  "componentInstance" : {
+                    "aNode" : {
+                      "astNodeId" : 17
                     },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c1"
+                    "qualifiedName" : {
+                      "qualifier" : [
+                      ],
+                      "base" : "c1"
                     },
-                    "component": {
-                      "astNodeId": 13
+                    "component" : {
+                      "astNodeId" : 13
                     },
-                    "baseId": 256,
-                    "maxId": 255,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
+                    "baseId" : 256,
+                    "maxId" : 255,
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecifierMap" : {
+                      
+                    }
                   },
-                  "portInstance": {
-                    "General": {
-                      "aNode": {
-                        "astNodeId": 12
+                  "portInstance" : {
+                    "General" : {
+                      "aNode" : {
+                        "astNodeId" : 12
                       },
-                      "specifier": {
-                        "kind": {
-                          "Output": {}
-                        },
-                        "name": "pOut",
-                        "size": "None",
-                        "port": {
-                          "Some": {
-                            "astNodeId": 11
+                      "specifier" : {
+                        "kind" : {
+                          "Output" : {
+                            
                           }
                         },
-                        "priority": "None",
-                        "queueFull": "None"
+                        "name" : "pOut",
+                        "size" : "None",
+                        "port" : {
+                          "Some" : {
+                            "astNodeId" : 11
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None"
                       },
-                      "kind": "Output",
-                      "size": 1,
-                      "ty": {
-                        "DefPort": {
-                          "symbol": {
-                            "Port": {
-                              "nodeId": 0,
-                              "unqualifiedName": "P"
+                      "kind" : "Output",
+                      "size" : 1,
+                      "ty" : {
+                        "DefPort" : {
+                          "symbol" : {
+                            "Port" : {
+                              "nodeId" : 0,
+                              "unqualifiedName" : "P"
                             }
                           }
                         }
                       },
-                      "importNodeIds": []
+                      "importNodeIds" : [
+                      ]
                     }
                   }
                 },
-                "portNumber": "None"
+                "portNumber" : "None"
               },
-              "to": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                  "pos": "23.16",
-                  "includingLoc": "None"
+              "to" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                  "pos" : "23.16",
+                  "includingLoc" : "None"
                 },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 21
+                "port" : {
+                  "componentInstance" : {
+                    "aNode" : {
+                      "astNodeId" : 21
                     },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c2"
+                    "qualifiedName" : {
+                      "qualifier" : [
+                      ],
+                      "base" : "c2"
                     },
-                    "component": {
-                      "astNodeId": 13
+                    "component" : {
+                      "astNodeId" : 13
                     },
-                    "baseId": 512,
-                    "maxId": 511,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
+                    "baseId" : 512,
+                    "maxId" : 511,
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecifierMap" : {
+                      
+                    }
                   },
-                  "portInstance": {
-                    "General": {
-                      "aNode": {
-                        "astNodeId": 3
+                  "portInstance" : {
+                    "General" : {
+                      "aNode" : {
+                        "astNodeId" : 3
                       },
-                      "specifier": {
-                        "kind": {
-                          "SyncInput": {}
-                        },
-                        "name": "pIn",
-                        "size": "None",
-                        "port": {
-                          "Some": {
-                            "astNodeId": 2
+                      "specifier" : {
+                        "kind" : {
+                          "SyncInput" : {
+                            
                           }
                         },
-                        "priority": "None",
-                        "queueFull": "None"
+                        "name" : "pIn",
+                        "size" : "None",
+                        "port" : {
+                          "Some" : {
+                            "astNodeId" : 2
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None"
                       },
-                      "kind": "SyncInput",
-                      "size": 1,
-                      "ty": {
-                        "DefPort": {
-                          "symbol": {
-                            "Port": {
-                              "nodeId": 0,
-                              "unqualifiedName": "P"
+                      "kind" : "SyncInput",
+                      "size" : 1,
+                      "ty" : {
+                        "DefPort" : {
+                          "symbol" : {
+                            "Port" : {
+                              "nodeId" : 0,
+                              "unqualifiedName" : "P"
                             }
                           }
                         }
                       },
-                      "importNodeIds": []
+                      "importNodeIds" : [
+                      ]
                     }
                   }
                 },
-                "portNumber": "None"
+                "portNumber" : "None"
               },
-              "isUnmatched": false
+              "isUnmatched" : false
             },
             0
           ]
         ],
-        "unconnectedPortSet": []
+        "unconnectedPortSet" : [
+        ]
       },
-      "118": {
-        "aNode": {
-          "astNodeId": 118
+      "118" : {
+        "aNode" : {
+          "astNodeId" : 118
         },
-        "directImportMap": {
-          "72": {
-            "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-            "pos": "35.3",
-            "includingLoc": "None"
+        "directImportMap" : {
+          "72" : {
+            "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+            "pos" : "35.3",
+            "includingLoc" : "None"
           }
         },
-        "transitiveImportSet": [
+        "transitiveImportSet" : [
           {
-            "node": {
-              "astNodeId": 72
+            "node" : {
+              "astNodeId" : 72
             }
           }
         ],
-        "instanceMap": [
+        "instanceMap" : [
           [
             {
-              "aNode": {
-                "astNodeId": 25
+              "aNode" : {
+                "astNodeId" : 25
               },
-              "qualifiedName": {
-                "qualifier": [],
-                "base": "c3"
+              "qualifiedName" : {
+                "qualifier" : [
+                ],
+                "base" : "c3"
               },
-              "component": {
-                "astNodeId": 13
+              "component" : {
+                "astNodeId" : 13
               },
-              "baseId": 768,
-              "maxId": 767,
-              "file": "None",
-              "queueSize": "None",
-              "stackSize": "None",
-              "priority": "None",
-              "cpu": "None",
-              "initSpecifierMap": {}
+              "baseId" : 768,
+              "maxId" : 767,
+              "file" : "None",
+              "queueSize" : "None",
+              "stackSize" : "None",
+              "priority" : "None",
+              "cpu" : "None",
+              "initSpecifierMap" : {
+                
+              }
             },
             [
               {
-                "Public": {}
+                "Public" : {
+                  
+                }
               },
               {
-                "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                "pos": "37.3",
-                "includingLoc": "None"
+                "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                "pos" : "37.3",
+                "includingLoc" : "None"
               }
             ]
           ],
           [
             {
-              "aNode": {
-                "astNodeId": 29
+              "aNode" : {
+                "astNodeId" : 29
               },
-              "qualifiedName": {
-                "qualifier": [],
-                "base": "c4"
+              "qualifiedName" : {
+                "qualifier" : [
+                ],
+                "base" : "c4"
               },
-              "component": {
-                "astNodeId": 13
+              "component" : {
+                "astNodeId" : 13
               },
-              "baseId": 1024,
-              "maxId": 1023,
-              "file": "None",
-              "queueSize": "None",
-              "stackSize": "None",
-              "priority": "None",
-              "cpu": "None",
-              "initSpecifierMap": {}
+              "baseId" : 1024,
+              "maxId" : 1023,
+              "file" : "None",
+              "queueSize" : "None",
+              "stackSize" : "None",
+              "priority" : "None",
+              "cpu" : "None",
+              "initSpecifierMap" : {
+                
+              }
             },
             [
               {
-                "Public": {}
+                "Public" : {
+                  
+                }
               },
               {
-                "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                "pos": "39.3",
-                "includingLoc": "None"
+                "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                "pos" : "39.3",
+                "includingLoc" : "None"
               }
             ]
           ],
           [
             {
-              "aNode": {
-                "astNodeId": 17
+              "aNode" : {
+                "astNodeId" : 17
               },
-              "qualifiedName": {
-                "qualifier": [],
-                "base": "c1"
+              "qualifiedName" : {
+                "qualifier" : [
+                ],
+                "base" : "c1"
               },
-              "component": {
-                "astNodeId": 13
+              "component" : {
+                "astNodeId" : 13
               },
-              "baseId": 256,
-              "maxId": 255,
-              "file": "None",
-              "queueSize": "None",
-              "stackSize": "None",
-              "priority": "None",
-              "cpu": "None",
-              "initSpecifierMap": {}
+              "baseId" : 256,
+              "maxId" : 255,
+              "file" : "None",
+              "queueSize" : "None",
+              "stackSize" : "None",
+              "priority" : "None",
+              "cpu" : "None",
+              "initSpecifierMap" : {
+                
+              }
             },
             [
               {
-                "Public": {}
+                "Public" : {
+                  
+                }
               },
               {
-                "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                "pos": "17.3",
-                "includingLoc": "None"
+                "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                "pos" : "17.3",
+                "includingLoc" : "None"
               }
             ]
           ]
         ],
-        "patternMap": {},
-        "connectionMap": {
-          "C3": [
+        "patternMap" : {
+          
+        },
+        "connectionMap" : {
+          "C3" : [
             {
-              "from": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                  "pos": "43.5",
-                  "includingLoc": "None"
+              "from" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                  "pos" : "43.5",
+                  "includingLoc" : "None"
                 },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 25
+                "port" : {
+                  "componentInstance" : {
+                    "aNode" : {
+                      "astNodeId" : 25
                     },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c3"
+                    "qualifiedName" : {
+                      "qualifier" : [
+                      ],
+                      "base" : "c3"
                     },
-                    "component": {
-                      "astNodeId": 13
+                    "component" : {
+                      "astNodeId" : 13
                     },
-                    "baseId": 768,
-                    "maxId": 767,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
+                    "baseId" : 768,
+                    "maxId" : 767,
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecifierMap" : {
+                      
+                    }
                   },
-                  "portInstance": {
-                    "General": {
-                      "aNode": {
-                        "astNodeId": 12
+                  "portInstance" : {
+                    "General" : {
+                      "aNode" : {
+                        "astNodeId" : 12
                       },
-                      "specifier": {
-                        "kind": {
-                          "Output": {}
-                        },
-                        "name": "pOut",
-                        "size": "None",
-                        "port": {
-                          "Some": {
-                            "astNodeId": 11
+                      "specifier" : {
+                        "kind" : {
+                          "Output" : {
+                            
                           }
                         },
-                        "priority": "None",
-                        "queueFull": "None"
+                        "name" : "pOut",
+                        "size" : "None",
+                        "port" : {
+                          "Some" : {
+                            "astNodeId" : 11
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None"
                       },
-                      "kind": "Output",
-                      "size": 1,
-                      "ty": {
-                        "DefPort": {
-                          "symbol": {
-                            "Port": {
-                              "nodeId": 0,
-                              "unqualifiedName": "P"
+                      "kind" : "Output",
+                      "size" : 1,
+                      "ty" : {
+                        "DefPort" : {
+                          "symbol" : {
+                            "Port" : {
+                              "nodeId" : 0,
+                              "unqualifiedName" : "P"
                             }
                           }
                         }
                       },
-                      "importNodeIds": []
+                      "importNodeIds" : [
+                      ]
                     }
                   }
                 },
-                "portNumber": "None"
+                "portNumber" : "None"
               },
-              "to": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                  "pos": "43.16",
-                  "includingLoc": "None"
+              "to" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                  "pos" : "43.16",
+                  "includingLoc" : "None"
                 },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 29
+                "port" : {
+                  "componentInstance" : {
+                    "aNode" : {
+                      "astNodeId" : 29
                     },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c4"
+                    "qualifiedName" : {
+                      "qualifier" : [
+                      ],
+                      "base" : "c4"
                     },
-                    "component": {
-                      "astNodeId": 13
+                    "component" : {
+                      "astNodeId" : 13
                     },
-                    "baseId": 1024,
-                    "maxId": 1023,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
+                    "baseId" : 1024,
+                    "maxId" : 1023,
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecifierMap" : {
+                      
+                    }
                   },
-                  "portInstance": {
-                    "General": {
-                      "aNode": {
-                        "astNodeId": 3
+                  "portInstance" : {
+                    "General" : {
+                      "aNode" : {
+                        "astNodeId" : 3
                       },
-                      "specifier": {
-                        "kind": {
-                          "SyncInput": {}
-                        },
-                        "name": "pIn",
-                        "size": "None",
-                        "port": {
-                          "Some": {
-                            "astNodeId": 2
+                      "specifier" : {
+                        "kind" : {
+                          "SyncInput" : {
+                            
                           }
                         },
-                        "priority": "None",
-                        "queueFull": "None"
+                        "name" : "pIn",
+                        "size" : "None",
+                        "port" : {
+                          "Some" : {
+                            "astNodeId" : 2
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None"
                       },
-                      "kind": "SyncInput",
-                      "size": 1,
-                      "ty": {
-                        "DefPort": {
-                          "symbol": {
-                            "Port": {
-                              "nodeId": 0,
-                              "unqualifiedName": "P"
+                      "kind" : "SyncInput",
+                      "size" : 1,
+                      "ty" : {
+                        "DefPort" : {
+                          "symbol" : {
+                            "Port" : {
+                              "nodeId" : 0,
+                              "unqualifiedName" : "P"
                             }
                           }
                         }
                       },
-                      "importNodeIds": []
+                      "importNodeIds" : [
+                      ]
                     }
                   }
                 },
-                "portNumber": "None"
+                "portNumber" : "None"
               },
-              "isUnmatched": false
+              "isUnmatched" : false
             }
           ],
-          "C4": [
+          "C4" : [
             {
-              "from": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                  "pos": "48.5",
-                  "includingLoc": "None"
+              "from" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                  "pos" : "48.5",
+                  "includingLoc" : "None"
                 },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 29
+                "port" : {
+                  "componentInstance" : {
+                    "aNode" : {
+                      "astNodeId" : 29
                     },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c4"
+                    "qualifiedName" : {
+                      "qualifier" : [
+                      ],
+                      "base" : "c4"
                     },
-                    "component": {
-                      "astNodeId": 13
+                    "component" : {
+                      "astNodeId" : 13
                     },
-                    "baseId": 1024,
-                    "maxId": 1023,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
+                    "baseId" : 1024,
+                    "maxId" : 1023,
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecifierMap" : {
+                      
+                    }
                   },
-                  "portInstance": {
-                    "General": {
-                      "aNode": {
-                        "astNodeId": 12
+                  "portInstance" : {
+                    "General" : {
+                      "aNode" : {
+                        "astNodeId" : 12
                       },
-                      "specifier": {
-                        "kind": {
-                          "Output": {}
-                        },
-                        "name": "pOut",
-                        "size": "None",
-                        "port": {
-                          "Some": {
-                            "astNodeId": 11
+                      "specifier" : {
+                        "kind" : {
+                          "Output" : {
+                            
                           }
                         },
-                        "priority": "None",
-                        "queueFull": "None"
+                        "name" : "pOut",
+                        "size" : "None",
+                        "port" : {
+                          "Some" : {
+                            "astNodeId" : 11
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None"
                       },
-                      "kind": "Output",
-                      "size": 1,
-                      "ty": {
-                        "DefPort": {
-                          "symbol": {
-                            "Port": {
-                              "nodeId": 0,
-                              "unqualifiedName": "P"
+                      "kind" : "Output",
+                      "size" : 1,
+                      "ty" : {
+                        "DefPort" : {
+                          "symbol" : {
+                            "Port" : {
+                              "nodeId" : 0,
+                              "unqualifiedName" : "P"
                             }
                           }
                         }
                       },
-                      "importNodeIds": []
+                      "importNodeIds" : [
+                      ]
                     }
                   }
                 },
-                "portNumber": "None"
+                "portNumber" : "None"
               },
-              "to": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                  "pos": "48.16",
-                  "includingLoc": "None"
+              "to" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                  "pos" : "48.16",
+                  "includingLoc" : "None"
                 },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 25
+                "port" : {
+                  "componentInstance" : {
+                    "aNode" : {
+                      "astNodeId" : 25
                     },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c3"
+                    "qualifiedName" : {
+                      "qualifier" : [
+                      ],
+                      "base" : "c3"
                     },
-                    "component": {
-                      "astNodeId": 13
+                    "component" : {
+                      "astNodeId" : 13
                     },
-                    "baseId": 768,
-                    "maxId": 767,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
+                    "baseId" : 768,
+                    "maxId" : 767,
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecifierMap" : {
+                      
+                    }
                   },
-                  "portInstance": {
-                    "General": {
-                      "aNode": {
-                        "astNodeId": 3
+                  "portInstance" : {
+                    "General" : {
+                      "aNode" : {
+                        "astNodeId" : 3
                       },
-                      "specifier": {
-                        "kind": {
-                          "SyncInput": {}
-                        },
-                        "name": "pIn",
-                        "size": "None",
-                        "port": {
-                          "Some": {
-                            "astNodeId": 2
+                      "specifier" : {
+                        "kind" : {
+                          "SyncInput" : {
+                            
                           }
                         },
-                        "priority": "None",
-                        "queueFull": "None"
+                        "name" : "pIn",
+                        "size" : "None",
+                        "port" : {
+                          "Some" : {
+                            "astNodeId" : 2
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None"
                       },
-                      "kind": "SyncInput",
-                      "size": 1,
-                      "ty": {
-                        "DefPort": {
-                          "symbol": {
-                            "Port": {
-                              "nodeId": 0,
-                              "unqualifiedName": "P"
+                      "kind" : "SyncInput",
+                      "size" : 1,
+                      "ty" : {
+                        "DefPort" : {
+                          "symbol" : {
+                            "Port" : {
+                              "nodeId" : 0,
+                              "unqualifiedName" : "P"
                             }
                           }
                         }
                       },
-                      "importNodeIds": []
+                      "importNodeIds" : [
+                      ]
                     }
                   }
                 },
-                "portNumber": "None"
+                "portNumber" : "None"
               },
-              "isUnmatched": false
+              "isUnmatched" : false
             }
           ]
         },
-        "localConnectionMap": {
-          "C3": [
+        "localConnectionMap" : {
+          "C3" : [
             {
-              "from": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                  "pos": "43.5",
-                  "includingLoc": "None"
+              "from" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                  "pos" : "43.5",
+                  "includingLoc" : "None"
                 },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 25
+                "port" : {
+                  "componentInstance" : {
+                    "aNode" : {
+                      "astNodeId" : 25
                     },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c3"
+                    "qualifiedName" : {
+                      "qualifier" : [
+                      ],
+                      "base" : "c3"
                     },
-                    "component": {
-                      "astNodeId": 13
+                    "component" : {
+                      "astNodeId" : 13
                     },
-                    "baseId": 768,
-                    "maxId": 767,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
+                    "baseId" : 768,
+                    "maxId" : 767,
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecifierMap" : {
+                      
+                    }
                   },
-                  "portInstance": {
-                    "General": {
-                      "aNode": {
-                        "astNodeId": 12
+                  "portInstance" : {
+                    "General" : {
+                      "aNode" : {
+                        "astNodeId" : 12
                       },
-                      "specifier": {
-                        "kind": {
-                          "Output": {}
-                        },
-                        "name": "pOut",
-                        "size": "None",
-                        "port": {
-                          "Some": {
-                            "astNodeId": 11
+                      "specifier" : {
+                        "kind" : {
+                          "Output" : {
+                            
                           }
                         },
-                        "priority": "None",
-                        "queueFull": "None"
+                        "name" : "pOut",
+                        "size" : "None",
+                        "port" : {
+                          "Some" : {
+                            "astNodeId" : 11
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None"
                       },
-                      "kind": "Output",
-                      "size": 1,
-                      "ty": {
-                        "DefPort": {
-                          "symbol": {
-                            "Port": {
-                              "nodeId": 0,
-                              "unqualifiedName": "P"
+                      "kind" : "Output",
+                      "size" : 1,
+                      "ty" : {
+                        "DefPort" : {
+                          "symbol" : {
+                            "Port" : {
+                              "nodeId" : 0,
+                              "unqualifiedName" : "P"
                             }
                           }
                         }
                       },
-                      "importNodeIds": []
+                      "importNodeIds" : [
+                      ]
                     }
                   }
                 },
-                "portNumber": "None"
+                "portNumber" : "None"
               },
-              "to": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                  "pos": "43.16",
-                  "includingLoc": "None"
+              "to" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                  "pos" : "43.16",
+                  "includingLoc" : "None"
                 },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 29
+                "port" : {
+                  "componentInstance" : {
+                    "aNode" : {
+                      "astNodeId" : 29
                     },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c4"
+                    "qualifiedName" : {
+                      "qualifier" : [
+                      ],
+                      "base" : "c4"
                     },
-                    "component": {
-                      "astNodeId": 13
+                    "component" : {
+                      "astNodeId" : 13
                     },
-                    "baseId": 1024,
-                    "maxId": 1023,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
+                    "baseId" : 1024,
+                    "maxId" : 1023,
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecifierMap" : {
+                      
+                    }
                   },
-                  "portInstance": {
-                    "General": {
-                      "aNode": {
-                        "astNodeId": 3
+                  "portInstance" : {
+                    "General" : {
+                      "aNode" : {
+                        "astNodeId" : 3
                       },
-                      "specifier": {
-                        "kind": {
-                          "SyncInput": {}
-                        },
-                        "name": "pIn",
-                        "size": "None",
-                        "port": {
-                          "Some": {
-                            "astNodeId": 2
+                      "specifier" : {
+                        "kind" : {
+                          "SyncInput" : {
+                            
                           }
                         },
-                        "priority": "None",
-                        "queueFull": "None"
+                        "name" : "pIn",
+                        "size" : "None",
+                        "port" : {
+                          "Some" : {
+                            "astNodeId" : 2
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None"
                       },
-                      "kind": "SyncInput",
-                      "size": 1,
-                      "ty": {
-                        "DefPort": {
-                          "symbol": {
-                            "Port": {
-                              "nodeId": 0,
-                              "unqualifiedName": "P"
+                      "kind" : "SyncInput",
+                      "size" : 1,
+                      "ty" : {
+                        "DefPort" : {
+                          "symbol" : {
+                            "Port" : {
+                              "nodeId" : 0,
+                              "unqualifiedName" : "P"
                             }
                           }
                         }
                       },
-                      "importNodeIds": []
+                      "importNodeIds" : [
+                      ]
                     }
                   }
                 },
-                "portNumber": "None"
+                "portNumber" : "None"
               },
-              "isUnmatched": false
+              "isUnmatched" : false
             }
           ],
-          "C4": [
+          "C4" : [
             {
-              "from": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                  "pos": "48.5",
-                  "includingLoc": "None"
+              "from" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                  "pos" : "48.5",
+                  "includingLoc" : "None"
                 },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 29
+                "port" : {
+                  "componentInstance" : {
+                    "aNode" : {
+                      "astNodeId" : 29
                     },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c4"
+                    "qualifiedName" : {
+                      "qualifier" : [
+                      ],
+                      "base" : "c4"
                     },
-                    "component": {
-                      "astNodeId": 13
+                    "component" : {
+                      "astNodeId" : 13
                     },
-                    "baseId": 1024,
-                    "maxId": 1023,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
+                    "baseId" : 1024,
+                    "maxId" : 1023,
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecifierMap" : {
+                      
+                    }
                   },
-                  "portInstance": {
-                    "General": {
-                      "aNode": {
-                        "astNodeId": 12
+                  "portInstance" : {
+                    "General" : {
+                      "aNode" : {
+                        "astNodeId" : 12
                       },
-                      "specifier": {
-                        "kind": {
-                          "Output": {}
-                        },
-                        "name": "pOut",
-                        "size": "None",
-                        "port": {
-                          "Some": {
-                            "astNodeId": 11
+                      "specifier" : {
+                        "kind" : {
+                          "Output" : {
+                            
                           }
                         },
-                        "priority": "None",
-                        "queueFull": "None"
+                        "name" : "pOut",
+                        "size" : "None",
+                        "port" : {
+                          "Some" : {
+                            "astNodeId" : 11
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None"
                       },
-                      "kind": "Output",
-                      "size": 1,
-                      "ty": {
-                        "DefPort": {
-                          "symbol": {
-                            "Port": {
-                              "nodeId": 0,
-                              "unqualifiedName": "P"
+                      "kind" : "Output",
+                      "size" : 1,
+                      "ty" : {
+                        "DefPort" : {
+                          "symbol" : {
+                            "Port" : {
+                              "nodeId" : 0,
+                              "unqualifiedName" : "P"
                             }
                           }
                         }
                       },
-                      "importNodeIds": []
+                      "importNodeIds" : [
+                      ]
                     }
                   }
                 },
-                "portNumber": "None"
+                "portNumber" : "None"
               },
-              "to": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                  "pos": "48.16",
-                  "includingLoc": "None"
+              "to" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                  "pos" : "48.16",
+                  "includingLoc" : "None"
                 },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 25
+                "port" : {
+                  "componentInstance" : {
+                    "aNode" : {
+                      "astNodeId" : 25
                     },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c3"
+                    "qualifiedName" : {
+                      "qualifier" : [
+                      ],
+                      "base" : "c3"
                     },
-                    "component": {
-                      "astNodeId": 13
+                    "component" : {
+                      "astNodeId" : 13
                     },
-                    "baseId": 768,
-                    "maxId": 767,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
+                    "baseId" : 768,
+                    "maxId" : 767,
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecifierMap" : {
+                      
+                    }
                   },
-                  "portInstance": {
-                    "General": {
-                      "aNode": {
-                        "astNodeId": 3
+                  "portInstance" : {
+                    "General" : {
+                      "aNode" : {
+                        "astNodeId" : 3
                       },
-                      "specifier": {
-                        "kind": {
-                          "SyncInput": {}
-                        },
-                        "name": "pIn",
-                        "size": "None",
-                        "port": {
-                          "Some": {
-                            "astNodeId": 2
+                      "specifier" : {
+                        "kind" : {
+                          "SyncInput" : {
+                            
                           }
                         },
-                        "priority": "None",
-                        "queueFull": "None"
+                        "name" : "pIn",
+                        "size" : "None",
+                        "port" : {
+                          "Some" : {
+                            "astNodeId" : 2
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None"
                       },
-                      "kind": "SyncInput",
-                      "size": 1,
-                      "ty": {
-                        "DefPort": {
-                          "symbol": {
-                            "Port": {
-                              "nodeId": 0,
-                              "unqualifiedName": "P"
+                      "kind" : "SyncInput",
+                      "size" : 1,
+                      "ty" : {
+                        "DefPort" : {
+                          "symbol" : {
+                            "Port" : {
+                              "nodeId" : 0,
+                              "unqualifiedName" : "P"
                             }
                           }
                         }
                       },
-                      "importNodeIds": []
+                      "importNodeIds" : [
+                      ]
                     }
                   }
                 },
-                "portNumber": "None"
+                "portNumber" : "None"
               },
-              "isUnmatched": false
+              "isUnmatched" : false
             }
           ]
         },
-        "outputConnectionMap": [
+        "outputConnectionMap" : [
           [
             {
-              "componentInstance": {
-                "aNode": {
-                  "astNodeId": 25
+              "componentInstance" : {
+                "aNode" : {
+                  "astNodeId" : 25
                 },
-                "qualifiedName": {
-                  "qualifier": [],
-                  "base": "c3"
+                "qualifiedName" : {
+                  "qualifier" : [
+                  ],
+                  "base" : "c3"
                 },
-                "component": {
-                  "astNodeId": 13
+                "component" : {
+                  "astNodeId" : 13
                 },
-                "baseId": 768,
-                "maxId": 767,
-                "file": "None",
-                "queueSize": "None",
-                "stackSize": "None",
-                "priority": "None",
-                "cpu": "None",
-                "initSpecifierMap": {}
+                "baseId" : 768,
+                "maxId" : 767,
+                "file" : "None",
+                "queueSize" : "None",
+                "stackSize" : "None",
+                "priority" : "None",
+                "cpu" : "None",
+                "initSpecifierMap" : {
+                  
+                }
               },
-              "portInstance": {
-                "General": {
-                  "aNode": {
-                    "astNodeId": 12
+              "portInstance" : {
+                "General" : {
+                  "aNode" : {
+                    "astNodeId" : 12
                   },
-                  "specifier": {
-                    "kind": {
-                      "Output": {}
-                    },
-                    "name": "pOut",
-                    "size": "None",
-                    "port": {
-                      "Some": {
-                        "astNodeId": 11
+                  "specifier" : {
+                    "kind" : {
+                      "Output" : {
+                        
                       }
                     },
-                    "priority": "None",
-                    "queueFull": "None"
+                    "name" : "pOut",
+                    "size" : "None",
+                    "port" : {
+                      "Some" : {
+                        "astNodeId" : 11
+                      }
+                    },
+                    "priority" : "None",
+                    "queueFull" : "None"
                   },
-                  "kind": "Output",
-                  "size": 1,
-                  "ty": {
-                    "DefPort": {
-                      "symbol": {
-                        "Port": {
-                          "nodeId": 0,
-                          "unqualifiedName": "P"
+                  "kind" : "Output",
+                  "size" : 1,
+                  "ty" : {
+                    "DefPort" : {
+                      "symbol" : {
+                        "Port" : {
+                          "nodeId" : 0,
+                          "unqualifiedName" : "P"
                         }
                       }
                     }
                   },
-                  "importNodeIds": []
+                  "importNodeIds" : [
+                  ]
                 }
               }
             },
             [
               {
-                "from": {
-                  "loc": {
-                    "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                    "pos": "43.5",
-                    "includingLoc": "None"
+                "from" : {
+                  "loc" : {
+                    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                    "pos" : "43.5",
+                    "includingLoc" : "None"
                   },
-                  "port": {
-                    "componentInstance": {
-                      "aNode": {
-                        "astNodeId": 25
+                  "port" : {
+                    "componentInstance" : {
+                      "aNode" : {
+                        "astNodeId" : 25
                       },
-                      "qualifiedName": {
-                        "qualifier": [],
-                        "base": "c3"
+                      "qualifiedName" : {
+                        "qualifier" : [
+                        ],
+                        "base" : "c3"
                       },
-                      "component": {
-                        "astNodeId": 13
+                      "component" : {
+                        "astNodeId" : 13
                       },
-                      "baseId": 768,
-                      "maxId": 767,
-                      "file": "None",
-                      "queueSize": "None",
-                      "stackSize": "None",
-                      "priority": "None",
-                      "cpu": "None",
-                      "initSpecifierMap": {}
+                      "baseId" : 768,
+                      "maxId" : 767,
+                      "file" : "None",
+                      "queueSize" : "None",
+                      "stackSize" : "None",
+                      "priority" : "None",
+                      "cpu" : "None",
+                      "initSpecifierMap" : {
+                        
+                      }
                     },
-                    "portInstance": {
-                      "General": {
-                        "aNode": {
-                          "astNodeId": 12
+                    "portInstance" : {
+                      "General" : {
+                        "aNode" : {
+                          "astNodeId" : 12
                         },
-                        "specifier": {
-                          "kind": {
-                            "Output": {}
-                          },
-                          "name": "pOut",
-                          "size": "None",
-                          "port": {
-                            "Some": {
-                              "astNodeId": 11
+                        "specifier" : {
+                          "kind" : {
+                            "Output" : {
+                              
                             }
                           },
-                          "priority": "None",
-                          "queueFull": "None"
+                          "name" : "pOut",
+                          "size" : "None",
+                          "port" : {
+                            "Some" : {
+                              "astNodeId" : 11
+                            }
+                          },
+                          "priority" : "None",
+                          "queueFull" : "None"
                         },
-                        "kind": "Output",
-                        "size": 1,
-                        "ty": {
-                          "DefPort": {
-                            "symbol": {
-                              "Port": {
-                                "nodeId": 0,
-                                "unqualifiedName": "P"
+                        "kind" : "Output",
+                        "size" : 1,
+                        "ty" : {
+                          "DefPort" : {
+                            "symbol" : {
+                              "Port" : {
+                                "nodeId" : 0,
+                                "unqualifiedName" : "P"
                               }
                             }
                           }
                         },
-                        "importNodeIds": []
+                        "importNodeIds" : [
+                        ]
                       }
                     }
                   },
-                  "portNumber": "None"
+                  "portNumber" : "None"
                 },
-                "to": {
-                  "loc": {
-                    "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                    "pos": "43.16",
-                    "includingLoc": "None"
+                "to" : {
+                  "loc" : {
+                    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                    "pos" : "43.16",
+                    "includingLoc" : "None"
                   },
-                  "port": {
-                    "componentInstance": {
-                      "aNode": {
-                        "astNodeId": 29
+                  "port" : {
+                    "componentInstance" : {
+                      "aNode" : {
+                        "astNodeId" : 29
                       },
-                      "qualifiedName": {
-                        "qualifier": [],
-                        "base": "c4"
+                      "qualifiedName" : {
+                        "qualifier" : [
+                        ],
+                        "base" : "c4"
                       },
-                      "component": {
-                        "astNodeId": 13
+                      "component" : {
+                        "astNodeId" : 13
                       },
-                      "baseId": 1024,
-                      "maxId": 1023,
-                      "file": "None",
-                      "queueSize": "None",
-                      "stackSize": "None",
-                      "priority": "None",
-                      "cpu": "None",
-                      "initSpecifierMap": {}
+                      "baseId" : 1024,
+                      "maxId" : 1023,
+                      "file" : "None",
+                      "queueSize" : "None",
+                      "stackSize" : "None",
+                      "priority" : "None",
+                      "cpu" : "None",
+                      "initSpecifierMap" : {
+                        
+                      }
                     },
-                    "portInstance": {
-                      "General": {
-                        "aNode": {
-                          "astNodeId": 3
+                    "portInstance" : {
+                      "General" : {
+                        "aNode" : {
+                          "astNodeId" : 3
                         },
-                        "specifier": {
-                          "kind": {
-                            "SyncInput": {}
-                          },
-                          "name": "pIn",
-                          "size": "None",
-                          "port": {
-                            "Some": {
-                              "astNodeId": 2
+                        "specifier" : {
+                          "kind" : {
+                            "SyncInput" : {
+                              
                             }
                           },
-                          "priority": "None",
-                          "queueFull": "None"
+                          "name" : "pIn",
+                          "size" : "None",
+                          "port" : {
+                            "Some" : {
+                              "astNodeId" : 2
+                            }
+                          },
+                          "priority" : "None",
+                          "queueFull" : "None"
                         },
-                        "kind": "SyncInput",
-                        "size": 1,
-                        "ty": {
-                          "DefPort": {
-                            "symbol": {
-                              "Port": {
-                                "nodeId": 0,
-                                "unqualifiedName": "P"
+                        "kind" : "SyncInput",
+                        "size" : 1,
+                        "ty" : {
+                          "DefPort" : {
+                            "symbol" : {
+                              "Port" : {
+                                "nodeId" : 0,
+                                "unqualifiedName" : "P"
                               }
                             }
                           }
                         },
-                        "importNodeIds": []
+                        "importNodeIds" : [
+                        ]
                       }
                     }
                   },
-                  "portNumber": "None"
+                  "portNumber" : "None"
                 },
-                "isUnmatched": false
+                "isUnmatched" : false
               }
             ]
           ],
           [
             {
-              "componentInstance": {
-                "aNode": {
-                  "astNodeId": 29
+              "componentInstance" : {
+                "aNode" : {
+                  "astNodeId" : 29
                 },
-                "qualifiedName": {
-                  "qualifier": [],
-                  "base": "c4"
+                "qualifiedName" : {
+                  "qualifier" : [
+                  ],
+                  "base" : "c4"
                 },
-                "component": {
-                  "astNodeId": 13
+                "component" : {
+                  "astNodeId" : 13
                 },
-                "baseId": 1024,
-                "maxId": 1023,
-                "file": "None",
-                "queueSize": "None",
-                "stackSize": "None",
-                "priority": "None",
-                "cpu": "None",
-                "initSpecifierMap": {}
+                "baseId" : 1024,
+                "maxId" : 1023,
+                "file" : "None",
+                "queueSize" : "None",
+                "stackSize" : "None",
+                "priority" : "None",
+                "cpu" : "None",
+                "initSpecifierMap" : {
+                  
+                }
               },
-              "portInstance": {
-                "General": {
-                  "aNode": {
-                    "astNodeId": 12
+              "portInstance" : {
+                "General" : {
+                  "aNode" : {
+                    "astNodeId" : 12
                   },
-                  "specifier": {
-                    "kind": {
-                      "Output": {}
-                    },
-                    "name": "pOut",
-                    "size": "None",
-                    "port": {
-                      "Some": {
-                        "astNodeId": 11
+                  "specifier" : {
+                    "kind" : {
+                      "Output" : {
+                        
                       }
                     },
-                    "priority": "None",
-                    "queueFull": "None"
+                    "name" : "pOut",
+                    "size" : "None",
+                    "port" : {
+                      "Some" : {
+                        "astNodeId" : 11
+                      }
+                    },
+                    "priority" : "None",
+                    "queueFull" : "None"
                   },
-                  "kind": "Output",
-                  "size": 1,
-                  "ty": {
-                    "DefPort": {
-                      "symbol": {
-                        "Port": {
-                          "nodeId": 0,
-                          "unqualifiedName": "P"
+                  "kind" : "Output",
+                  "size" : 1,
+                  "ty" : {
+                    "DefPort" : {
+                      "symbol" : {
+                        "Port" : {
+                          "nodeId" : 0,
+                          "unqualifiedName" : "P"
                         }
                       }
                     }
                   },
-                  "importNodeIds": []
+                  "importNodeIds" : [
+                  ]
                 }
               }
             },
             [
               {
-                "from": {
-                  "loc": {
-                    "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                    "pos": "48.5",
-                    "includingLoc": "None"
+                "from" : {
+                  "loc" : {
+                    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                    "pos" : "48.5",
+                    "includingLoc" : "None"
                   },
-                  "port": {
-                    "componentInstance": {
-                      "aNode": {
-                        "astNodeId": 29
+                  "port" : {
+                    "componentInstance" : {
+                      "aNode" : {
+                        "astNodeId" : 29
                       },
-                      "qualifiedName": {
-                        "qualifier": [],
-                        "base": "c4"
+                      "qualifiedName" : {
+                        "qualifier" : [
+                        ],
+                        "base" : "c4"
                       },
-                      "component": {
-                        "astNodeId": 13
+                      "component" : {
+                        "astNodeId" : 13
                       },
-                      "baseId": 1024,
-                      "maxId": 1023,
-                      "file": "None",
-                      "queueSize": "None",
-                      "stackSize": "None",
-                      "priority": "None",
-                      "cpu": "None",
-                      "initSpecifierMap": {}
+                      "baseId" : 1024,
+                      "maxId" : 1023,
+                      "file" : "None",
+                      "queueSize" : "None",
+                      "stackSize" : "None",
+                      "priority" : "None",
+                      "cpu" : "None",
+                      "initSpecifierMap" : {
+                        
+                      }
                     },
-                    "portInstance": {
-                      "General": {
-                        "aNode": {
-                          "astNodeId": 12
+                    "portInstance" : {
+                      "General" : {
+                        "aNode" : {
+                          "astNodeId" : 12
                         },
-                        "specifier": {
-                          "kind": {
-                            "Output": {}
-                          },
-                          "name": "pOut",
-                          "size": "None",
-                          "port": {
-                            "Some": {
-                              "astNodeId": 11
+                        "specifier" : {
+                          "kind" : {
+                            "Output" : {
+                              
                             }
                           },
-                          "priority": "None",
-                          "queueFull": "None"
+                          "name" : "pOut",
+                          "size" : "None",
+                          "port" : {
+                            "Some" : {
+                              "astNodeId" : 11
+                            }
+                          },
+                          "priority" : "None",
+                          "queueFull" : "None"
                         },
-                        "kind": "Output",
-                        "size": 1,
-                        "ty": {
-                          "DefPort": {
-                            "symbol": {
-                              "Port": {
-                                "nodeId": 0,
-                                "unqualifiedName": "P"
+                        "kind" : "Output",
+                        "size" : 1,
+                        "ty" : {
+                          "DefPort" : {
+                            "symbol" : {
+                              "Port" : {
+                                "nodeId" : 0,
+                                "unqualifiedName" : "P"
                               }
                             }
                           }
                         },
-                        "importNodeIds": []
+                        "importNodeIds" : [
+                        ]
                       }
                     }
                   },
-                  "portNumber": "None"
+                  "portNumber" : "None"
                 },
-                "to": {
-                  "loc": {
-                    "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                    "pos": "48.16",
-                    "includingLoc": "None"
+                "to" : {
+                  "loc" : {
+                    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                    "pos" : "48.16",
+                    "includingLoc" : "None"
                   },
-                  "port": {
-                    "componentInstance": {
-                      "aNode": {
-                        "astNodeId": 25
+                  "port" : {
+                    "componentInstance" : {
+                      "aNode" : {
+                        "astNodeId" : 25
                       },
-                      "qualifiedName": {
-                        "qualifier": [],
-                        "base": "c3"
+                      "qualifiedName" : {
+                        "qualifier" : [
+                        ],
+                        "base" : "c3"
                       },
-                      "component": {
-                        "astNodeId": 13
+                      "component" : {
+                        "astNodeId" : 13
                       },
-                      "baseId": 768,
-                      "maxId": 767,
-                      "file": "None",
-                      "queueSize": "None",
-                      "stackSize": "None",
-                      "priority": "None",
-                      "cpu": "None",
-                      "initSpecifierMap": {}
+                      "baseId" : 768,
+                      "maxId" : 767,
+                      "file" : "None",
+                      "queueSize" : "None",
+                      "stackSize" : "None",
+                      "priority" : "None",
+                      "cpu" : "None",
+                      "initSpecifierMap" : {
+                        
+                      }
                     },
-                    "portInstance": {
-                      "General": {
-                        "aNode": {
-                          "astNodeId": 3
+                    "portInstance" : {
+                      "General" : {
+                        "aNode" : {
+                          "astNodeId" : 3
                         },
-                        "specifier": {
-                          "kind": {
-                            "SyncInput": {}
-                          },
-                          "name": "pIn",
-                          "size": "None",
-                          "port": {
-                            "Some": {
-                              "astNodeId": 2
+                        "specifier" : {
+                          "kind" : {
+                            "SyncInput" : {
+                              
                             }
                           },
-                          "priority": "None",
-                          "queueFull": "None"
+                          "name" : "pIn",
+                          "size" : "None",
+                          "port" : {
+                            "Some" : {
+                              "astNodeId" : 2
+                            }
+                          },
+                          "priority" : "None",
+                          "queueFull" : "None"
                         },
-                        "kind": "SyncInput",
-                        "size": 1,
-                        "ty": {
-                          "DefPort": {
-                            "symbol": {
-                              "Port": {
-                                "nodeId": 0,
-                                "unqualifiedName": "P"
+                        "kind" : "SyncInput",
+                        "size" : 1,
+                        "ty" : {
+                          "DefPort" : {
+                            "symbol" : {
+                              "Port" : {
+                                "nodeId" : 0,
+                                "unqualifiedName" : "P"
                               }
                             }
                           }
                         },
-                        "importNodeIds": []
+                        "importNodeIds" : [
+                        ]
                       }
                     }
                   },
-                  "portNumber": "None"
+                  "portNumber" : "None"
                 },
-                "isUnmatched": false
+                "isUnmatched" : false
               }
             ]
           ]
         ],
-        "inputConnectionMap": [
+        "inputConnectionMap" : [
           [
             {
-              "componentInstance": {
-                "aNode": {
-                  "astNodeId": 29
+              "componentInstance" : {
+                "aNode" : {
+                  "astNodeId" : 29
                 },
-                "qualifiedName": {
-                  "qualifier": [],
-                  "base": "c4"
+                "qualifiedName" : {
+                  "qualifier" : [
+                  ],
+                  "base" : "c4"
                 },
-                "component": {
-                  "astNodeId": 13
+                "component" : {
+                  "astNodeId" : 13
                 },
-                "baseId": 1024,
-                "maxId": 1023,
-                "file": "None",
-                "queueSize": "None",
-                "stackSize": "None",
-                "priority": "None",
-                "cpu": "None",
-                "initSpecifierMap": {}
+                "baseId" : 1024,
+                "maxId" : 1023,
+                "file" : "None",
+                "queueSize" : "None",
+                "stackSize" : "None",
+                "priority" : "None",
+                "cpu" : "None",
+                "initSpecifierMap" : {
+                  
+                }
               },
-              "portInstance": {
-                "General": {
-                  "aNode": {
-                    "astNodeId": 3
+              "portInstance" : {
+                "General" : {
+                  "aNode" : {
+                    "astNodeId" : 3
                   },
-                  "specifier": {
-                    "kind": {
-                      "SyncInput": {}
-                    },
-                    "name": "pIn",
-                    "size": "None",
-                    "port": {
-                      "Some": {
-                        "astNodeId": 2
+                  "specifier" : {
+                    "kind" : {
+                      "SyncInput" : {
+                        
                       }
                     },
-                    "priority": "None",
-                    "queueFull": "None"
+                    "name" : "pIn",
+                    "size" : "None",
+                    "port" : {
+                      "Some" : {
+                        "astNodeId" : 2
+                      }
+                    },
+                    "priority" : "None",
+                    "queueFull" : "None"
                   },
-                  "kind": "SyncInput",
-                  "size": 1,
-                  "ty": {
-                    "DefPort": {
-                      "symbol": {
-                        "Port": {
-                          "nodeId": 0,
-                          "unqualifiedName": "P"
+                  "kind" : "SyncInput",
+                  "size" : 1,
+                  "ty" : {
+                    "DefPort" : {
+                      "symbol" : {
+                        "Port" : {
+                          "nodeId" : 0,
+                          "unqualifiedName" : "P"
                         }
                       }
                     }
                   },
-                  "importNodeIds": []
+                  "importNodeIds" : [
+                  ]
                 }
               }
             },
             [
               {
-                "from": {
-                  "loc": {
-                    "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                    "pos": "43.5",
-                    "includingLoc": "None"
+                "from" : {
+                  "loc" : {
+                    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                    "pos" : "43.5",
+                    "includingLoc" : "None"
                   },
-                  "port": {
-                    "componentInstance": {
-                      "aNode": {
-                        "astNodeId": 25
+                  "port" : {
+                    "componentInstance" : {
+                      "aNode" : {
+                        "astNodeId" : 25
                       },
-                      "qualifiedName": {
-                        "qualifier": [],
-                        "base": "c3"
+                      "qualifiedName" : {
+                        "qualifier" : [
+                        ],
+                        "base" : "c3"
                       },
-                      "component": {
-                        "astNodeId": 13
+                      "component" : {
+                        "astNodeId" : 13
                       },
-                      "baseId": 768,
-                      "maxId": 767,
-                      "file": "None",
-                      "queueSize": "None",
-                      "stackSize": "None",
-                      "priority": "None",
-                      "cpu": "None",
-                      "initSpecifierMap": {}
+                      "baseId" : 768,
+                      "maxId" : 767,
+                      "file" : "None",
+                      "queueSize" : "None",
+                      "stackSize" : "None",
+                      "priority" : "None",
+                      "cpu" : "None",
+                      "initSpecifierMap" : {
+                        
+                      }
                     },
-                    "portInstance": {
-                      "General": {
-                        "aNode": {
-                          "astNodeId": 12
+                    "portInstance" : {
+                      "General" : {
+                        "aNode" : {
+                          "astNodeId" : 12
                         },
-                        "specifier": {
-                          "kind": {
-                            "Output": {}
-                          },
-                          "name": "pOut",
-                          "size": "None",
-                          "port": {
-                            "Some": {
-                              "astNodeId": 11
+                        "specifier" : {
+                          "kind" : {
+                            "Output" : {
+                              
                             }
                           },
-                          "priority": "None",
-                          "queueFull": "None"
+                          "name" : "pOut",
+                          "size" : "None",
+                          "port" : {
+                            "Some" : {
+                              "astNodeId" : 11
+                            }
+                          },
+                          "priority" : "None",
+                          "queueFull" : "None"
                         },
-                        "kind": "Output",
-                        "size": 1,
-                        "ty": {
-                          "DefPort": {
-                            "symbol": {
-                              "Port": {
-                                "nodeId": 0,
-                                "unqualifiedName": "P"
+                        "kind" : "Output",
+                        "size" : 1,
+                        "ty" : {
+                          "DefPort" : {
+                            "symbol" : {
+                              "Port" : {
+                                "nodeId" : 0,
+                                "unqualifiedName" : "P"
                               }
                             }
                           }
                         },
-                        "importNodeIds": []
+                        "importNodeIds" : [
+                        ]
                       }
                     }
                   },
-                  "portNumber": "None"
+                  "portNumber" : "None"
                 },
-                "to": {
-                  "loc": {
-                    "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                    "pos": "43.16",
-                    "includingLoc": "None"
+                "to" : {
+                  "loc" : {
+                    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                    "pos" : "43.16",
+                    "includingLoc" : "None"
                   },
-                  "port": {
-                    "componentInstance": {
-                      "aNode": {
-                        "astNodeId": 29
+                  "port" : {
+                    "componentInstance" : {
+                      "aNode" : {
+                        "astNodeId" : 29
                       },
-                      "qualifiedName": {
-                        "qualifier": [],
-                        "base": "c4"
+                      "qualifiedName" : {
+                        "qualifier" : [
+                        ],
+                        "base" : "c4"
                       },
-                      "component": {
-                        "astNodeId": 13
+                      "component" : {
+                        "astNodeId" : 13
                       },
-                      "baseId": 1024,
-                      "maxId": 1023,
-                      "file": "None",
-                      "queueSize": "None",
-                      "stackSize": "None",
-                      "priority": "None",
-                      "cpu": "None",
-                      "initSpecifierMap": {}
+                      "baseId" : 1024,
+                      "maxId" : 1023,
+                      "file" : "None",
+                      "queueSize" : "None",
+                      "stackSize" : "None",
+                      "priority" : "None",
+                      "cpu" : "None",
+                      "initSpecifierMap" : {
+                        
+                      }
                     },
-                    "portInstance": {
-                      "General": {
-                        "aNode": {
-                          "astNodeId": 3
+                    "portInstance" : {
+                      "General" : {
+                        "aNode" : {
+                          "astNodeId" : 3
                         },
-                        "specifier": {
-                          "kind": {
-                            "SyncInput": {}
-                          },
-                          "name": "pIn",
-                          "size": "None",
-                          "port": {
-                            "Some": {
-                              "astNodeId": 2
+                        "specifier" : {
+                          "kind" : {
+                            "SyncInput" : {
+                              
                             }
                           },
-                          "priority": "None",
-                          "queueFull": "None"
+                          "name" : "pIn",
+                          "size" : "None",
+                          "port" : {
+                            "Some" : {
+                              "astNodeId" : 2
+                            }
+                          },
+                          "priority" : "None",
+                          "queueFull" : "None"
                         },
-                        "kind": "SyncInput",
-                        "size": 1,
-                        "ty": {
-                          "DefPort": {
-                            "symbol": {
-                              "Port": {
-                                "nodeId": 0,
-                                "unqualifiedName": "P"
+                        "kind" : "SyncInput",
+                        "size" : 1,
+                        "ty" : {
+                          "DefPort" : {
+                            "symbol" : {
+                              "Port" : {
+                                "nodeId" : 0,
+                                "unqualifiedName" : "P"
                               }
                             }
                           }
                         },
-                        "importNodeIds": []
+                        "importNodeIds" : [
+                        ]
                       }
                     }
                   },
-                  "portNumber": "None"
+                  "portNumber" : "None"
                 },
-                "isUnmatched": false
+                "isUnmatched" : false
               }
             ]
           ],
           [
             {
-              "componentInstance": {
-                "aNode": {
-                  "astNodeId": 25
+              "componentInstance" : {
+                "aNode" : {
+                  "astNodeId" : 25
                 },
-                "qualifiedName": {
-                  "qualifier": [],
-                  "base": "c3"
+                "qualifiedName" : {
+                  "qualifier" : [
+                  ],
+                  "base" : "c3"
                 },
-                "component": {
-                  "astNodeId": 13
+                "component" : {
+                  "astNodeId" : 13
                 },
-                "baseId": 768,
-                "maxId": 767,
-                "file": "None",
-                "queueSize": "None",
-                "stackSize": "None",
-                "priority": "None",
-                "cpu": "None",
-                "initSpecifierMap": {}
+                "baseId" : 768,
+                "maxId" : 767,
+                "file" : "None",
+                "queueSize" : "None",
+                "stackSize" : "None",
+                "priority" : "None",
+                "cpu" : "None",
+                "initSpecifierMap" : {
+                  
+                }
               },
-              "portInstance": {
-                "General": {
-                  "aNode": {
-                    "astNodeId": 3
+              "portInstance" : {
+                "General" : {
+                  "aNode" : {
+                    "astNodeId" : 3
                   },
-                  "specifier": {
-                    "kind": {
-                      "SyncInput": {}
-                    },
-                    "name": "pIn",
-                    "size": "None",
-                    "port": {
-                      "Some": {
-                        "astNodeId": 2
+                  "specifier" : {
+                    "kind" : {
+                      "SyncInput" : {
+                        
                       }
                     },
-                    "priority": "None",
-                    "queueFull": "None"
+                    "name" : "pIn",
+                    "size" : "None",
+                    "port" : {
+                      "Some" : {
+                        "astNodeId" : 2
+                      }
+                    },
+                    "priority" : "None",
+                    "queueFull" : "None"
                   },
-                  "kind": "SyncInput",
-                  "size": 1,
-                  "ty": {
-                    "DefPort": {
-                      "symbol": {
-                        "Port": {
-                          "nodeId": 0,
-                          "unqualifiedName": "P"
+                  "kind" : "SyncInput",
+                  "size" : 1,
+                  "ty" : {
+                    "DefPort" : {
+                      "symbol" : {
+                        "Port" : {
+                          "nodeId" : 0,
+                          "unqualifiedName" : "P"
                         }
                       }
                     }
                   },
-                  "importNodeIds": []
+                  "importNodeIds" : [
+                  ]
                 }
               }
             },
             [
               {
-                "from": {
-                  "loc": {
-                    "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                    "pos": "48.5",
-                    "includingLoc": "None"
+                "from" : {
+                  "loc" : {
+                    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                    "pos" : "48.5",
+                    "includingLoc" : "None"
                   },
-                  "port": {
-                    "componentInstance": {
-                      "aNode": {
-                        "astNodeId": 29
+                  "port" : {
+                    "componentInstance" : {
+                      "aNode" : {
+                        "astNodeId" : 29
                       },
-                      "qualifiedName": {
-                        "qualifier": [],
-                        "base": "c4"
+                      "qualifiedName" : {
+                        "qualifier" : [
+                        ],
+                        "base" : "c4"
                       },
-                      "component": {
-                        "astNodeId": 13
+                      "component" : {
+                        "astNodeId" : 13
                       },
-                      "baseId": 1024,
-                      "maxId": 1023,
-                      "file": "None",
-                      "queueSize": "None",
-                      "stackSize": "None",
-                      "priority": "None",
-                      "cpu": "None",
-                      "initSpecifierMap": {}
+                      "baseId" : 1024,
+                      "maxId" : 1023,
+                      "file" : "None",
+                      "queueSize" : "None",
+                      "stackSize" : "None",
+                      "priority" : "None",
+                      "cpu" : "None",
+                      "initSpecifierMap" : {
+                        
+                      }
                     },
-                    "portInstance": {
-                      "General": {
-                        "aNode": {
-                          "astNodeId": 12
+                    "portInstance" : {
+                      "General" : {
+                        "aNode" : {
+                          "astNodeId" : 12
                         },
-                        "specifier": {
-                          "kind": {
-                            "Output": {}
-                          },
-                          "name": "pOut",
-                          "size": "None",
-                          "port": {
-                            "Some": {
-                              "astNodeId": 11
+                        "specifier" : {
+                          "kind" : {
+                            "Output" : {
+                              
                             }
                           },
-                          "priority": "None",
-                          "queueFull": "None"
+                          "name" : "pOut",
+                          "size" : "None",
+                          "port" : {
+                            "Some" : {
+                              "astNodeId" : 11
+                            }
+                          },
+                          "priority" : "None",
+                          "queueFull" : "None"
                         },
-                        "kind": "Output",
-                        "size": 1,
-                        "ty": {
-                          "DefPort": {
-                            "symbol": {
-                              "Port": {
-                                "nodeId": 0,
-                                "unqualifiedName": "P"
+                        "kind" : "Output",
+                        "size" : 1,
+                        "ty" : {
+                          "DefPort" : {
+                            "symbol" : {
+                              "Port" : {
+                                "nodeId" : 0,
+                                "unqualifiedName" : "P"
                               }
                             }
                           }
                         },
-                        "importNodeIds": []
+                        "importNodeIds" : [
+                        ]
                       }
                     }
                   },
-                  "portNumber": "None"
+                  "portNumber" : "None"
                 },
-                "to": {
-                  "loc": {
-                    "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                    "pos": "48.16",
-                    "includingLoc": "None"
+                "to" : {
+                  "loc" : {
+                    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                    "pos" : "48.16",
+                    "includingLoc" : "None"
                   },
-                  "port": {
-                    "componentInstance": {
-                      "aNode": {
-                        "astNodeId": 25
+                  "port" : {
+                    "componentInstance" : {
+                      "aNode" : {
+                        "astNodeId" : 25
                       },
-                      "qualifiedName": {
-                        "qualifier": [],
-                        "base": "c3"
+                      "qualifiedName" : {
+                        "qualifier" : [
+                        ],
+                        "base" : "c3"
                       },
-                      "component": {
-                        "astNodeId": 13
+                      "component" : {
+                        "astNodeId" : 13
                       },
-                      "baseId": 768,
-                      "maxId": 767,
-                      "file": "None",
-                      "queueSize": "None",
-                      "stackSize": "None",
-                      "priority": "None",
-                      "cpu": "None",
-                      "initSpecifierMap": {}
+                      "baseId" : 768,
+                      "maxId" : 767,
+                      "file" : "None",
+                      "queueSize" : "None",
+                      "stackSize" : "None",
+                      "priority" : "None",
+                      "cpu" : "None",
+                      "initSpecifierMap" : {
+                        
+                      }
                     },
-                    "portInstance": {
-                      "General": {
-                        "aNode": {
-                          "astNodeId": 3
+                    "portInstance" : {
+                      "General" : {
+                        "aNode" : {
+                          "astNodeId" : 3
                         },
-                        "specifier": {
-                          "kind": {
-                            "SyncInput": {}
-                          },
-                          "name": "pIn",
-                          "size": "None",
-                          "port": {
-                            "Some": {
-                              "astNodeId": 2
+                        "specifier" : {
+                          "kind" : {
+                            "SyncInput" : {
+                              
                             }
                           },
-                          "priority": "None",
-                          "queueFull": "None"
+                          "name" : "pIn",
+                          "size" : "None",
+                          "port" : {
+                            "Some" : {
+                              "astNodeId" : 2
+                            }
+                          },
+                          "priority" : "None",
+                          "queueFull" : "None"
                         },
-                        "kind": "SyncInput",
-                        "size": 1,
-                        "ty": {
-                          "DefPort": {
-                            "symbol": {
-                              "Port": {
-                                "nodeId": 0,
-                                "unqualifiedName": "P"
+                        "kind" : "SyncInput",
+                        "size" : 1,
+                        "ty" : {
+                          "DefPort" : {
+                            "symbol" : {
+                              "Port" : {
+                                "nodeId" : 0,
+                                "unqualifiedName" : "P"
                               }
                             }
                           }
                         },
-                        "importNodeIds": []
+                        "importNodeIds" : [
+                        ]
                       }
                     }
                   },
-                  "portNumber": "None"
+                  "portNumber" : "None"
                 },
-                "isUnmatched": false
+                "isUnmatched" : false
               }
             ]
           ]
         ],
-        "fromPortNumberMap": [
+        "fromPortNumberMap" : [
           [
             {
-              "from": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                  "pos": "43.5",
-                  "includingLoc": "None"
+              "from" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                  "pos" : "43.5",
+                  "includingLoc" : "None"
                 },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 25
+                "port" : {
+                  "componentInstance" : {
+                    "aNode" : {
+                      "astNodeId" : 25
                     },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c3"
+                    "qualifiedName" : {
+                      "qualifier" : [
+                      ],
+                      "base" : "c3"
                     },
-                    "component": {
-                      "astNodeId": 13
+                    "component" : {
+                      "astNodeId" : 13
                     },
-                    "baseId": 768,
-                    "maxId": 767,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
+                    "baseId" : 768,
+                    "maxId" : 767,
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecifierMap" : {
+                      
+                    }
                   },
-                  "portInstance": {
-                    "General": {
-                      "aNode": {
-                        "astNodeId": 12
+                  "portInstance" : {
+                    "General" : {
+                      "aNode" : {
+                        "astNodeId" : 12
                       },
-                      "specifier": {
-                        "kind": {
-                          "Output": {}
-                        },
-                        "name": "pOut",
-                        "size": "None",
-                        "port": {
-                          "Some": {
-                            "astNodeId": 11
+                      "specifier" : {
+                        "kind" : {
+                          "Output" : {
+                            
                           }
                         },
-                        "priority": "None",
-                        "queueFull": "None"
+                        "name" : "pOut",
+                        "size" : "None",
+                        "port" : {
+                          "Some" : {
+                            "astNodeId" : 11
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None"
                       },
-                      "kind": "Output",
-                      "size": 1,
-                      "ty": {
-                        "DefPort": {
-                          "symbol": {
-                            "Port": {
-                              "nodeId": 0,
-                              "unqualifiedName": "P"
+                      "kind" : "Output",
+                      "size" : 1,
+                      "ty" : {
+                        "DefPort" : {
+                          "symbol" : {
+                            "Port" : {
+                              "nodeId" : 0,
+                              "unqualifiedName" : "P"
                             }
                           }
                         }
                       },
-                      "importNodeIds": []
+                      "importNodeIds" : [
+                      ]
                     }
                   }
                 },
-                "portNumber": "None"
+                "portNumber" : "None"
               },
-              "to": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                  "pos": "43.16",
-                  "includingLoc": "None"
+              "to" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                  "pos" : "43.16",
+                  "includingLoc" : "None"
                 },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 29
+                "port" : {
+                  "componentInstance" : {
+                    "aNode" : {
+                      "astNodeId" : 29
                     },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c4"
+                    "qualifiedName" : {
+                      "qualifier" : [
+                      ],
+                      "base" : "c4"
                     },
-                    "component": {
-                      "astNodeId": 13
+                    "component" : {
+                      "astNodeId" : 13
                     },
-                    "baseId": 1024,
-                    "maxId": 1023,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
+                    "baseId" : 1024,
+                    "maxId" : 1023,
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecifierMap" : {
+                      
+                    }
                   },
-                  "portInstance": {
-                    "General": {
-                      "aNode": {
-                        "astNodeId": 3
+                  "portInstance" : {
+                    "General" : {
+                      "aNode" : {
+                        "astNodeId" : 3
                       },
-                      "specifier": {
-                        "kind": {
-                          "SyncInput": {}
-                        },
-                        "name": "pIn",
-                        "size": "None",
-                        "port": {
-                          "Some": {
-                            "astNodeId": 2
+                      "specifier" : {
+                        "kind" : {
+                          "SyncInput" : {
+                            
                           }
                         },
-                        "priority": "None",
-                        "queueFull": "None"
+                        "name" : "pIn",
+                        "size" : "None",
+                        "port" : {
+                          "Some" : {
+                            "astNodeId" : 2
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None"
                       },
-                      "kind": "SyncInput",
-                      "size": 1,
-                      "ty": {
-                        "DefPort": {
-                          "symbol": {
-                            "Port": {
-                              "nodeId": 0,
-                              "unqualifiedName": "P"
+                      "kind" : "SyncInput",
+                      "size" : 1,
+                      "ty" : {
+                        "DefPort" : {
+                          "symbol" : {
+                            "Port" : {
+                              "nodeId" : 0,
+                              "unqualifiedName" : "P"
                             }
                           }
                         }
                       },
-                      "importNodeIds": []
+                      "importNodeIds" : [
+                      ]
                     }
                   }
                 },
-                "portNumber": "None"
+                "portNumber" : "None"
               },
-              "isUnmatched": false
+              "isUnmatched" : false
             },
             0
           ],
           [
             {
-              "from": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                  "pos": "48.5",
-                  "includingLoc": "None"
+              "from" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                  "pos" : "48.5",
+                  "includingLoc" : "None"
                 },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 29
+                "port" : {
+                  "componentInstance" : {
+                    "aNode" : {
+                      "astNodeId" : 29
                     },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c4"
+                    "qualifiedName" : {
+                      "qualifier" : [
+                      ],
+                      "base" : "c4"
                     },
-                    "component": {
-                      "astNodeId": 13
+                    "component" : {
+                      "astNodeId" : 13
                     },
-                    "baseId": 1024,
-                    "maxId": 1023,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
+                    "baseId" : 1024,
+                    "maxId" : 1023,
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecifierMap" : {
+                      
+                    }
                   },
-                  "portInstance": {
-                    "General": {
-                      "aNode": {
-                        "astNodeId": 12
+                  "portInstance" : {
+                    "General" : {
+                      "aNode" : {
+                        "astNodeId" : 12
                       },
-                      "specifier": {
-                        "kind": {
-                          "Output": {}
-                        },
-                        "name": "pOut",
-                        "size": "None",
-                        "port": {
-                          "Some": {
-                            "astNodeId": 11
+                      "specifier" : {
+                        "kind" : {
+                          "Output" : {
+                            
                           }
                         },
-                        "priority": "None",
-                        "queueFull": "None"
+                        "name" : "pOut",
+                        "size" : "None",
+                        "port" : {
+                          "Some" : {
+                            "astNodeId" : 11
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None"
                       },
-                      "kind": "Output",
-                      "size": 1,
-                      "ty": {
-                        "DefPort": {
-                          "symbol": {
-                            "Port": {
-                              "nodeId": 0,
-                              "unqualifiedName": "P"
+                      "kind" : "Output",
+                      "size" : 1,
+                      "ty" : {
+                        "DefPort" : {
+                          "symbol" : {
+                            "Port" : {
+                              "nodeId" : 0,
+                              "unqualifiedName" : "P"
                             }
                           }
                         }
                       },
-                      "importNodeIds": []
+                      "importNodeIds" : [
+                      ]
                     }
                   }
                 },
-                "portNumber": "None"
+                "portNumber" : "None"
               },
-              "to": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                  "pos": "48.16",
-                  "includingLoc": "None"
+              "to" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                  "pos" : "48.16",
+                  "includingLoc" : "None"
                 },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 25
+                "port" : {
+                  "componentInstance" : {
+                    "aNode" : {
+                      "astNodeId" : 25
                     },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c3"
+                    "qualifiedName" : {
+                      "qualifier" : [
+                      ],
+                      "base" : "c3"
                     },
-                    "component": {
-                      "astNodeId": 13
+                    "component" : {
+                      "astNodeId" : 13
                     },
-                    "baseId": 768,
-                    "maxId": 767,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
+                    "baseId" : 768,
+                    "maxId" : 767,
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecifierMap" : {
+                      
+                    }
                   },
-                  "portInstance": {
-                    "General": {
-                      "aNode": {
-                        "astNodeId": 3
+                  "portInstance" : {
+                    "General" : {
+                      "aNode" : {
+                        "astNodeId" : 3
                       },
-                      "specifier": {
-                        "kind": {
-                          "SyncInput": {}
-                        },
-                        "name": "pIn",
-                        "size": "None",
-                        "port": {
-                          "Some": {
-                            "astNodeId": 2
+                      "specifier" : {
+                        "kind" : {
+                          "SyncInput" : {
+                            
                           }
                         },
-                        "priority": "None",
-                        "queueFull": "None"
+                        "name" : "pIn",
+                        "size" : "None",
+                        "port" : {
+                          "Some" : {
+                            "astNodeId" : 2
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None"
                       },
-                      "kind": "SyncInput",
-                      "size": 1,
-                      "ty": {
-                        "DefPort": {
-                          "symbol": {
-                            "Port": {
-                              "nodeId": 0,
-                              "unqualifiedName": "P"
+                      "kind" : "SyncInput",
+                      "size" : 1,
+                      "ty" : {
+                        "DefPort" : {
+                          "symbol" : {
+                            "Port" : {
+                              "nodeId" : 0,
+                              "unqualifiedName" : "P"
                             }
                           }
                         }
                       },
-                      "importNodeIds": []
+                      "importNodeIds" : [
+                      ]
                     }
                   }
                 },
-                "portNumber": "None"
+                "portNumber" : "None"
               },
-              "isUnmatched": false
+              "isUnmatched" : false
             },
             0
           ]
         ],
-        "toPortNumberMap": [
+        "toPortNumberMap" : [
           [
             {
-              "from": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                  "pos": "48.5",
-                  "includingLoc": "None"
+              "from" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                  "pos" : "48.5",
+                  "includingLoc" : "None"
                 },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 29
+                "port" : {
+                  "componentInstance" : {
+                    "aNode" : {
+                      "astNodeId" : 29
                     },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c4"
+                    "qualifiedName" : {
+                      "qualifier" : [
+                      ],
+                      "base" : "c4"
                     },
-                    "component": {
-                      "astNodeId": 13
+                    "component" : {
+                      "astNodeId" : 13
                     },
-                    "baseId": 1024,
-                    "maxId": 1023,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
+                    "baseId" : 1024,
+                    "maxId" : 1023,
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecifierMap" : {
+                      
+                    }
                   },
-                  "portInstance": {
-                    "General": {
-                      "aNode": {
-                        "astNodeId": 12
+                  "portInstance" : {
+                    "General" : {
+                      "aNode" : {
+                        "astNodeId" : 12
                       },
-                      "specifier": {
-                        "kind": {
-                          "Output": {}
-                        },
-                        "name": "pOut",
-                        "size": "None",
-                        "port": {
-                          "Some": {
-                            "astNodeId": 11
+                      "specifier" : {
+                        "kind" : {
+                          "Output" : {
+                            
                           }
                         },
-                        "priority": "None",
-                        "queueFull": "None"
+                        "name" : "pOut",
+                        "size" : "None",
+                        "port" : {
+                          "Some" : {
+                            "astNodeId" : 11
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None"
                       },
-                      "kind": "Output",
-                      "size": 1,
-                      "ty": {
-                        "DefPort": {
-                          "symbol": {
-                            "Port": {
-                              "nodeId": 0,
-                              "unqualifiedName": "P"
+                      "kind" : "Output",
+                      "size" : 1,
+                      "ty" : {
+                        "DefPort" : {
+                          "symbol" : {
+                            "Port" : {
+                              "nodeId" : 0,
+                              "unqualifiedName" : "P"
                             }
                           }
                         }
                       },
-                      "importNodeIds": []
+                      "importNodeIds" : [
+                      ]
                     }
                   }
                 },
-                "portNumber": "None"
+                "portNumber" : "None"
               },
-              "to": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                  "pos": "48.16",
-                  "includingLoc": "None"
+              "to" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                  "pos" : "48.16",
+                  "includingLoc" : "None"
                 },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 25
+                "port" : {
+                  "componentInstance" : {
+                    "aNode" : {
+                      "astNodeId" : 25
                     },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c3"
+                    "qualifiedName" : {
+                      "qualifier" : [
+                      ],
+                      "base" : "c3"
                     },
-                    "component": {
-                      "astNodeId": 13
+                    "component" : {
+                      "astNodeId" : 13
                     },
-                    "baseId": 768,
-                    "maxId": 767,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
+                    "baseId" : 768,
+                    "maxId" : 767,
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecifierMap" : {
+                      
+                    }
                   },
-                  "portInstance": {
-                    "General": {
-                      "aNode": {
-                        "astNodeId": 3
+                  "portInstance" : {
+                    "General" : {
+                      "aNode" : {
+                        "astNodeId" : 3
                       },
-                      "specifier": {
-                        "kind": {
-                          "SyncInput": {}
-                        },
-                        "name": "pIn",
-                        "size": "None",
-                        "port": {
-                          "Some": {
-                            "astNodeId": 2
+                      "specifier" : {
+                        "kind" : {
+                          "SyncInput" : {
+                            
                           }
                         },
-                        "priority": "None",
-                        "queueFull": "None"
+                        "name" : "pIn",
+                        "size" : "None",
+                        "port" : {
+                          "Some" : {
+                            "astNodeId" : 2
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None"
                       },
-                      "kind": "SyncInput",
-                      "size": 1,
-                      "ty": {
-                        "DefPort": {
-                          "symbol": {
-                            "Port": {
-                              "nodeId": 0,
-                              "unqualifiedName": "P"
+                      "kind" : "SyncInput",
+                      "size" : 1,
+                      "ty" : {
+                        "DefPort" : {
+                          "symbol" : {
+                            "Port" : {
+                              "nodeId" : 0,
+                              "unqualifiedName" : "P"
                             }
                           }
                         }
                       },
-                      "importNodeIds": []
+                      "importNodeIds" : [
+                      ]
                     }
                   }
                 },
-                "portNumber": "None"
+                "portNumber" : "None"
               },
-              "isUnmatched": false
+              "isUnmatched" : false
             },
             0
           ],
           [
             {
-              "from": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                  "pos": "43.5",
-                  "includingLoc": "None"
+              "from" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                  "pos" : "43.5",
+                  "includingLoc" : "None"
                 },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 25
+                "port" : {
+                  "componentInstance" : {
+                    "aNode" : {
+                      "astNodeId" : 25
                     },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c3"
+                    "qualifiedName" : {
+                      "qualifier" : [
+                      ],
+                      "base" : "c3"
                     },
-                    "component": {
-                      "astNodeId": 13
+                    "component" : {
+                      "astNodeId" : 13
                     },
-                    "baseId": 768,
-                    "maxId": 767,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
+                    "baseId" : 768,
+                    "maxId" : 767,
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecifierMap" : {
+                      
+                    }
                   },
-                  "portInstance": {
-                    "General": {
-                      "aNode": {
-                        "astNodeId": 12
+                  "portInstance" : {
+                    "General" : {
+                      "aNode" : {
+                        "astNodeId" : 12
                       },
-                      "specifier": {
-                        "kind": {
-                          "Output": {}
-                        },
-                        "name": "pOut",
-                        "size": "None",
-                        "port": {
-                          "Some": {
-                            "astNodeId": 11
+                      "specifier" : {
+                        "kind" : {
+                          "Output" : {
+                            
                           }
                         },
-                        "priority": "None",
-                        "queueFull": "None"
+                        "name" : "pOut",
+                        "size" : "None",
+                        "port" : {
+                          "Some" : {
+                            "astNodeId" : 11
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None"
                       },
-                      "kind": "Output",
-                      "size": 1,
-                      "ty": {
-                        "DefPort": {
-                          "symbol": {
-                            "Port": {
-                              "nodeId": 0,
-                              "unqualifiedName": "P"
+                      "kind" : "Output",
+                      "size" : 1,
+                      "ty" : {
+                        "DefPort" : {
+                          "symbol" : {
+                            "Port" : {
+                              "nodeId" : 0,
+                              "unqualifiedName" : "P"
                             }
                           }
                         }
                       },
-                      "importNodeIds": []
+                      "importNodeIds" : [
+                      ]
                     }
                   }
                 },
-                "portNumber": "None"
+                "portNumber" : "None"
               },
-              "to": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                  "pos": "43.16",
-                  "includingLoc": "None"
+              "to" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                  "pos" : "43.16",
+                  "includingLoc" : "None"
                 },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 29
+                "port" : {
+                  "componentInstance" : {
+                    "aNode" : {
+                      "astNodeId" : 29
                     },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c4"
+                    "qualifiedName" : {
+                      "qualifier" : [
+                      ],
+                      "base" : "c4"
                     },
-                    "component": {
-                      "astNodeId": 13
+                    "component" : {
+                      "astNodeId" : 13
                     },
-                    "baseId": 1024,
-                    "maxId": 1023,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
+                    "baseId" : 1024,
+                    "maxId" : 1023,
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecifierMap" : {
+                      
+                    }
                   },
-                  "portInstance": {
-                    "General": {
-                      "aNode": {
-                        "astNodeId": 3
+                  "portInstance" : {
+                    "General" : {
+                      "aNode" : {
+                        "astNodeId" : 3
                       },
-                      "specifier": {
-                        "kind": {
-                          "SyncInput": {}
-                        },
-                        "name": "pIn",
-                        "size": "None",
-                        "port": {
-                          "Some": {
-                            "astNodeId": 2
+                      "specifier" : {
+                        "kind" : {
+                          "SyncInput" : {
+                            
                           }
                         },
-                        "priority": "None",
-                        "queueFull": "None"
+                        "name" : "pIn",
+                        "size" : "None",
+                        "port" : {
+                          "Some" : {
+                            "astNodeId" : 2
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None"
                       },
-                      "kind": "SyncInput",
-                      "size": 1,
-                      "ty": {
-                        "DefPort": {
-                          "symbol": {
-                            "Port": {
-                              "nodeId": 0,
-                              "unqualifiedName": "P"
+                      "kind" : "SyncInput",
+                      "size" : 1,
+                      "ty" : {
+                        "DefPort" : {
+                          "symbol" : {
+                            "Port" : {
+                              "nodeId" : 0,
+                              "unqualifiedName" : "P"
                             }
                           }
                         }
                       },
-                      "importNodeIds": []
+                      "importNodeIds" : [
+                      ]
                     }
                   }
                 },
-                "portNumber": "None"
+                "portNumber" : "None"
               },
-              "isUnmatched": false
+              "isUnmatched" : false
             },
             0
           ]
         ],
-        "unconnectedPortSet": [
+        "unconnectedPortSet" : [
           {
-            "componentInstance": {
-              "aNode": {
-                "astNodeId": 17
+            "componentInstance" : {
+              "aNode" : {
+                "astNodeId" : 17
               },
-              "qualifiedName": {
-                "qualifier": [],
-                "base": "c1"
+              "qualifiedName" : {
+                "qualifier" : [
+                ],
+                "base" : "c1"
               },
-              "component": {
-                "astNodeId": 13
+              "component" : {
+                "astNodeId" : 13
               },
-              "baseId": 256,
-              "maxId": 255,
-              "file": "None",
-              "queueSize": "None",
-              "stackSize": "None",
-              "priority": "None",
-              "cpu": "None",
-              "initSpecifierMap": {}
+              "baseId" : 256,
+              "maxId" : 255,
+              "file" : "None",
+              "queueSize" : "None",
+              "stackSize" : "None",
+              "priority" : "None",
+              "cpu" : "None",
+              "initSpecifierMap" : {
+                
+              }
             },
-            "portInstance": {
-              "General": {
-                "aNode": {
-                  "astNodeId": 3
+            "portInstance" : {
+              "General" : {
+                "aNode" : {
+                  "astNodeId" : 3
                 },
-                "specifier": {
-                  "kind": {
-                    "SyncInput": {}
-                  },
-                  "name": "pIn",
-                  "size": "None",
-                  "port": {
-                    "Some": {
-                      "astNodeId": 2
+                "specifier" : {
+                  "kind" : {
+                    "SyncInput" : {
+                      
                     }
                   },
-                  "priority": "None",
-                  "queueFull": "None"
+                  "name" : "pIn",
+                  "size" : "None",
+                  "port" : {
+                    "Some" : {
+                      "astNodeId" : 2
+                    }
+                  },
+                  "priority" : "None",
+                  "queueFull" : "None"
                 },
-                "kind": "SyncInput",
-                "size": 1,
-                "ty": {
-                  "DefPort": {
-                    "symbol": {
-                      "Port": {
-                        "nodeId": 0,
-                        "unqualifiedName": "P"
+                "kind" : "SyncInput",
+                "size" : 1,
+                "ty" : {
+                  "DefPort" : {
+                    "symbol" : {
+                      "Port" : {
+                        "nodeId" : 0,
+                        "unqualifiedName" : "P"
                       }
                     }
                   }
                 },
-                "importNodeIds": []
+                "importNodeIds" : [
+                ]
               }
             }
           },
           {
-            "componentInstance": {
-              "aNode": {
-                "astNodeId": 17
+            "componentInstance" : {
+              "aNode" : {
+                "astNodeId" : 17
               },
-              "qualifiedName": {
-                "qualifier": [],
-                "base": "c1"
+              "qualifiedName" : {
+                "qualifier" : [
+                ],
+                "base" : "c1"
               },
-              "component": {
-                "astNodeId": 13
+              "component" : {
+                "astNodeId" : 13
               },
-              "baseId": 256,
-              "maxId": 255,
-              "file": "None",
-              "queueSize": "None",
-              "stackSize": "None",
-              "priority": "None",
-              "cpu": "None",
-              "initSpecifierMap": {}
+              "baseId" : 256,
+              "maxId" : 255,
+              "file" : "None",
+              "queueSize" : "None",
+              "stackSize" : "None",
+              "priority" : "None",
+              "cpu" : "None",
+              "initSpecifierMap" : {
+                
+              }
             },
-            "portInstance": {
-              "General": {
-                "aNode": {
-                  "astNodeId": 12
+            "portInstance" : {
+              "General" : {
+                "aNode" : {
+                  "astNodeId" : 12
                 },
-                "specifier": {
-                  "kind": {
-                    "Output": {}
-                  },
-                  "name": "pOut",
-                  "size": "None",
-                  "port": {
-                    "Some": {
-                      "astNodeId": 11
+                "specifier" : {
+                  "kind" : {
+                    "Output" : {
+                      
                     }
                   },
-                  "priority": "None",
-                  "queueFull": "None"
+                  "name" : "pOut",
+                  "size" : "None",
+                  "port" : {
+                    "Some" : {
+                      "astNodeId" : 11
+                    }
+                  },
+                  "priority" : "None",
+                  "queueFull" : "None"
                 },
-                "kind": "Output",
-                "size": 1,
-                "ty": {
-                  "DefPort": {
-                    "symbol": {
-                      "Port": {
-                        "nodeId": 0,
-                        "unqualifiedName": "P"
+                "kind" : "Output",
+                "size" : 1,
+                "ty" : {
+                  "DefPort" : {
+                    "symbol" : {
+                      "Port" : {
+                        "nodeId" : 0,
+                        "unqualifiedName" : "P"
                       }
                     }
                   }
                 },
-                "importNodeIds": []
+                "importNodeIds" : [
+                ]
               }
             }
           }
         ]
       },
-      "128": {
-        "aNode": {
-          "astNodeId": 128
+      "128" : {
+        "aNode" : {
+          "astNodeId" : 128
         },
-        "directImportMap": {
-          "118": {
-            "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-            "pos": "55.3",
-            "includingLoc": "None"
+        "directImportMap" : {
+          "118" : {
+            "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+            "pos" : "55.3",
+            "includingLoc" : "None"
           }
         },
-        "transitiveImportSet": [
+        "transitiveImportSet" : [
           {
-            "node": {
-              "astNodeId": 72
+            "node" : {
+              "astNodeId" : 72
             }
           },
           {
-            "node": {
-              "astNodeId": 118
+            "node" : {
+              "astNodeId" : 118
             }
           }
         ],
-        "instanceMap": [
+        "instanceMap" : [
           [
             {
-              "aNode": {
-                "astNodeId": 25
+              "aNode" : {
+                "astNodeId" : 25
               },
-              "qualifiedName": {
-                "qualifier": [],
-                "base": "c3"
+              "qualifiedName" : {
+                "qualifier" : [
+                ],
+                "base" : "c3"
               },
-              "component": {
-                "astNodeId": 13
+              "component" : {
+                "astNodeId" : 13
               },
-              "baseId": 768,
-              "maxId": 767,
-              "file": "None",
-              "queueSize": "None",
-              "stackSize": "None",
-              "priority": "None",
-              "cpu": "None",
-              "initSpecifierMap": {}
+              "baseId" : 768,
+              "maxId" : 767,
+              "file" : "None",
+              "queueSize" : "None",
+              "stackSize" : "None",
+              "priority" : "None",
+              "cpu" : "None",
+              "initSpecifierMap" : {
+                
+              }
             },
             [
               {
-                "Public": {}
+                "Public" : {
+                  
+                }
               },
               {
-                "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                "pos": "37.3",
-                "includingLoc": "None"
+                "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                "pos" : "37.3",
+                "includingLoc" : "None"
               }
             ]
           ],
           [
             {
-              "aNode": {
-                "astNodeId": 29
+              "aNode" : {
+                "astNodeId" : 29
               },
-              "qualifiedName": {
-                "qualifier": [],
-                "base": "c4"
+              "qualifiedName" : {
+                "qualifier" : [
+                ],
+                "base" : "c4"
               },
-              "component": {
-                "astNodeId": 13
+              "component" : {
+                "astNodeId" : 13
               },
-              "baseId": 1024,
-              "maxId": 1023,
-              "file": "None",
-              "queueSize": "None",
-              "stackSize": "None",
-              "priority": "None",
-              "cpu": "None",
-              "initSpecifierMap": {}
+              "baseId" : 1024,
+              "maxId" : 1023,
+              "file" : "None",
+              "queueSize" : "None",
+              "stackSize" : "None",
+              "priority" : "None",
+              "cpu" : "None",
+              "initSpecifierMap" : {
+                
+              }
             },
             [
               {
-                "Public": {}
+                "Public" : {
+                  
+                }
               },
               {
-                "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                "pos": "39.3",
-                "includingLoc": "None"
+                "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                "pos" : "39.3",
+                "includingLoc" : "None"
               }
             ]
           ],
           [
             {
-              "aNode": {
-                "astNodeId": 17
+              "aNode" : {
+                "astNodeId" : 17
               },
-              "qualifiedName": {
-                "qualifier": [],
-                "base": "c1"
+              "qualifiedName" : {
+                "qualifier" : [
+                ],
+                "base" : "c1"
               },
-              "component": {
-                "astNodeId": 13
+              "component" : {
+                "astNodeId" : 13
               },
-              "baseId": 256,
-              "maxId": 255,
-              "file": "None",
-              "queueSize": "None",
-              "stackSize": "None",
-              "priority": "None",
-              "cpu": "None",
-              "initSpecifierMap": {}
+              "baseId" : 256,
+              "maxId" : 255,
+              "file" : "None",
+              "queueSize" : "None",
+              "stackSize" : "None",
+              "priority" : "None",
+              "cpu" : "None",
+              "initSpecifierMap" : {
+                
+              }
             },
             [
               {
-                "Public": {}
+                "Public" : {
+                  
+                }
               },
               {
-                "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                "pos": "17.3",
-                "includingLoc": "None"
+                "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                "pos" : "17.3",
+                "includingLoc" : "None"
               }
             ]
           ]
         ],
-        "patternMap": {},
-        "connectionMap": {
-          "C3": [
+        "patternMap" : {
+          
+        },
+        "connectionMap" : {
+          "C3" : [
             {
-              "from": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                  "pos": "43.5",
-                  "includingLoc": "None"
+              "from" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                  "pos" : "43.5",
+                  "includingLoc" : "None"
                 },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 25
+                "port" : {
+                  "componentInstance" : {
+                    "aNode" : {
+                      "astNodeId" : 25
                     },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c3"
+                    "qualifiedName" : {
+                      "qualifier" : [
+                      ],
+                      "base" : "c3"
                     },
-                    "component": {
-                      "astNodeId": 13
+                    "component" : {
+                      "astNodeId" : 13
                     },
-                    "baseId": 768,
-                    "maxId": 767,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
+                    "baseId" : 768,
+                    "maxId" : 767,
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecifierMap" : {
+                      
+                    }
                   },
-                  "portInstance": {
-                    "General": {
-                      "aNode": {
-                        "astNodeId": 12
+                  "portInstance" : {
+                    "General" : {
+                      "aNode" : {
+                        "astNodeId" : 12
                       },
-                      "specifier": {
-                        "kind": {
-                          "Output": {}
-                        },
-                        "name": "pOut",
-                        "size": "None",
-                        "port": {
-                          "Some": {
-                            "astNodeId": 11
+                      "specifier" : {
+                        "kind" : {
+                          "Output" : {
+                            
                           }
                         },
-                        "priority": "None",
-                        "queueFull": "None"
+                        "name" : "pOut",
+                        "size" : "None",
+                        "port" : {
+                          "Some" : {
+                            "astNodeId" : 11
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None"
                       },
-                      "kind": "Output",
-                      "size": 1,
-                      "ty": {
-                        "DefPort": {
-                          "symbol": {
-                            "Port": {
-                              "nodeId": 0,
-                              "unqualifiedName": "P"
+                      "kind" : "Output",
+                      "size" : 1,
+                      "ty" : {
+                        "DefPort" : {
+                          "symbol" : {
+                            "Port" : {
+                              "nodeId" : 0,
+                              "unqualifiedName" : "P"
                             }
                           }
                         }
                       },
-                      "importNodeIds": []
+                      "importNodeIds" : [
+                      ]
                     }
                   }
                 },
-                "portNumber": "None"
+                "portNumber" : "None"
               },
-              "to": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                  "pos": "43.16",
-                  "includingLoc": "None"
+              "to" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                  "pos" : "43.16",
+                  "includingLoc" : "None"
                 },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 29
+                "port" : {
+                  "componentInstance" : {
+                    "aNode" : {
+                      "astNodeId" : 29
                     },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c4"
+                    "qualifiedName" : {
+                      "qualifier" : [
+                      ],
+                      "base" : "c4"
                     },
-                    "component": {
-                      "astNodeId": 13
+                    "component" : {
+                      "astNodeId" : 13
                     },
-                    "baseId": 1024,
-                    "maxId": 1023,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
+                    "baseId" : 1024,
+                    "maxId" : 1023,
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecifierMap" : {
+                      
+                    }
                   },
-                  "portInstance": {
-                    "General": {
-                      "aNode": {
-                        "astNodeId": 3
+                  "portInstance" : {
+                    "General" : {
+                      "aNode" : {
+                        "astNodeId" : 3
                       },
-                      "specifier": {
-                        "kind": {
-                          "SyncInput": {}
-                        },
-                        "name": "pIn",
-                        "size": "None",
-                        "port": {
-                          "Some": {
-                            "astNodeId": 2
+                      "specifier" : {
+                        "kind" : {
+                          "SyncInput" : {
+                            
                           }
                         },
-                        "priority": "None",
-                        "queueFull": "None"
+                        "name" : "pIn",
+                        "size" : "None",
+                        "port" : {
+                          "Some" : {
+                            "astNodeId" : 2
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None"
                       },
-                      "kind": "SyncInput",
-                      "size": 1,
-                      "ty": {
-                        "DefPort": {
-                          "symbol": {
-                            "Port": {
-                              "nodeId": 0,
-                              "unqualifiedName": "P"
+                      "kind" : "SyncInput",
+                      "size" : 1,
+                      "ty" : {
+                        "DefPort" : {
+                          "symbol" : {
+                            "Port" : {
+                              "nodeId" : 0,
+                              "unqualifiedName" : "P"
                             }
                           }
                         }
                       },
-                      "importNodeIds": []
+                      "importNodeIds" : [
+                      ]
                     }
                   }
                 },
-                "portNumber": "None"
+                "portNumber" : "None"
               },
-              "isUnmatched": false
+              "isUnmatched" : false
             }
           ],
-          "C4": [
+          "C4" : [
             {
-              "from": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                  "pos": "48.5",
-                  "includingLoc": "None"
+              "from" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                  "pos" : "48.5",
+                  "includingLoc" : "None"
                 },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 29
+                "port" : {
+                  "componentInstance" : {
+                    "aNode" : {
+                      "astNodeId" : 29
                     },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c4"
+                    "qualifiedName" : {
+                      "qualifier" : [
+                      ],
+                      "base" : "c4"
                     },
-                    "component": {
-                      "astNodeId": 13
+                    "component" : {
+                      "astNodeId" : 13
                     },
-                    "baseId": 1024,
-                    "maxId": 1023,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
+                    "baseId" : 1024,
+                    "maxId" : 1023,
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecifierMap" : {
+                      
+                    }
                   },
-                  "portInstance": {
-                    "General": {
-                      "aNode": {
-                        "astNodeId": 12
+                  "portInstance" : {
+                    "General" : {
+                      "aNode" : {
+                        "astNodeId" : 12
                       },
-                      "specifier": {
-                        "kind": {
-                          "Output": {}
-                        },
-                        "name": "pOut",
-                        "size": "None",
-                        "port": {
-                          "Some": {
-                            "astNodeId": 11
+                      "specifier" : {
+                        "kind" : {
+                          "Output" : {
+                            
                           }
                         },
-                        "priority": "None",
-                        "queueFull": "None"
+                        "name" : "pOut",
+                        "size" : "None",
+                        "port" : {
+                          "Some" : {
+                            "astNodeId" : 11
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None"
                       },
-                      "kind": "Output",
-                      "size": 1,
-                      "ty": {
-                        "DefPort": {
-                          "symbol": {
-                            "Port": {
-                              "nodeId": 0,
-                              "unqualifiedName": "P"
+                      "kind" : "Output",
+                      "size" : 1,
+                      "ty" : {
+                        "DefPort" : {
+                          "symbol" : {
+                            "Port" : {
+                              "nodeId" : 0,
+                              "unqualifiedName" : "P"
                             }
                           }
                         }
                       },
-                      "importNodeIds": []
+                      "importNodeIds" : [
+                      ]
                     }
                   }
                 },
-                "portNumber": "None"
+                "portNumber" : "None"
               },
-              "to": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                  "pos": "48.16",
-                  "includingLoc": "None"
+              "to" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                  "pos" : "48.16",
+                  "includingLoc" : "None"
                 },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 25
+                "port" : {
+                  "componentInstance" : {
+                    "aNode" : {
+                      "astNodeId" : 25
                     },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c3"
+                    "qualifiedName" : {
+                      "qualifier" : [
+                      ],
+                      "base" : "c3"
                     },
-                    "component": {
-                      "astNodeId": 13
+                    "component" : {
+                      "astNodeId" : 13
                     },
-                    "baseId": 768,
-                    "maxId": 767,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
+                    "baseId" : 768,
+                    "maxId" : 767,
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecifierMap" : {
+                      
+                    }
                   },
-                  "portInstance": {
-                    "General": {
-                      "aNode": {
-                        "astNodeId": 3
+                  "portInstance" : {
+                    "General" : {
+                      "aNode" : {
+                        "astNodeId" : 3
                       },
-                      "specifier": {
-                        "kind": {
-                          "SyncInput": {}
-                        },
-                        "name": "pIn",
-                        "size": "None",
-                        "port": {
-                          "Some": {
-                            "astNodeId": 2
+                      "specifier" : {
+                        "kind" : {
+                          "SyncInput" : {
+                            
                           }
                         },
-                        "priority": "None",
-                        "queueFull": "None"
+                        "name" : "pIn",
+                        "size" : "None",
+                        "port" : {
+                          "Some" : {
+                            "astNodeId" : 2
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None"
                       },
-                      "kind": "SyncInput",
-                      "size": 1,
-                      "ty": {
-                        "DefPort": {
-                          "symbol": {
-                            "Port": {
-                              "nodeId": 0,
-                              "unqualifiedName": "P"
+                      "kind" : "SyncInput",
+                      "size" : 1,
+                      "ty" : {
+                        "DefPort" : {
+                          "symbol" : {
+                            "Port" : {
+                              "nodeId" : 0,
+                              "unqualifiedName" : "P"
                             }
                           }
                         }
                       },
-                      "importNodeIds": []
+                      "importNodeIds" : [
+                      ]
                     }
                   }
                 },
-                "portNumber": "None"
+                "portNumber" : "None"
               },
-              "isUnmatched": false
+              "isUnmatched" : false
             }
           ]
         },
-        "localConnectionMap": {},
-        "outputConnectionMap": [
+        "localConnectionMap" : {
+          
+        },
+        "outputConnectionMap" : [
           [
             {
-              "componentInstance": {
-                "aNode": {
-                  "astNodeId": 25
+              "componentInstance" : {
+                "aNode" : {
+                  "astNodeId" : 25
                 },
-                "qualifiedName": {
-                  "qualifier": [],
-                  "base": "c3"
+                "qualifiedName" : {
+                  "qualifier" : [
+                  ],
+                  "base" : "c3"
                 },
-                "component": {
-                  "astNodeId": 13
+                "component" : {
+                  "astNodeId" : 13
                 },
-                "baseId": 768,
-                "maxId": 767,
-                "file": "None",
-                "queueSize": "None",
-                "stackSize": "None",
-                "priority": "None",
-                "cpu": "None",
-                "initSpecifierMap": {}
+                "baseId" : 768,
+                "maxId" : 767,
+                "file" : "None",
+                "queueSize" : "None",
+                "stackSize" : "None",
+                "priority" : "None",
+                "cpu" : "None",
+                "initSpecifierMap" : {
+                  
+                }
               },
-              "portInstance": {
-                "General": {
-                  "aNode": {
-                    "astNodeId": 12
+              "portInstance" : {
+                "General" : {
+                  "aNode" : {
+                    "astNodeId" : 12
                   },
-                  "specifier": {
-                    "kind": {
-                      "Output": {}
-                    },
-                    "name": "pOut",
-                    "size": "None",
-                    "port": {
-                      "Some": {
-                        "astNodeId": 11
+                  "specifier" : {
+                    "kind" : {
+                      "Output" : {
+                        
                       }
                     },
-                    "priority": "None",
-                    "queueFull": "None"
+                    "name" : "pOut",
+                    "size" : "None",
+                    "port" : {
+                      "Some" : {
+                        "astNodeId" : 11
+                      }
+                    },
+                    "priority" : "None",
+                    "queueFull" : "None"
                   },
-                  "kind": "Output",
-                  "size": 1,
-                  "ty": {
-                    "DefPort": {
-                      "symbol": {
-                        "Port": {
-                          "nodeId": 0,
-                          "unqualifiedName": "P"
+                  "kind" : "Output",
+                  "size" : 1,
+                  "ty" : {
+                    "DefPort" : {
+                      "symbol" : {
+                        "Port" : {
+                          "nodeId" : 0,
+                          "unqualifiedName" : "P"
                         }
                       }
                     }
                   },
-                  "importNodeIds": []
+                  "importNodeIds" : [
+                  ]
                 }
               }
             },
             [
               {
-                "from": {
-                  "loc": {
-                    "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                    "pos": "43.5",
-                    "includingLoc": "None"
+                "from" : {
+                  "loc" : {
+                    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                    "pos" : "43.5",
+                    "includingLoc" : "None"
                   },
-                  "port": {
-                    "componentInstance": {
-                      "aNode": {
-                        "astNodeId": 25
+                  "port" : {
+                    "componentInstance" : {
+                      "aNode" : {
+                        "astNodeId" : 25
                       },
-                      "qualifiedName": {
-                        "qualifier": [],
-                        "base": "c3"
+                      "qualifiedName" : {
+                        "qualifier" : [
+                        ],
+                        "base" : "c3"
                       },
-                      "component": {
-                        "astNodeId": 13
+                      "component" : {
+                        "astNodeId" : 13
                       },
-                      "baseId": 768,
-                      "maxId": 767,
-                      "file": "None",
-                      "queueSize": "None",
-                      "stackSize": "None",
-                      "priority": "None",
-                      "cpu": "None",
-                      "initSpecifierMap": {}
+                      "baseId" : 768,
+                      "maxId" : 767,
+                      "file" : "None",
+                      "queueSize" : "None",
+                      "stackSize" : "None",
+                      "priority" : "None",
+                      "cpu" : "None",
+                      "initSpecifierMap" : {
+                        
+                      }
                     },
-                    "portInstance": {
-                      "General": {
-                        "aNode": {
-                          "astNodeId": 12
+                    "portInstance" : {
+                      "General" : {
+                        "aNode" : {
+                          "astNodeId" : 12
                         },
-                        "specifier": {
-                          "kind": {
-                            "Output": {}
-                          },
-                          "name": "pOut",
-                          "size": "None",
-                          "port": {
-                            "Some": {
-                              "astNodeId": 11
+                        "specifier" : {
+                          "kind" : {
+                            "Output" : {
+                              
                             }
                           },
-                          "priority": "None",
-                          "queueFull": "None"
+                          "name" : "pOut",
+                          "size" : "None",
+                          "port" : {
+                            "Some" : {
+                              "astNodeId" : 11
+                            }
+                          },
+                          "priority" : "None",
+                          "queueFull" : "None"
                         },
-                        "kind": "Output",
-                        "size": 1,
-                        "ty": {
-                          "DefPort": {
-                            "symbol": {
-                              "Port": {
-                                "nodeId": 0,
-                                "unqualifiedName": "P"
+                        "kind" : "Output",
+                        "size" : 1,
+                        "ty" : {
+                          "DefPort" : {
+                            "symbol" : {
+                              "Port" : {
+                                "nodeId" : 0,
+                                "unqualifiedName" : "P"
                               }
                             }
                           }
                         },
-                        "importNodeIds": []
+                        "importNodeIds" : [
+                        ]
                       }
                     }
                   },
-                  "portNumber": "None"
+                  "portNumber" : "None"
                 },
-                "to": {
-                  "loc": {
-                    "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                    "pos": "43.16",
-                    "includingLoc": "None"
+                "to" : {
+                  "loc" : {
+                    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                    "pos" : "43.16",
+                    "includingLoc" : "None"
                   },
-                  "port": {
-                    "componentInstance": {
-                      "aNode": {
-                        "astNodeId": 29
+                  "port" : {
+                    "componentInstance" : {
+                      "aNode" : {
+                        "astNodeId" : 29
                       },
-                      "qualifiedName": {
-                        "qualifier": [],
-                        "base": "c4"
+                      "qualifiedName" : {
+                        "qualifier" : [
+                        ],
+                        "base" : "c4"
                       },
-                      "component": {
-                        "astNodeId": 13
+                      "component" : {
+                        "astNodeId" : 13
                       },
-                      "baseId": 1024,
-                      "maxId": 1023,
-                      "file": "None",
-                      "queueSize": "None",
-                      "stackSize": "None",
-                      "priority": "None",
-                      "cpu": "None",
-                      "initSpecifierMap": {}
+                      "baseId" : 1024,
+                      "maxId" : 1023,
+                      "file" : "None",
+                      "queueSize" : "None",
+                      "stackSize" : "None",
+                      "priority" : "None",
+                      "cpu" : "None",
+                      "initSpecifierMap" : {
+                        
+                      }
                     },
-                    "portInstance": {
-                      "General": {
-                        "aNode": {
-                          "astNodeId": 3
+                    "portInstance" : {
+                      "General" : {
+                        "aNode" : {
+                          "astNodeId" : 3
                         },
-                        "specifier": {
-                          "kind": {
-                            "SyncInput": {}
-                          },
-                          "name": "pIn",
-                          "size": "None",
-                          "port": {
-                            "Some": {
-                              "astNodeId": 2
+                        "specifier" : {
+                          "kind" : {
+                            "SyncInput" : {
+                              
                             }
                           },
-                          "priority": "None",
-                          "queueFull": "None"
+                          "name" : "pIn",
+                          "size" : "None",
+                          "port" : {
+                            "Some" : {
+                              "astNodeId" : 2
+                            }
+                          },
+                          "priority" : "None",
+                          "queueFull" : "None"
                         },
-                        "kind": "SyncInput",
-                        "size": 1,
-                        "ty": {
-                          "DefPort": {
-                            "symbol": {
-                              "Port": {
-                                "nodeId": 0,
-                                "unqualifiedName": "P"
+                        "kind" : "SyncInput",
+                        "size" : 1,
+                        "ty" : {
+                          "DefPort" : {
+                            "symbol" : {
+                              "Port" : {
+                                "nodeId" : 0,
+                                "unqualifiedName" : "P"
                               }
                             }
                           }
                         },
-                        "importNodeIds": []
+                        "importNodeIds" : [
+                        ]
                       }
                     }
                   },
-                  "portNumber": "None"
+                  "portNumber" : "None"
                 },
-                "isUnmatched": false
+                "isUnmatched" : false
               }
             ]
           ],
           [
             {
-              "componentInstance": {
-                "aNode": {
-                  "astNodeId": 29
+              "componentInstance" : {
+                "aNode" : {
+                  "astNodeId" : 29
                 },
-                "qualifiedName": {
-                  "qualifier": [],
-                  "base": "c4"
+                "qualifiedName" : {
+                  "qualifier" : [
+                  ],
+                  "base" : "c4"
                 },
-                "component": {
-                  "astNodeId": 13
+                "component" : {
+                  "astNodeId" : 13
                 },
-                "baseId": 1024,
-                "maxId": 1023,
-                "file": "None",
-                "queueSize": "None",
-                "stackSize": "None",
-                "priority": "None",
-                "cpu": "None",
-                "initSpecifierMap": {}
+                "baseId" : 1024,
+                "maxId" : 1023,
+                "file" : "None",
+                "queueSize" : "None",
+                "stackSize" : "None",
+                "priority" : "None",
+                "cpu" : "None",
+                "initSpecifierMap" : {
+                  
+                }
               },
-              "portInstance": {
-                "General": {
-                  "aNode": {
-                    "astNodeId": 12
+              "portInstance" : {
+                "General" : {
+                  "aNode" : {
+                    "astNodeId" : 12
                   },
-                  "specifier": {
-                    "kind": {
-                      "Output": {}
-                    },
-                    "name": "pOut",
-                    "size": "None",
-                    "port": {
-                      "Some": {
-                        "astNodeId": 11
+                  "specifier" : {
+                    "kind" : {
+                      "Output" : {
+                        
                       }
                     },
-                    "priority": "None",
-                    "queueFull": "None"
+                    "name" : "pOut",
+                    "size" : "None",
+                    "port" : {
+                      "Some" : {
+                        "astNodeId" : 11
+                      }
+                    },
+                    "priority" : "None",
+                    "queueFull" : "None"
                   },
-                  "kind": "Output",
-                  "size": 1,
-                  "ty": {
-                    "DefPort": {
-                      "symbol": {
-                        "Port": {
-                          "nodeId": 0,
-                          "unqualifiedName": "P"
+                  "kind" : "Output",
+                  "size" : 1,
+                  "ty" : {
+                    "DefPort" : {
+                      "symbol" : {
+                        "Port" : {
+                          "nodeId" : 0,
+                          "unqualifiedName" : "P"
                         }
                       }
                     }
                   },
-                  "importNodeIds": []
+                  "importNodeIds" : [
+                  ]
                 }
               }
             },
             [
               {
-                "from": {
-                  "loc": {
-                    "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                    "pos": "48.5",
-                    "includingLoc": "None"
+                "from" : {
+                  "loc" : {
+                    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                    "pos" : "48.5",
+                    "includingLoc" : "None"
                   },
-                  "port": {
-                    "componentInstance": {
-                      "aNode": {
-                        "astNodeId": 29
+                  "port" : {
+                    "componentInstance" : {
+                      "aNode" : {
+                        "astNodeId" : 29
                       },
-                      "qualifiedName": {
-                        "qualifier": [],
-                        "base": "c4"
+                      "qualifiedName" : {
+                        "qualifier" : [
+                        ],
+                        "base" : "c4"
                       },
-                      "component": {
-                        "astNodeId": 13
+                      "component" : {
+                        "astNodeId" : 13
                       },
-                      "baseId": 1024,
-                      "maxId": 1023,
-                      "file": "None",
-                      "queueSize": "None",
-                      "stackSize": "None",
-                      "priority": "None",
-                      "cpu": "None",
-                      "initSpecifierMap": {}
+                      "baseId" : 1024,
+                      "maxId" : 1023,
+                      "file" : "None",
+                      "queueSize" : "None",
+                      "stackSize" : "None",
+                      "priority" : "None",
+                      "cpu" : "None",
+                      "initSpecifierMap" : {
+                        
+                      }
                     },
-                    "portInstance": {
-                      "General": {
-                        "aNode": {
-                          "astNodeId": 12
+                    "portInstance" : {
+                      "General" : {
+                        "aNode" : {
+                          "astNodeId" : 12
                         },
-                        "specifier": {
-                          "kind": {
-                            "Output": {}
-                          },
-                          "name": "pOut",
-                          "size": "None",
-                          "port": {
-                            "Some": {
-                              "astNodeId": 11
+                        "specifier" : {
+                          "kind" : {
+                            "Output" : {
+                              
                             }
                           },
-                          "priority": "None",
-                          "queueFull": "None"
+                          "name" : "pOut",
+                          "size" : "None",
+                          "port" : {
+                            "Some" : {
+                              "astNodeId" : 11
+                            }
+                          },
+                          "priority" : "None",
+                          "queueFull" : "None"
                         },
-                        "kind": "Output",
-                        "size": 1,
-                        "ty": {
-                          "DefPort": {
-                            "symbol": {
-                              "Port": {
-                                "nodeId": 0,
-                                "unqualifiedName": "P"
+                        "kind" : "Output",
+                        "size" : 1,
+                        "ty" : {
+                          "DefPort" : {
+                            "symbol" : {
+                              "Port" : {
+                                "nodeId" : 0,
+                                "unqualifiedName" : "P"
                               }
                             }
                           }
                         },
-                        "importNodeIds": []
+                        "importNodeIds" : [
+                        ]
                       }
                     }
                   },
-                  "portNumber": "None"
+                  "portNumber" : "None"
                 },
-                "to": {
-                  "loc": {
-                    "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                    "pos": "48.16",
-                    "includingLoc": "None"
+                "to" : {
+                  "loc" : {
+                    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                    "pos" : "48.16",
+                    "includingLoc" : "None"
                   },
-                  "port": {
-                    "componentInstance": {
-                      "aNode": {
-                        "astNodeId": 25
+                  "port" : {
+                    "componentInstance" : {
+                      "aNode" : {
+                        "astNodeId" : 25
                       },
-                      "qualifiedName": {
-                        "qualifier": [],
-                        "base": "c3"
+                      "qualifiedName" : {
+                        "qualifier" : [
+                        ],
+                        "base" : "c3"
                       },
-                      "component": {
-                        "astNodeId": 13
+                      "component" : {
+                        "astNodeId" : 13
                       },
-                      "baseId": 768,
-                      "maxId": 767,
-                      "file": "None",
-                      "queueSize": "None",
-                      "stackSize": "None",
-                      "priority": "None",
-                      "cpu": "None",
-                      "initSpecifierMap": {}
+                      "baseId" : 768,
+                      "maxId" : 767,
+                      "file" : "None",
+                      "queueSize" : "None",
+                      "stackSize" : "None",
+                      "priority" : "None",
+                      "cpu" : "None",
+                      "initSpecifierMap" : {
+                        
+                      }
                     },
-                    "portInstance": {
-                      "General": {
-                        "aNode": {
-                          "astNodeId": 3
+                    "portInstance" : {
+                      "General" : {
+                        "aNode" : {
+                          "astNodeId" : 3
                         },
-                        "specifier": {
-                          "kind": {
-                            "SyncInput": {}
-                          },
-                          "name": "pIn",
-                          "size": "None",
-                          "port": {
-                            "Some": {
-                              "astNodeId": 2
+                        "specifier" : {
+                          "kind" : {
+                            "SyncInput" : {
+                              
                             }
                           },
-                          "priority": "None",
-                          "queueFull": "None"
+                          "name" : "pIn",
+                          "size" : "None",
+                          "port" : {
+                            "Some" : {
+                              "astNodeId" : 2
+                            }
+                          },
+                          "priority" : "None",
+                          "queueFull" : "None"
                         },
-                        "kind": "SyncInput",
-                        "size": 1,
-                        "ty": {
-                          "DefPort": {
-                            "symbol": {
-                              "Port": {
-                                "nodeId": 0,
-                                "unqualifiedName": "P"
+                        "kind" : "SyncInput",
+                        "size" : 1,
+                        "ty" : {
+                          "DefPort" : {
+                            "symbol" : {
+                              "Port" : {
+                                "nodeId" : 0,
+                                "unqualifiedName" : "P"
                               }
                             }
                           }
                         },
-                        "importNodeIds": []
+                        "importNodeIds" : [
+                        ]
                       }
                     }
                   },
-                  "portNumber": "None"
+                  "portNumber" : "None"
                 },
-                "isUnmatched": false
+                "isUnmatched" : false
               }
             ]
           ]
         ],
-        "inputConnectionMap": [
+        "inputConnectionMap" : [
           [
             {
-              "componentInstance": {
-                "aNode": {
-                  "astNodeId": 29
+              "componentInstance" : {
+                "aNode" : {
+                  "astNodeId" : 29
                 },
-                "qualifiedName": {
-                  "qualifier": [],
-                  "base": "c4"
+                "qualifiedName" : {
+                  "qualifier" : [
+                  ],
+                  "base" : "c4"
                 },
-                "component": {
-                  "astNodeId": 13
+                "component" : {
+                  "astNodeId" : 13
                 },
-                "baseId": 1024,
-                "maxId": 1023,
-                "file": "None",
-                "queueSize": "None",
-                "stackSize": "None",
-                "priority": "None",
-                "cpu": "None",
-                "initSpecifierMap": {}
+                "baseId" : 1024,
+                "maxId" : 1023,
+                "file" : "None",
+                "queueSize" : "None",
+                "stackSize" : "None",
+                "priority" : "None",
+                "cpu" : "None",
+                "initSpecifierMap" : {
+                  
+                }
               },
-              "portInstance": {
-                "General": {
-                  "aNode": {
-                    "astNodeId": 3
+              "portInstance" : {
+                "General" : {
+                  "aNode" : {
+                    "astNodeId" : 3
                   },
-                  "specifier": {
-                    "kind": {
-                      "SyncInput": {}
-                    },
-                    "name": "pIn",
-                    "size": "None",
-                    "port": {
-                      "Some": {
-                        "astNodeId": 2
+                  "specifier" : {
+                    "kind" : {
+                      "SyncInput" : {
+                        
                       }
                     },
-                    "priority": "None",
-                    "queueFull": "None"
+                    "name" : "pIn",
+                    "size" : "None",
+                    "port" : {
+                      "Some" : {
+                        "astNodeId" : 2
+                      }
+                    },
+                    "priority" : "None",
+                    "queueFull" : "None"
                   },
-                  "kind": "SyncInput",
-                  "size": 1,
-                  "ty": {
-                    "DefPort": {
-                      "symbol": {
-                        "Port": {
-                          "nodeId": 0,
-                          "unqualifiedName": "P"
+                  "kind" : "SyncInput",
+                  "size" : 1,
+                  "ty" : {
+                    "DefPort" : {
+                      "symbol" : {
+                        "Port" : {
+                          "nodeId" : 0,
+                          "unqualifiedName" : "P"
                         }
                       }
                     }
                   },
-                  "importNodeIds": []
+                  "importNodeIds" : [
+                  ]
                 }
               }
             },
             [
               {
-                "from": {
-                  "loc": {
-                    "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                    "pos": "43.5",
-                    "includingLoc": "None"
+                "from" : {
+                  "loc" : {
+                    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                    "pos" : "43.5",
+                    "includingLoc" : "None"
                   },
-                  "port": {
-                    "componentInstance": {
-                      "aNode": {
-                        "astNodeId": 25
+                  "port" : {
+                    "componentInstance" : {
+                      "aNode" : {
+                        "astNodeId" : 25
                       },
-                      "qualifiedName": {
-                        "qualifier": [],
-                        "base": "c3"
+                      "qualifiedName" : {
+                        "qualifier" : [
+                        ],
+                        "base" : "c3"
                       },
-                      "component": {
-                        "astNodeId": 13
+                      "component" : {
+                        "astNodeId" : 13
                       },
-                      "baseId": 768,
-                      "maxId": 767,
-                      "file": "None",
-                      "queueSize": "None",
-                      "stackSize": "None",
-                      "priority": "None",
-                      "cpu": "None",
-                      "initSpecifierMap": {}
+                      "baseId" : 768,
+                      "maxId" : 767,
+                      "file" : "None",
+                      "queueSize" : "None",
+                      "stackSize" : "None",
+                      "priority" : "None",
+                      "cpu" : "None",
+                      "initSpecifierMap" : {
+                        
+                      }
                     },
-                    "portInstance": {
-                      "General": {
-                        "aNode": {
-                          "astNodeId": 12
+                    "portInstance" : {
+                      "General" : {
+                        "aNode" : {
+                          "astNodeId" : 12
                         },
-                        "specifier": {
-                          "kind": {
-                            "Output": {}
-                          },
-                          "name": "pOut",
-                          "size": "None",
-                          "port": {
-                            "Some": {
-                              "astNodeId": 11
+                        "specifier" : {
+                          "kind" : {
+                            "Output" : {
+                              
                             }
                           },
-                          "priority": "None",
-                          "queueFull": "None"
+                          "name" : "pOut",
+                          "size" : "None",
+                          "port" : {
+                            "Some" : {
+                              "astNodeId" : 11
+                            }
+                          },
+                          "priority" : "None",
+                          "queueFull" : "None"
                         },
-                        "kind": "Output",
-                        "size": 1,
-                        "ty": {
-                          "DefPort": {
-                            "symbol": {
-                              "Port": {
-                                "nodeId": 0,
-                                "unqualifiedName": "P"
+                        "kind" : "Output",
+                        "size" : 1,
+                        "ty" : {
+                          "DefPort" : {
+                            "symbol" : {
+                              "Port" : {
+                                "nodeId" : 0,
+                                "unqualifiedName" : "P"
                               }
                             }
                           }
                         },
-                        "importNodeIds": []
+                        "importNodeIds" : [
+                        ]
                       }
                     }
                   },
-                  "portNumber": "None"
+                  "portNumber" : "None"
                 },
-                "to": {
-                  "loc": {
-                    "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                    "pos": "43.16",
-                    "includingLoc": "None"
+                "to" : {
+                  "loc" : {
+                    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                    "pos" : "43.16",
+                    "includingLoc" : "None"
                   },
-                  "port": {
-                    "componentInstance": {
-                      "aNode": {
-                        "astNodeId": 29
+                  "port" : {
+                    "componentInstance" : {
+                      "aNode" : {
+                        "astNodeId" : 29
                       },
-                      "qualifiedName": {
-                        "qualifier": [],
-                        "base": "c4"
+                      "qualifiedName" : {
+                        "qualifier" : [
+                        ],
+                        "base" : "c4"
                       },
-                      "component": {
-                        "astNodeId": 13
+                      "component" : {
+                        "astNodeId" : 13
                       },
-                      "baseId": 1024,
-                      "maxId": 1023,
-                      "file": "None",
-                      "queueSize": "None",
-                      "stackSize": "None",
-                      "priority": "None",
-                      "cpu": "None",
-                      "initSpecifierMap": {}
+                      "baseId" : 1024,
+                      "maxId" : 1023,
+                      "file" : "None",
+                      "queueSize" : "None",
+                      "stackSize" : "None",
+                      "priority" : "None",
+                      "cpu" : "None",
+                      "initSpecifierMap" : {
+                        
+                      }
                     },
-                    "portInstance": {
-                      "General": {
-                        "aNode": {
-                          "astNodeId": 3
+                    "portInstance" : {
+                      "General" : {
+                        "aNode" : {
+                          "astNodeId" : 3
                         },
-                        "specifier": {
-                          "kind": {
-                            "SyncInput": {}
-                          },
-                          "name": "pIn",
-                          "size": "None",
-                          "port": {
-                            "Some": {
-                              "astNodeId": 2
+                        "specifier" : {
+                          "kind" : {
+                            "SyncInput" : {
+                              
                             }
                           },
-                          "priority": "None",
-                          "queueFull": "None"
+                          "name" : "pIn",
+                          "size" : "None",
+                          "port" : {
+                            "Some" : {
+                              "astNodeId" : 2
+                            }
+                          },
+                          "priority" : "None",
+                          "queueFull" : "None"
                         },
-                        "kind": "SyncInput",
-                        "size": 1,
-                        "ty": {
-                          "DefPort": {
-                            "symbol": {
-                              "Port": {
-                                "nodeId": 0,
-                                "unqualifiedName": "P"
+                        "kind" : "SyncInput",
+                        "size" : 1,
+                        "ty" : {
+                          "DefPort" : {
+                            "symbol" : {
+                              "Port" : {
+                                "nodeId" : 0,
+                                "unqualifiedName" : "P"
                               }
                             }
                           }
                         },
-                        "importNodeIds": []
+                        "importNodeIds" : [
+                        ]
                       }
                     }
                   },
-                  "portNumber": "None"
+                  "portNumber" : "None"
                 },
-                "isUnmatched": false
+                "isUnmatched" : false
               }
             ]
           ],
           [
             {
-              "componentInstance": {
-                "aNode": {
-                  "astNodeId": 25
+              "componentInstance" : {
+                "aNode" : {
+                  "astNodeId" : 25
                 },
-                "qualifiedName": {
-                  "qualifier": [],
-                  "base": "c3"
+                "qualifiedName" : {
+                  "qualifier" : [
+                  ],
+                  "base" : "c3"
                 },
-                "component": {
-                  "astNodeId": 13
+                "component" : {
+                  "astNodeId" : 13
                 },
-                "baseId": 768,
-                "maxId": 767,
-                "file": "None",
-                "queueSize": "None",
-                "stackSize": "None",
-                "priority": "None",
-                "cpu": "None",
-                "initSpecifierMap": {}
+                "baseId" : 768,
+                "maxId" : 767,
+                "file" : "None",
+                "queueSize" : "None",
+                "stackSize" : "None",
+                "priority" : "None",
+                "cpu" : "None",
+                "initSpecifierMap" : {
+                  
+                }
               },
-              "portInstance": {
-                "General": {
-                  "aNode": {
-                    "astNodeId": 3
+              "portInstance" : {
+                "General" : {
+                  "aNode" : {
+                    "astNodeId" : 3
                   },
-                  "specifier": {
-                    "kind": {
-                      "SyncInput": {}
-                    },
-                    "name": "pIn",
-                    "size": "None",
-                    "port": {
-                      "Some": {
-                        "astNodeId": 2
+                  "specifier" : {
+                    "kind" : {
+                      "SyncInput" : {
+                        
                       }
                     },
-                    "priority": "None",
-                    "queueFull": "None"
+                    "name" : "pIn",
+                    "size" : "None",
+                    "port" : {
+                      "Some" : {
+                        "astNodeId" : 2
+                      }
+                    },
+                    "priority" : "None",
+                    "queueFull" : "None"
                   },
-                  "kind": "SyncInput",
-                  "size": 1,
-                  "ty": {
-                    "DefPort": {
-                      "symbol": {
-                        "Port": {
-                          "nodeId": 0,
-                          "unqualifiedName": "P"
+                  "kind" : "SyncInput",
+                  "size" : 1,
+                  "ty" : {
+                    "DefPort" : {
+                      "symbol" : {
+                        "Port" : {
+                          "nodeId" : 0,
+                          "unqualifiedName" : "P"
                         }
                       }
                     }
                   },
-                  "importNodeIds": []
+                  "importNodeIds" : [
+                  ]
                 }
               }
             },
             [
               {
-                "from": {
-                  "loc": {
-                    "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                    "pos": "48.5",
-                    "includingLoc": "None"
+                "from" : {
+                  "loc" : {
+                    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                    "pos" : "48.5",
+                    "includingLoc" : "None"
                   },
-                  "port": {
-                    "componentInstance": {
-                      "aNode": {
-                        "astNodeId": 29
+                  "port" : {
+                    "componentInstance" : {
+                      "aNode" : {
+                        "astNodeId" : 29
                       },
-                      "qualifiedName": {
-                        "qualifier": [],
-                        "base": "c4"
+                      "qualifiedName" : {
+                        "qualifier" : [
+                        ],
+                        "base" : "c4"
                       },
-                      "component": {
-                        "astNodeId": 13
+                      "component" : {
+                        "astNodeId" : 13
                       },
-                      "baseId": 1024,
-                      "maxId": 1023,
-                      "file": "None",
-                      "queueSize": "None",
-                      "stackSize": "None",
-                      "priority": "None",
-                      "cpu": "None",
-                      "initSpecifierMap": {}
+                      "baseId" : 1024,
+                      "maxId" : 1023,
+                      "file" : "None",
+                      "queueSize" : "None",
+                      "stackSize" : "None",
+                      "priority" : "None",
+                      "cpu" : "None",
+                      "initSpecifierMap" : {
+                        
+                      }
                     },
-                    "portInstance": {
-                      "General": {
-                        "aNode": {
-                          "astNodeId": 12
+                    "portInstance" : {
+                      "General" : {
+                        "aNode" : {
+                          "astNodeId" : 12
                         },
-                        "specifier": {
-                          "kind": {
-                            "Output": {}
-                          },
-                          "name": "pOut",
-                          "size": "None",
-                          "port": {
-                            "Some": {
-                              "astNodeId": 11
+                        "specifier" : {
+                          "kind" : {
+                            "Output" : {
+                              
                             }
                           },
-                          "priority": "None",
-                          "queueFull": "None"
+                          "name" : "pOut",
+                          "size" : "None",
+                          "port" : {
+                            "Some" : {
+                              "astNodeId" : 11
+                            }
+                          },
+                          "priority" : "None",
+                          "queueFull" : "None"
                         },
-                        "kind": "Output",
-                        "size": 1,
-                        "ty": {
-                          "DefPort": {
-                            "symbol": {
-                              "Port": {
-                                "nodeId": 0,
-                                "unqualifiedName": "P"
+                        "kind" : "Output",
+                        "size" : 1,
+                        "ty" : {
+                          "DefPort" : {
+                            "symbol" : {
+                              "Port" : {
+                                "nodeId" : 0,
+                                "unqualifiedName" : "P"
                               }
                             }
                           }
                         },
-                        "importNodeIds": []
+                        "importNodeIds" : [
+                        ]
                       }
                     }
                   },
-                  "portNumber": "None"
+                  "portNumber" : "None"
                 },
-                "to": {
-                  "loc": {
-                    "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                    "pos": "48.16",
-                    "includingLoc": "None"
+                "to" : {
+                  "loc" : {
+                    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                    "pos" : "48.16",
+                    "includingLoc" : "None"
                   },
-                  "port": {
-                    "componentInstance": {
-                      "aNode": {
-                        "astNodeId": 25
+                  "port" : {
+                    "componentInstance" : {
+                      "aNode" : {
+                        "astNodeId" : 25
                       },
-                      "qualifiedName": {
-                        "qualifier": [],
-                        "base": "c3"
+                      "qualifiedName" : {
+                        "qualifier" : [
+                        ],
+                        "base" : "c3"
                       },
-                      "component": {
-                        "astNodeId": 13
+                      "component" : {
+                        "astNodeId" : 13
                       },
-                      "baseId": 768,
-                      "maxId": 767,
-                      "file": "None",
-                      "queueSize": "None",
-                      "stackSize": "None",
-                      "priority": "None",
-                      "cpu": "None",
-                      "initSpecifierMap": {}
+                      "baseId" : 768,
+                      "maxId" : 767,
+                      "file" : "None",
+                      "queueSize" : "None",
+                      "stackSize" : "None",
+                      "priority" : "None",
+                      "cpu" : "None",
+                      "initSpecifierMap" : {
+                        
+                      }
                     },
-                    "portInstance": {
-                      "General": {
-                        "aNode": {
-                          "astNodeId": 3
+                    "portInstance" : {
+                      "General" : {
+                        "aNode" : {
+                          "astNodeId" : 3
                         },
-                        "specifier": {
-                          "kind": {
-                            "SyncInput": {}
-                          },
-                          "name": "pIn",
-                          "size": "None",
-                          "port": {
-                            "Some": {
-                              "astNodeId": 2
+                        "specifier" : {
+                          "kind" : {
+                            "SyncInput" : {
+                              
                             }
                           },
-                          "priority": "None",
-                          "queueFull": "None"
+                          "name" : "pIn",
+                          "size" : "None",
+                          "port" : {
+                            "Some" : {
+                              "astNodeId" : 2
+                            }
+                          },
+                          "priority" : "None",
+                          "queueFull" : "None"
                         },
-                        "kind": "SyncInput",
-                        "size": 1,
-                        "ty": {
-                          "DefPort": {
-                            "symbol": {
-                              "Port": {
-                                "nodeId": 0,
-                                "unqualifiedName": "P"
+                        "kind" : "SyncInput",
+                        "size" : 1,
+                        "ty" : {
+                          "DefPort" : {
+                            "symbol" : {
+                              "Port" : {
+                                "nodeId" : 0,
+                                "unqualifiedName" : "P"
                               }
                             }
                           }
                         },
-                        "importNodeIds": []
+                        "importNodeIds" : [
+                        ]
                       }
                     }
                   },
-                  "portNumber": "None"
+                  "portNumber" : "None"
                 },
-                "isUnmatched": false
+                "isUnmatched" : false
               }
             ]
           ]
         ],
-        "fromPortNumberMap": [
+        "fromPortNumberMap" : [
           [
             {
-              "from": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                  "pos": "43.5",
-                  "includingLoc": "None"
+              "from" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                  "pos" : "43.5",
+                  "includingLoc" : "None"
                 },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 25
+                "port" : {
+                  "componentInstance" : {
+                    "aNode" : {
+                      "astNodeId" : 25
                     },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c3"
+                    "qualifiedName" : {
+                      "qualifier" : [
+                      ],
+                      "base" : "c3"
                     },
-                    "component": {
-                      "astNodeId": 13
+                    "component" : {
+                      "astNodeId" : 13
                     },
-                    "baseId": 768,
-                    "maxId": 767,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
+                    "baseId" : 768,
+                    "maxId" : 767,
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecifierMap" : {
+                      
+                    }
                   },
-                  "portInstance": {
-                    "General": {
-                      "aNode": {
-                        "astNodeId": 12
+                  "portInstance" : {
+                    "General" : {
+                      "aNode" : {
+                        "astNodeId" : 12
                       },
-                      "specifier": {
-                        "kind": {
-                          "Output": {}
-                        },
-                        "name": "pOut",
-                        "size": "None",
-                        "port": {
-                          "Some": {
-                            "astNodeId": 11
+                      "specifier" : {
+                        "kind" : {
+                          "Output" : {
+                            
                           }
                         },
-                        "priority": "None",
-                        "queueFull": "None"
+                        "name" : "pOut",
+                        "size" : "None",
+                        "port" : {
+                          "Some" : {
+                            "astNodeId" : 11
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None"
                       },
-                      "kind": "Output",
-                      "size": 1,
-                      "ty": {
-                        "DefPort": {
-                          "symbol": {
-                            "Port": {
-                              "nodeId": 0,
-                              "unqualifiedName": "P"
+                      "kind" : "Output",
+                      "size" : 1,
+                      "ty" : {
+                        "DefPort" : {
+                          "symbol" : {
+                            "Port" : {
+                              "nodeId" : 0,
+                              "unqualifiedName" : "P"
                             }
                           }
                         }
                       },
-                      "importNodeIds": []
+                      "importNodeIds" : [
+                      ]
                     }
                   }
                 },
-                "portNumber": "None"
+                "portNumber" : "None"
               },
-              "to": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                  "pos": "43.16",
-                  "includingLoc": "None"
+              "to" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                  "pos" : "43.16",
+                  "includingLoc" : "None"
                 },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 29
+                "port" : {
+                  "componentInstance" : {
+                    "aNode" : {
+                      "astNodeId" : 29
                     },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c4"
+                    "qualifiedName" : {
+                      "qualifier" : [
+                      ],
+                      "base" : "c4"
                     },
-                    "component": {
-                      "astNodeId": 13
+                    "component" : {
+                      "astNodeId" : 13
                     },
-                    "baseId": 1024,
-                    "maxId": 1023,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
+                    "baseId" : 1024,
+                    "maxId" : 1023,
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecifierMap" : {
+                      
+                    }
                   },
-                  "portInstance": {
-                    "General": {
-                      "aNode": {
-                        "astNodeId": 3
+                  "portInstance" : {
+                    "General" : {
+                      "aNode" : {
+                        "astNodeId" : 3
                       },
-                      "specifier": {
-                        "kind": {
-                          "SyncInput": {}
-                        },
-                        "name": "pIn",
-                        "size": "None",
-                        "port": {
-                          "Some": {
-                            "astNodeId": 2
+                      "specifier" : {
+                        "kind" : {
+                          "SyncInput" : {
+                            
                           }
                         },
-                        "priority": "None",
-                        "queueFull": "None"
+                        "name" : "pIn",
+                        "size" : "None",
+                        "port" : {
+                          "Some" : {
+                            "astNodeId" : 2
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None"
                       },
-                      "kind": "SyncInput",
-                      "size": 1,
-                      "ty": {
-                        "DefPort": {
-                          "symbol": {
-                            "Port": {
-                              "nodeId": 0,
-                              "unqualifiedName": "P"
+                      "kind" : "SyncInput",
+                      "size" : 1,
+                      "ty" : {
+                        "DefPort" : {
+                          "symbol" : {
+                            "Port" : {
+                              "nodeId" : 0,
+                              "unqualifiedName" : "P"
                             }
                           }
                         }
                       },
-                      "importNodeIds": []
+                      "importNodeIds" : [
+                      ]
                     }
                   }
                 },
-                "portNumber": "None"
+                "portNumber" : "None"
               },
-              "isUnmatched": false
+              "isUnmatched" : false
             },
             0
           ],
           [
             {
-              "from": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                  "pos": "48.5",
-                  "includingLoc": "None"
+              "from" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                  "pos" : "48.5",
+                  "includingLoc" : "None"
                 },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 29
+                "port" : {
+                  "componentInstance" : {
+                    "aNode" : {
+                      "astNodeId" : 29
                     },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c4"
+                    "qualifiedName" : {
+                      "qualifier" : [
+                      ],
+                      "base" : "c4"
                     },
-                    "component": {
-                      "astNodeId": 13
+                    "component" : {
+                      "astNodeId" : 13
                     },
-                    "baseId": 1024,
-                    "maxId": 1023,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
+                    "baseId" : 1024,
+                    "maxId" : 1023,
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecifierMap" : {
+                      
+                    }
                   },
-                  "portInstance": {
-                    "General": {
-                      "aNode": {
-                        "astNodeId": 12
+                  "portInstance" : {
+                    "General" : {
+                      "aNode" : {
+                        "astNodeId" : 12
                       },
-                      "specifier": {
-                        "kind": {
-                          "Output": {}
-                        },
-                        "name": "pOut",
-                        "size": "None",
-                        "port": {
-                          "Some": {
-                            "astNodeId": 11
+                      "specifier" : {
+                        "kind" : {
+                          "Output" : {
+                            
                           }
                         },
-                        "priority": "None",
-                        "queueFull": "None"
+                        "name" : "pOut",
+                        "size" : "None",
+                        "port" : {
+                          "Some" : {
+                            "astNodeId" : 11
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None"
                       },
-                      "kind": "Output",
-                      "size": 1,
-                      "ty": {
-                        "DefPort": {
-                          "symbol": {
-                            "Port": {
-                              "nodeId": 0,
-                              "unqualifiedName": "P"
+                      "kind" : "Output",
+                      "size" : 1,
+                      "ty" : {
+                        "DefPort" : {
+                          "symbol" : {
+                            "Port" : {
+                              "nodeId" : 0,
+                              "unqualifiedName" : "P"
                             }
                           }
                         }
                       },
-                      "importNodeIds": []
+                      "importNodeIds" : [
+                      ]
                     }
                   }
                 },
-                "portNumber": "None"
+                "portNumber" : "None"
               },
-              "to": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                  "pos": "48.16",
-                  "includingLoc": "None"
+              "to" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                  "pos" : "48.16",
+                  "includingLoc" : "None"
                 },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 25
+                "port" : {
+                  "componentInstance" : {
+                    "aNode" : {
+                      "astNodeId" : 25
                     },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c3"
+                    "qualifiedName" : {
+                      "qualifier" : [
+                      ],
+                      "base" : "c3"
                     },
-                    "component": {
-                      "astNodeId": 13
+                    "component" : {
+                      "astNodeId" : 13
                     },
-                    "baseId": 768,
-                    "maxId": 767,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
+                    "baseId" : 768,
+                    "maxId" : 767,
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecifierMap" : {
+                      
+                    }
                   },
-                  "portInstance": {
-                    "General": {
-                      "aNode": {
-                        "astNodeId": 3
+                  "portInstance" : {
+                    "General" : {
+                      "aNode" : {
+                        "astNodeId" : 3
                       },
-                      "specifier": {
-                        "kind": {
-                          "SyncInput": {}
-                        },
-                        "name": "pIn",
-                        "size": "None",
-                        "port": {
-                          "Some": {
-                            "astNodeId": 2
+                      "specifier" : {
+                        "kind" : {
+                          "SyncInput" : {
+                            
                           }
                         },
-                        "priority": "None",
-                        "queueFull": "None"
+                        "name" : "pIn",
+                        "size" : "None",
+                        "port" : {
+                          "Some" : {
+                            "astNodeId" : 2
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None"
                       },
-                      "kind": "SyncInput",
-                      "size": 1,
-                      "ty": {
-                        "DefPort": {
-                          "symbol": {
-                            "Port": {
-                              "nodeId": 0,
-                              "unqualifiedName": "P"
+                      "kind" : "SyncInput",
+                      "size" : 1,
+                      "ty" : {
+                        "DefPort" : {
+                          "symbol" : {
+                            "Port" : {
+                              "nodeId" : 0,
+                              "unqualifiedName" : "P"
                             }
                           }
                         }
                       },
-                      "importNodeIds": []
+                      "importNodeIds" : [
+                      ]
                     }
                   }
                 },
-                "portNumber": "None"
+                "portNumber" : "None"
               },
-              "isUnmatched": false
+              "isUnmatched" : false
             },
             0
           ]
         ],
-        "toPortNumberMap": [
+        "toPortNumberMap" : [
           [
             {
-              "from": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                  "pos": "48.5",
-                  "includingLoc": "None"
+              "from" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                  "pos" : "48.5",
+                  "includingLoc" : "None"
                 },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 29
+                "port" : {
+                  "componentInstance" : {
+                    "aNode" : {
+                      "astNodeId" : 29
                     },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c4"
+                    "qualifiedName" : {
+                      "qualifier" : [
+                      ],
+                      "base" : "c4"
                     },
-                    "component": {
-                      "astNodeId": 13
+                    "component" : {
+                      "astNodeId" : 13
                     },
-                    "baseId": 1024,
-                    "maxId": 1023,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
+                    "baseId" : 1024,
+                    "maxId" : 1023,
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecifierMap" : {
+                      
+                    }
                   },
-                  "portInstance": {
-                    "General": {
-                      "aNode": {
-                        "astNodeId": 12
+                  "portInstance" : {
+                    "General" : {
+                      "aNode" : {
+                        "astNodeId" : 12
                       },
-                      "specifier": {
-                        "kind": {
-                          "Output": {}
-                        },
-                        "name": "pOut",
-                        "size": "None",
-                        "port": {
-                          "Some": {
-                            "astNodeId": 11
+                      "specifier" : {
+                        "kind" : {
+                          "Output" : {
+                            
                           }
                         },
-                        "priority": "None",
-                        "queueFull": "None"
+                        "name" : "pOut",
+                        "size" : "None",
+                        "port" : {
+                          "Some" : {
+                            "astNodeId" : 11
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None"
                       },
-                      "kind": "Output",
-                      "size": 1,
-                      "ty": {
-                        "DefPort": {
-                          "symbol": {
-                            "Port": {
-                              "nodeId": 0,
-                              "unqualifiedName": "P"
+                      "kind" : "Output",
+                      "size" : 1,
+                      "ty" : {
+                        "DefPort" : {
+                          "symbol" : {
+                            "Port" : {
+                              "nodeId" : 0,
+                              "unqualifiedName" : "P"
                             }
                           }
                         }
                       },
-                      "importNodeIds": []
+                      "importNodeIds" : [
+                      ]
                     }
                   }
                 },
-                "portNumber": "None"
+                "portNumber" : "None"
               },
-              "to": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                  "pos": "48.16",
-                  "includingLoc": "None"
+              "to" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                  "pos" : "48.16",
+                  "includingLoc" : "None"
                 },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 25
+                "port" : {
+                  "componentInstance" : {
+                    "aNode" : {
+                      "astNodeId" : 25
                     },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c3"
+                    "qualifiedName" : {
+                      "qualifier" : [
+                      ],
+                      "base" : "c3"
                     },
-                    "component": {
-                      "astNodeId": 13
+                    "component" : {
+                      "astNodeId" : 13
                     },
-                    "baseId": 768,
-                    "maxId": 767,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
+                    "baseId" : 768,
+                    "maxId" : 767,
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecifierMap" : {
+                      
+                    }
                   },
-                  "portInstance": {
-                    "General": {
-                      "aNode": {
-                        "astNodeId": 3
+                  "portInstance" : {
+                    "General" : {
+                      "aNode" : {
+                        "astNodeId" : 3
                       },
-                      "specifier": {
-                        "kind": {
-                          "SyncInput": {}
-                        },
-                        "name": "pIn",
-                        "size": "None",
-                        "port": {
-                          "Some": {
-                            "astNodeId": 2
+                      "specifier" : {
+                        "kind" : {
+                          "SyncInput" : {
+                            
                           }
                         },
-                        "priority": "None",
-                        "queueFull": "None"
+                        "name" : "pIn",
+                        "size" : "None",
+                        "port" : {
+                          "Some" : {
+                            "astNodeId" : 2
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None"
                       },
-                      "kind": "SyncInput",
-                      "size": 1,
-                      "ty": {
-                        "DefPort": {
-                          "symbol": {
-                            "Port": {
-                              "nodeId": 0,
-                              "unqualifiedName": "P"
+                      "kind" : "SyncInput",
+                      "size" : 1,
+                      "ty" : {
+                        "DefPort" : {
+                          "symbol" : {
+                            "Port" : {
+                              "nodeId" : 0,
+                              "unqualifiedName" : "P"
                             }
                           }
                         }
                       },
-                      "importNodeIds": []
+                      "importNodeIds" : [
+                      ]
                     }
                   }
                 },
-                "portNumber": "None"
+                "portNumber" : "None"
               },
-              "isUnmatched": false
+              "isUnmatched" : false
             },
             0
           ],
           [
             {
-              "from": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                  "pos": "43.5",
-                  "includingLoc": "None"
+              "from" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                  "pos" : "43.5",
+                  "includingLoc" : "None"
                 },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 25
+                "port" : {
+                  "componentInstance" : {
+                    "aNode" : {
+                      "astNodeId" : 25
                     },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c3"
+                    "qualifiedName" : {
+                      "qualifier" : [
+                      ],
+                      "base" : "c3"
                     },
-                    "component": {
-                      "astNodeId": 13
+                    "component" : {
+                      "astNodeId" : 13
                     },
-                    "baseId": 768,
-                    "maxId": 767,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
+                    "baseId" : 768,
+                    "maxId" : 767,
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecifierMap" : {
+                      
+                    }
                   },
-                  "portInstance": {
-                    "General": {
-                      "aNode": {
-                        "astNodeId": 12
+                  "portInstance" : {
+                    "General" : {
+                      "aNode" : {
+                        "astNodeId" : 12
                       },
-                      "specifier": {
-                        "kind": {
-                          "Output": {}
-                        },
-                        "name": "pOut",
-                        "size": "None",
-                        "port": {
-                          "Some": {
-                            "astNodeId": 11
+                      "specifier" : {
+                        "kind" : {
+                          "Output" : {
+                            
                           }
                         },
-                        "priority": "None",
-                        "queueFull": "None"
+                        "name" : "pOut",
+                        "size" : "None",
+                        "port" : {
+                          "Some" : {
+                            "astNodeId" : 11
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None"
                       },
-                      "kind": "Output",
-                      "size": 1,
-                      "ty": {
-                        "DefPort": {
-                          "symbol": {
-                            "Port": {
-                              "nodeId": 0,
-                              "unqualifiedName": "P"
+                      "kind" : "Output",
+                      "size" : 1,
+                      "ty" : {
+                        "DefPort" : {
+                          "symbol" : {
+                            "Port" : {
+                              "nodeId" : 0,
+                              "unqualifiedName" : "P"
                             }
                           }
                         }
                       },
-                      "importNodeIds": []
+                      "importNodeIds" : [
+                      ]
                     }
                   }
                 },
-                "portNumber": "None"
+                "portNumber" : "None"
               },
-              "to": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                  "pos": "43.16",
-                  "includingLoc": "None"
+              "to" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                  "pos" : "43.16",
+                  "includingLoc" : "None"
                 },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 29
+                "port" : {
+                  "componentInstance" : {
+                    "aNode" : {
+                      "astNodeId" : 29
                     },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c4"
+                    "qualifiedName" : {
+                      "qualifier" : [
+                      ],
+                      "base" : "c4"
                     },
-                    "component": {
-                      "astNodeId": 13
+                    "component" : {
+                      "astNodeId" : 13
                     },
-                    "baseId": 1024,
-                    "maxId": 1023,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
+                    "baseId" : 1024,
+                    "maxId" : 1023,
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecifierMap" : {
+                      
+                    }
                   },
-                  "portInstance": {
-                    "General": {
-                      "aNode": {
-                        "astNodeId": 3
+                  "portInstance" : {
+                    "General" : {
+                      "aNode" : {
+                        "astNodeId" : 3
                       },
-                      "specifier": {
-                        "kind": {
-                          "SyncInput": {}
-                        },
-                        "name": "pIn",
-                        "size": "None",
-                        "port": {
-                          "Some": {
-                            "astNodeId": 2
+                      "specifier" : {
+                        "kind" : {
+                          "SyncInput" : {
+                            
                           }
                         },
-                        "priority": "None",
-                        "queueFull": "None"
+                        "name" : "pIn",
+                        "size" : "None",
+                        "port" : {
+                          "Some" : {
+                            "astNodeId" : 2
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None"
                       },
-                      "kind": "SyncInput",
-                      "size": 1,
-                      "ty": {
-                        "DefPort": {
-                          "symbol": {
-                            "Port": {
-                              "nodeId": 0,
-                              "unqualifiedName": "P"
+                      "kind" : "SyncInput",
+                      "size" : 1,
+                      "ty" : {
+                        "DefPort" : {
+                          "symbol" : {
+                            "Port" : {
+                              "nodeId" : 0,
+                              "unqualifiedName" : "P"
                             }
                           }
                         }
                       },
-                      "importNodeIds": []
+                      "importNodeIds" : [
+                      ]
                     }
                   }
                 },
-                "portNumber": "None"
+                "portNumber" : "None"
               },
-              "isUnmatched": false
+              "isUnmatched" : false
             },
             0
           ]
         ],
-        "unconnectedPortSet": [
+        "unconnectedPortSet" : [
           {
-            "componentInstance": {
-              "aNode": {
-                "astNodeId": 17
+            "componentInstance" : {
+              "aNode" : {
+                "astNodeId" : 17
               },
-              "qualifiedName": {
-                "qualifier": [],
-                "base": "c1"
+              "qualifiedName" : {
+                "qualifier" : [
+                ],
+                "base" : "c1"
               },
-              "component": {
-                "astNodeId": 13
+              "component" : {
+                "astNodeId" : 13
               },
-              "baseId": 256,
-              "maxId": 255,
-              "file": "None",
-              "queueSize": "None",
-              "stackSize": "None",
-              "priority": "None",
-              "cpu": "None",
-              "initSpecifierMap": {}
+              "baseId" : 256,
+              "maxId" : 255,
+              "file" : "None",
+              "queueSize" : "None",
+              "stackSize" : "None",
+              "priority" : "None",
+              "cpu" : "None",
+              "initSpecifierMap" : {
+                
+              }
             },
-            "portInstance": {
-              "General": {
-                "aNode": {
-                  "astNodeId": 3
+            "portInstance" : {
+              "General" : {
+                "aNode" : {
+                  "astNodeId" : 3
                 },
-                "specifier": {
-                  "kind": {
-                    "SyncInput": {}
-                  },
-                  "name": "pIn",
-                  "size": "None",
-                  "port": {
-                    "Some": {
-                      "astNodeId": 2
+                "specifier" : {
+                  "kind" : {
+                    "SyncInput" : {
+                      
                     }
                   },
-                  "priority": "None",
-                  "queueFull": "None"
+                  "name" : "pIn",
+                  "size" : "None",
+                  "port" : {
+                    "Some" : {
+                      "astNodeId" : 2
+                    }
+                  },
+                  "priority" : "None",
+                  "queueFull" : "None"
                 },
-                "kind": "SyncInput",
-                "size": 1,
-                "ty": {
-                  "DefPort": {
-                    "symbol": {
-                      "Port": {
-                        "nodeId": 0,
-                        "unqualifiedName": "P"
+                "kind" : "SyncInput",
+                "size" : 1,
+                "ty" : {
+                  "DefPort" : {
+                    "symbol" : {
+                      "Port" : {
+                        "nodeId" : 0,
+                        "unqualifiedName" : "P"
                       }
                     }
                   }
                 },
-                "importNodeIds": []
+                "importNodeIds" : [
+                ]
               }
             }
           },
           {
-            "componentInstance": {
-              "aNode": {
-                "astNodeId": 17
+            "componentInstance" : {
+              "aNode" : {
+                "astNodeId" : 17
               },
-              "qualifiedName": {
-                "qualifier": [],
-                "base": "c1"
+              "qualifiedName" : {
+                "qualifier" : [
+                ],
+                "base" : "c1"
               },
-              "component": {
-                "astNodeId": 13
+              "component" : {
+                "astNodeId" : 13
               },
-              "baseId": 256,
-              "maxId": 255,
-              "file": "None",
-              "queueSize": "None",
-              "stackSize": "None",
-              "priority": "None",
-              "cpu": "None",
-              "initSpecifierMap": {}
+              "baseId" : 256,
+              "maxId" : 255,
+              "file" : "None",
+              "queueSize" : "None",
+              "stackSize" : "None",
+              "priority" : "None",
+              "cpu" : "None",
+              "initSpecifierMap" : {
+                
+              }
             },
-            "portInstance": {
-              "General": {
-                "aNode": {
-                  "astNodeId": 12
+            "portInstance" : {
+              "General" : {
+                "aNode" : {
+                  "astNodeId" : 12
                 },
-                "specifier": {
-                  "kind": {
-                    "Output": {}
-                  },
-                  "name": "pOut",
-                  "size": "None",
-                  "port": {
-                    "Some": {
-                      "astNodeId": 11
+                "specifier" : {
+                  "kind" : {
+                    "Output" : {
+                      
                     }
                   },
-                  "priority": "None",
-                  "queueFull": "None"
+                  "name" : "pOut",
+                  "size" : "None",
+                  "port" : {
+                    "Some" : {
+                      "astNodeId" : 11
+                    }
+                  },
+                  "priority" : "None",
+                  "queueFull" : "None"
                 },
-                "kind": "Output",
-                "size": 1,
-                "ty": {
-                  "DefPort": {
-                    "symbol": {
-                      "Port": {
-                        "nodeId": 0,
-                        "unqualifiedName": "P"
+                "kind" : "Output",
+                "size" : 1,
+                "ty" : {
+                  "DefPort" : {
+                    "symbol" : {
+                      "Port" : {
+                        "nodeId" : 0,
+                        "unqualifiedName" : "P"
                       }
                     }
                   }
                 },
-                "importNodeIds": []
+                "importNodeIds" : [
+                ]
               }
             }
           }
         ]
       }
     },
-    "typeMap": {
-      "16": {
-        "Int": {
-          "Integer": {}
+    "typeMap" : {
+      "16" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "20": {
-        "Int": {
-          "Integer": {}
+      "20" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "24": {
-        "Int": {
-          "Integer": {}
+      "24" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "28": {
-        "Int": {
-          "Integer": {}
+      "28" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       }
     },
-    "useDefMap": {
-      "34": {
-        "ComponentInstance": {
-          "nodeId": 21,
-          "unqualifiedName": "c2"
+    "useDefMap" : {
+      "34" : {
+        "ComponentInstance" : {
+          "nodeId" : 21,
+          "unqualifiedName" : "c2"
         }
       },
-      "84": {
-        "ComponentInstance": {
-          "nodeId": 25,
-          "unqualifiedName": "c3"
+      "84" : {
+        "ComponentInstance" : {
+          "nodeId" : 25,
+          "unqualifiedName" : "c3"
         }
       },
-      "65": {
-        "ComponentInstance": {
-          "nodeId": 21,
-          "unqualifiedName": "c2"
+      "65" : {
+        "ComponentInstance" : {
+          "nodeId" : 21,
+          "unqualifiedName" : "c2"
         }
       },
-      "80": {
-        "ComponentInstance": {
-          "nodeId": 29,
-          "unqualifiedName": "c4"
+      "80" : {
+        "ComponentInstance" : {
+          "nodeId" : 29,
+          "unqualifiedName" : "c4"
         }
       },
-      "126": {
-        "Topology": {
-          "nodeId": 118,
-          "unqualifiedName": "Simple2"
+      "126" : {
+        "Topology" : {
+          "nodeId" : 118,
+          "unqualifiedName" : "Simple2"
         }
       },
-      "27": {
-        "Component": {
-          "nodeId": 13,
-          "unqualifiedName": "C"
+      "27" : {
+        "Component" : {
+          "nodeId" : 13,
+          "unqualifiedName" : "C"
         }
       },
-      "74": {
-        "Topology": {
-          "nodeId": 72,
-          "unqualifiedName": "Simple1"
+      "74" : {
+        "Topology" : {
+          "nodeId" : 72,
+          "unqualifiedName" : "Simple1"
         }
       },
-      "19": {
-        "Component": {
-          "nodeId": 13,
-          "unqualifiedName": "C"
+      "19" : {
+        "Component" : {
+          "nodeId" : 13,
+          "unqualifiedName" : "C"
         }
       },
-      "23": {
-        "Component": {
-          "nodeId": 13,
-          "unqualifiedName": "C"
+      "23" : {
+        "Component" : {
+          "nodeId" : 13,
+          "unqualifiedName" : "C"
         }
       },
-      "88": {
-        "ComponentInstance": {
-          "nodeId": 29,
-          "unqualifiedName": "c4"
+      "88" : {
+        "ComponentInstance" : {
+          "nodeId" : 29,
+          "unqualifiedName" : "c4"
         }
       },
-      "77": {
-        "ComponentInstance": {
-          "nodeId": 25,
-          "unqualifiedName": "c3"
+      "77" : {
+        "ComponentInstance" : {
+          "nodeId" : 25,
+          "unqualifiedName" : "c3"
         }
       },
-      "15": {
-        "Component": {
-          "nodeId": 13,
-          "unqualifiedName": "C"
+      "15" : {
+        "Component" : {
+          "nodeId" : 13,
+          "unqualifiedName" : "C"
         }
       },
-      "11": {
-        "Port": {
-          "nodeId": 0,
-          "unqualifiedName": "P"
+      "11" : {
+        "Port" : {
+          "nodeId" : 0,
+          "unqualifiedName" : "P"
         }
       },
-      "111": {
-        "ComponentInstance": {
-          "nodeId": 29,
-          "unqualifiedName": "c4"
+      "111" : {
+        "ComponentInstance" : {
+          "nodeId" : 29,
+          "unqualifiedName" : "c4"
         }
       },
-      "31": {
-        "ComponentInstance": {
-          "nodeId": 17,
-          "unqualifiedName": "c1"
+      "31" : {
+        "ComponentInstance" : {
+          "nodeId" : 17,
+          "unqualifiedName" : "c1"
         }
       },
-      "69": {
-        "ComponentInstance": {
-          "nodeId": 17,
-          "unqualifiedName": "c1"
+      "69" : {
+        "ComponentInstance" : {
+          "nodeId" : 17,
+          "unqualifiedName" : "c1"
         }
       },
-      "42": {
-        "ComponentInstance": {
-          "nodeId": 21,
-          "unqualifiedName": "c2"
+      "42" : {
+        "ComponentInstance" : {
+          "nodeId" : 21,
+          "unqualifiedName" : "c2"
         }
       },
-      "115": {
-        "ComponentInstance": {
-          "nodeId": 25,
-          "unqualifiedName": "c3"
+      "115" : {
+        "ComponentInstance" : {
+          "nodeId" : 25,
+          "unqualifiedName" : "c3"
         }
       },
-      "2": {
-        "Port": {
-          "nodeId": 0,
-          "unqualifiedName": "P"
+      "2" : {
+        "Port" : {
+          "nodeId" : 0,
+          "unqualifiedName" : "P"
         }
       },
-      "38": {
-        "ComponentInstance": {
-          "nodeId": 17,
-          "unqualifiedName": "c1"
+      "38" : {
+        "ComponentInstance" : {
+          "nodeId" : 17,
+          "unqualifiedName" : "c1"
         }
       }
     },
-    "valueMap": {
-      "16": {
-        "Integer": {
-          "value": 256
+    "valueMap" : {
+      "16" : {
+        "Integer" : {
+          "value" : 256
         }
       },
-      "20": {
-        "Integer": {
-          "value": 512
+      "20" : {
+        "Integer" : {
+          "value" : 512
         }
       },
-      "24": {
-        "Integer": {
-          "value": 768
+      "24" : {
+        "Integer" : {
+          "value" : 768
         }
       },
-      "28": {
-        "Integer": {
-          "value": 1024
+      "28" : {
+        "Integer" : {
+          "value" : 1024
         }
       }
     },
-    "stateMachineMap": {},
-    "dictionarySymbolSet": [],
-    "interfaceMap": {}
+    "stateMachineMap" : {
+      
+    },
+    "dictionarySymbolSet" : [
+    ],
+    "interfaceMap" : {
+      
+    }
   }
 }

--- a/tests/imported_topology/imported_topology_ast.json
+++ b/tests/imported_topology/imported_topology_ast.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion": "[ fpp version ]",
+  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
   "ast": [
     {
       "members": [

--- a/tests/imported_topology/imported_topology_ast.json
+++ b/tests/imported_topology/imported_topology_ast.json
@@ -1,798 +1,862 @@
 {
-  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
-  "ast": [
+  "fppVersion" : "v3.1.0a10-54-g11243e778",
+  "ast" : [
     {
-      "members": [
+      "members" : [
         [
-          [],
+          [
+          ],
           {
-            "DefPort": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "P",
-                    "params": [],
-                    "returnType": "None"
+            "DefPort" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "P",
+                    "params" : [
+                    ],
+                    "returnType" : "None"
                   },
-                  "id": 0
+                  "id" : 0
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          [],
+          [
+          ],
           {
-            "DefComponent": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "kind": {
-                      "Passive": {}
+            "DefComponent" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "kind" : {
+                      "Passive" : {
+                        
+                      }
                     },
-                    "name": "C",
-                    "members": [
+                    "name" : "C",
+                    "members" : [
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "SpecPortInstance": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "General": {
-                                    "kind": {
-                                      "SyncInput": {}
+                          "SpecPortInstance" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "General" : {
+                                    "kind" : {
+                                      "SyncInput" : {
+                                        
+                                      }
                                     },
-                                    "name": "pIn",
-                                    "size": "None",
-                                    "port": {
-                                      "Some": {
-                                        "AstNode": {
-                                          "data": {
-                                            "Unqualified": {
-                                              "name": "P"
+                                    "name" : "pIn",
+                                    "size" : "None",
+                                    "port" : {
+                                      "Some" : {
+                                        "AstNode" : {
+                                          "data" : {
+                                            "Unqualified" : {
+                                              "name" : "P"
                                             }
                                           },
-                                          "id": 2
+                                          "id" : 2
                                         }
                                       }
                                     },
-                                    "priority": "None",
-                                    "queueFull": "None"
+                                    "priority" : "None",
+                                    "queueFull" : "None"
                                   }
                                 },
-                                "id": 3
+                                "id" : 3
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "SpecPortInstance": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "General": {
-                                    "kind": {
-                                      "Output": {}
+                          "SpecPortInstance" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "General" : {
+                                    "kind" : {
+                                      "Output" : {
+                                        
+                                      }
                                     },
-                                    "name": "pOut",
-                                    "size": "None",
-                                    "port": {
-                                      "Some": {
-                                        "AstNode": {
-                                          "data": {
-                                            "Unqualified": {
-                                              "name": "P"
+                                    "name" : "pOut",
+                                    "size" : "None",
+                                    "port" : {
+                                      "Some" : {
+                                        "AstNode" : {
+                                          "data" : {
+                                            "Unqualified" : {
+                                              "name" : "P"
                                             }
                                           },
-                                          "id": 11
+                                          "id" : 11
                                         }
                                       }
                                     },
-                                    "priority": "None",
-                                    "queueFull": "None"
+                                    "priority" : "None",
+                                    "queueFull" : "None"
                                   }
                                 },
-                                "id": 12
+                                "id" : 12
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ]
                     ]
                   },
-                  "id": 13
+                  "id" : 13
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          [],
+          [
+          ],
           {
-            "DefComponentInstance": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "c1",
-                    "component": {
-                      "AstNode": {
-                        "data": {
-                          "Unqualified": {
-                            "name": "C"
+            "DefComponentInstance" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "c1",
+                    "component" : {
+                      "AstNode" : {
+                        "data" : {
+                          "Unqualified" : {
+                            "name" : "C"
                           }
                         },
-                        "id": 15
+                        "id" : 15
                       }
                     },
-                    "baseId": {
-                      "AstNode": {
-                        "data": {
-                          "ExprLiteralInt": {
-                            "value": "0x100"
+                    "baseId" : {
+                      "AstNode" : {
+                        "data" : {
+                          "ExprLiteralInt" : {
+                            "value" : "0x100"
                           }
                         },
-                        "id": 16
+                        "id" : 16
                       }
                     },
-                    "implType": "None",
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecs": []
+                    "implType" : "None",
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecs" : [
+                    ]
                   },
-                  "id": 17
+                  "id" : 17
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          [],
+          [
+          ],
           {
-            "DefComponentInstance": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "c2",
-                    "component": {
-                      "AstNode": {
-                        "data": {
-                          "Unqualified": {
-                            "name": "C"
+            "DefComponentInstance" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "c2",
+                    "component" : {
+                      "AstNode" : {
+                        "data" : {
+                          "Unqualified" : {
+                            "name" : "C"
                           }
                         },
-                        "id": 19
+                        "id" : 19
                       }
                     },
-                    "baseId": {
-                      "AstNode": {
-                        "data": {
-                          "ExprLiteralInt": {
-                            "value": "0x200"
+                    "baseId" : {
+                      "AstNode" : {
+                        "data" : {
+                          "ExprLiteralInt" : {
+                            "value" : "0x200"
                           }
                         },
-                        "id": 20
+                        "id" : 20
                       }
                     },
-                    "implType": "None",
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecs": []
+                    "implType" : "None",
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecs" : [
+                    ]
                   },
-                  "id": 21
+                  "id" : 21
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          [],
+          [
+          ],
           {
-            "DefComponentInstance": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "c3",
-                    "component": {
-                      "AstNode": {
-                        "data": {
-                          "Unqualified": {
-                            "name": "C"
+            "DefComponentInstance" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "c3",
+                    "component" : {
+                      "AstNode" : {
+                        "data" : {
+                          "Unqualified" : {
+                            "name" : "C"
                           }
                         },
-                        "id": 23
+                        "id" : 23
                       }
                     },
-                    "baseId": {
-                      "AstNode": {
-                        "data": {
-                          "ExprLiteralInt": {
-                            "value": "0x300"
+                    "baseId" : {
+                      "AstNode" : {
+                        "data" : {
+                          "ExprLiteralInt" : {
+                            "value" : "0x300"
                           }
                         },
-                        "id": 24
+                        "id" : 24
                       }
                     },
-                    "implType": "None",
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecs": []
+                    "implType" : "None",
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecs" : [
+                    ]
                   },
-                  "id": 25
+                  "id" : 25
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          [],
+          [
+          ],
           {
-            "DefComponentInstance": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "c4",
-                    "component": {
-                      "AstNode": {
-                        "data": {
-                          "Unqualified": {
-                            "name": "C"
+            "DefComponentInstance" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "c4",
+                    "component" : {
+                      "AstNode" : {
+                        "data" : {
+                          "Unqualified" : {
+                            "name" : "C"
                           }
                         },
-                        "id": 27
+                        "id" : 27
                       }
                     },
-                    "baseId": {
-                      "AstNode": {
-                        "data": {
-                          "ExprLiteralInt": {
-                            "value": "0x400"
+                    "baseId" : {
+                      "AstNode" : {
+                        "data" : {
+                          "ExprLiteralInt" : {
+                            "value" : "0x400"
                           }
                         },
-                        "id": 28
+                        "id" : 28
                       }
                     },
-                    "implType": "None",
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecs": []
+                    "implType" : "None",
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecs" : [
+                    ]
                   },
-                  "id": 29
+                  "id" : 29
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          ["A simple topology"],
+          [
+            "A simple topology"
+          ],
           {
-            "DefTopology": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "Simple1",
-                    "members": [
+            "DefTopology" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "Simple1",
+                    "members" : [
                       [
                         [
                           "This specifier says that instance c1 is part of the topology"
                         ],
                         {
-                          "SpecCompInstance": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "visibility": {
-                                    "Public": {}
+                          "SpecCompInstance" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "visibility" : {
+                                    "Public" : {
+                                      
+                                    }
                                   },
-                                  "instance": {
-                                    "AstNode": {
-                                      "data": {
-                                        "Unqualified": {
-                                          "name": "c1"
+                                  "instance" : {
+                                    "AstNode" : {
+                                      "data" : {
+                                        "Unqualified" : {
+                                          "name" : "c1"
                                         }
                                       },
-                                      "id": 31
+                                      "id" : 31
                                     }
                                   }
                                 },
-                                "id": 32
+                                "id" : 32
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
                         [
                           "This specifier says that instance c2 is part of the topology"
                         ],
                         {
-                          "SpecCompInstance": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "visibility": {
-                                    "Private": {}
+                          "SpecCompInstance" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "visibility" : {
+                                    "Private" : {
+                                      
+                                    }
                                   },
-                                  "instance": {
-                                    "AstNode": {
-                                      "data": {
-                                        "Unqualified": {
-                                          "name": "c2"
+                                  "instance" : {
+                                    "AstNode" : {
+                                      "data" : {
+                                        "Unqualified" : {
+                                          "name" : "c2"
                                         }
                                       },
-                                      "id": 34
+                                      "id" : 34
                                     }
                                   }
                                 },
-                                "id": 35
+                                "id" : 35
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        ["This code specifies a connection graph C1"],
+                        [
+                          "This code specifies a connection graph C1"
+                        ],
                         {
-                          "SpecConnectionGraph": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "Direct": {
-                                    "name": "C1",
-                                    "connections": [
+                          "SpecConnectionGraph" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "Direct" : {
+                                    "name" : "C1",
+                                    "connections" : [
                                       {
-                                        "isUnmatched": false,
-                                        "fromPort": {
-                                          "AstNode": {
-                                            "data": {
-                                              "componentInstance": {
-                                                "AstNode": {
-                                                  "data": {
-                                                    "Unqualified": {
-                                                      "name": "c1"
+                                        "isUnmatched" : false,
+                                        "fromPort" : {
+                                          "AstNode" : {
+                                            "data" : {
+                                              "componentInstance" : {
+                                                "AstNode" : {
+                                                  "data" : {
+                                                    "Unqualified" : {
+                                                      "name" : "c1"
                                                     }
                                                   },
-                                                  "id": 38
+                                                  "id" : 38
                                                 }
                                               },
-                                              "portName": {
-                                                "AstNode": {
-                                                  "data": "pOut",
-                                                  "id": 37
+                                              "portName" : {
+                                                "AstNode" : {
+                                                  "data" : "pOut",
+                                                  "id" : 37
                                                 }
                                               }
                                             },
-                                            "id": 39
+                                            "id" : 39
                                           }
                                         },
-                                        "fromIndex": "None",
-                                        "toPort": {
-                                          "AstNode": {
-                                            "data": {
-                                              "componentInstance": {
-                                                "AstNode": {
-                                                  "data": {
-                                                    "Unqualified": {
-                                                      "name": "c2"
+                                        "fromIndex" : "None",
+                                        "toPort" : {
+                                          "AstNode" : {
+                                            "data" : {
+                                              "componentInstance" : {
+                                                "AstNode" : {
+                                                  "data" : {
+                                                    "Unqualified" : {
+                                                      "name" : "c2"
                                                     }
                                                   },
-                                                  "id": 42
+                                                  "id" : 42
                                                 }
                                               },
-                                              "portName": {
-                                                "AstNode": {
-                                                  "data": "pIn",
-                                                  "id": 41
+                                              "portName" : {
+                                                "AstNode" : {
+                                                  "data" : "pIn",
+                                                  "id" : 41
                                                 }
                                               }
                                             },
-                                            "id": 43
+                                            "id" : 43
                                           }
                                         },
-                                        "toIndex": "None"
+                                        "toIndex" : "None"
                                       }
                                     ]
                                   }
                                 },
-                                "id": 44
+                                "id" : 44
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        ["This code specifies a connection graph C2"],
+                        [
+                          "This code specifies a connection graph C2"
+                        ],
                         {
-                          "SpecConnectionGraph": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "Direct": {
-                                    "name": "C2",
-                                    "connections": [
+                          "SpecConnectionGraph" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "Direct" : {
+                                    "name" : "C2",
+                                    "connections" : [
                                       {
-                                        "isUnmatched": false,
-                                        "fromPort": {
-                                          "AstNode": {
-                                            "data": {
-                                              "componentInstance": {
-                                                "AstNode": {
-                                                  "data": {
-                                                    "Unqualified": {
-                                                      "name": "c2"
+                                        "isUnmatched" : false,
+                                        "fromPort" : {
+                                          "AstNode" : {
+                                            "data" : {
+                                              "componentInstance" : {
+                                                "AstNode" : {
+                                                  "data" : {
+                                                    "Unqualified" : {
+                                                      "name" : "c2"
                                                     }
                                                   },
-                                                  "id": 65
+                                                  "id" : 65
                                                 }
                                               },
-                                              "portName": {
-                                                "AstNode": {
-                                                  "data": "pOut",
-                                                  "id": 64
+                                              "portName" : {
+                                                "AstNode" : {
+                                                  "data" : "pOut",
+                                                  "id" : 64
                                                 }
                                               }
                                             },
-                                            "id": 66
+                                            "id" : 66
                                           }
                                         },
-                                        "fromIndex": "None",
-                                        "toPort": {
-                                          "AstNode": {
-                                            "data": {
-                                              "componentInstance": {
-                                                "AstNode": {
-                                                  "data": {
-                                                    "Unqualified": {
-                                                      "name": "c1"
+                                        "fromIndex" : "None",
+                                        "toPort" : {
+                                          "AstNode" : {
+                                            "data" : {
+                                              "componentInstance" : {
+                                                "AstNode" : {
+                                                  "data" : {
+                                                    "Unqualified" : {
+                                                      "name" : "c1"
                                                     }
                                                   },
-                                                  "id": 69
+                                                  "id" : 69
                                                 }
                                               },
-                                              "portName": {
-                                                "AstNode": {
-                                                  "data": "pIn",
-                                                  "id": 68
+                                              "portName" : {
+                                                "AstNode" : {
+                                                  "data" : "pIn",
+                                                  "id" : 68
                                                 }
                                               }
                                             },
-                                            "id": 70
+                                            "id" : 70
                                           }
                                         },
-                                        "toIndex": "None"
+                                        "toIndex" : "None"
                                       }
                                     ]
                                   }
                                 },
-                                "id": 71
+                                "id" : 71
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ]
                     ]
                   },
-                  "id": 72
+                  "id" : 72
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          ["Another simple topology"],
+          [
+            "Another simple topology"
+          ],
           {
-            "DefTopology": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "Simple2",
-                    "members": [
+            "DefTopology" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "Simple2",
+                    "members" : [
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "SpecTopImport": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "sym": {
-                                    "AstNode": {
-                                      "data": {
-                                        "Unqualified": {
-                                          "name": "Simple1"
+                          "SpecTopImport" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "sym" : {
+                                    "AstNode" : {
+                                      "data" : {
+                                        "Unqualified" : {
+                                          "name" : "Simple1"
                                         }
                                       },
-                                      "id": 74
+                                      "id" : 74
                                     }
                                   }
                                 },
-                                "id": 75
+                                "id" : 75
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
                         [
                           "This specifier says that instance c3 is part of the topology"
                         ],
                         {
-                          "SpecCompInstance": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "visibility": {
-                                    "Public": {}
+                          "SpecCompInstance" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "visibility" : {
+                                    "Public" : {
+                                      
+                                    }
                                   },
-                                  "instance": {
-                                    "AstNode": {
-                                      "data": {
-                                        "Unqualified": {
-                                          "name": "c3"
+                                  "instance" : {
+                                    "AstNode" : {
+                                      "data" : {
+                                        "Unqualified" : {
+                                          "name" : "c3"
                                         }
                                       },
-                                      "id": 77
+                                      "id" : 77
                                     }
                                   }
                                 },
-                                "id": 78
+                                "id" : 78
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
                         [
                           "This specifier says that instance c4 is part of the topology"
                         ],
                         {
-                          "SpecCompInstance": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "visibility": {
-                                    "Public": {}
+                          "SpecCompInstance" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "visibility" : {
+                                    "Public" : {
+                                      
+                                    }
                                   },
-                                  "instance": {
-                                    "AstNode": {
-                                      "data": {
-                                        "Unqualified": {
-                                          "name": "c4"
+                                  "instance" : {
+                                    "AstNode" : {
+                                      "data" : {
+                                        "Unqualified" : {
+                                          "name" : "c4"
                                         }
                                       },
-                                      "id": 80
+                                      "id" : 80
                                     }
                                   }
                                 },
-                                "id": 81
+                                "id" : 81
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        ["This code specifies a connection graph C1"],
+                        [
+                          "This code specifies a connection graph C1"
+                        ],
                         {
-                          "SpecConnectionGraph": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "Direct": {
-                                    "name": "C3",
-                                    "connections": [
+                          "SpecConnectionGraph" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "Direct" : {
+                                    "name" : "C3",
+                                    "connections" : [
                                       {
-                                        "isUnmatched": false,
-                                        "fromPort": {
-                                          "AstNode": {
-                                            "data": {
-                                              "componentInstance": {
-                                                "AstNode": {
-                                                  "data": {
-                                                    "Unqualified": {
-                                                      "name": "c3"
+                                        "isUnmatched" : false,
+                                        "fromPort" : {
+                                          "AstNode" : {
+                                            "data" : {
+                                              "componentInstance" : {
+                                                "AstNode" : {
+                                                  "data" : {
+                                                    "Unqualified" : {
+                                                      "name" : "c3"
                                                     }
                                                   },
-                                                  "id": 84
+                                                  "id" : 84
                                                 }
                                               },
-                                              "portName": {
-                                                "AstNode": {
-                                                  "data": "pOut",
-                                                  "id": 83
+                                              "portName" : {
+                                                "AstNode" : {
+                                                  "data" : "pOut",
+                                                  "id" : 83
                                                 }
                                               }
                                             },
-                                            "id": 85
+                                            "id" : 85
                                           }
                                         },
-                                        "fromIndex": "None",
-                                        "toPort": {
-                                          "AstNode": {
-                                            "data": {
-                                              "componentInstance": {
-                                                "AstNode": {
-                                                  "data": {
-                                                    "Unqualified": {
-                                                      "name": "c4"
+                                        "fromIndex" : "None",
+                                        "toPort" : {
+                                          "AstNode" : {
+                                            "data" : {
+                                              "componentInstance" : {
+                                                "AstNode" : {
+                                                  "data" : {
+                                                    "Unqualified" : {
+                                                      "name" : "c4"
                                                     }
                                                   },
-                                                  "id": 88
+                                                  "id" : 88
                                                 }
                                               },
-                                              "portName": {
-                                                "AstNode": {
-                                                  "data": "pIn",
-                                                  "id": 87
+                                              "portName" : {
+                                                "AstNode" : {
+                                                  "data" : "pIn",
+                                                  "id" : 87
                                                 }
                                               }
                                             },
-                                            "id": 89
+                                            "id" : 89
                                           }
                                         },
-                                        "toIndex": "None"
+                                        "toIndex" : "None"
                                       }
                                     ]
                                   }
                                 },
-                                "id": 90
+                                "id" : 90
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        ["This code specifies a connection graph C2"],
+                        [
+                          "This code specifies a connection graph C2"
+                        ],
                         {
-                          "SpecConnectionGraph": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "Direct": {
-                                    "name": "C4",
-                                    "connections": [
+                          "SpecConnectionGraph" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "Direct" : {
+                                    "name" : "C4",
+                                    "connections" : [
                                       {
-                                        "isUnmatched": false,
-                                        "fromPort": {
-                                          "AstNode": {
-                                            "data": {
-                                              "componentInstance": {
-                                                "AstNode": {
-                                                  "data": {
-                                                    "Unqualified": {
-                                                      "name": "c4"
+                                        "isUnmatched" : false,
+                                        "fromPort" : {
+                                          "AstNode" : {
+                                            "data" : {
+                                              "componentInstance" : {
+                                                "AstNode" : {
+                                                  "data" : {
+                                                    "Unqualified" : {
+                                                      "name" : "c4"
                                                     }
                                                   },
-                                                  "id": 111
+                                                  "id" : 111
                                                 }
                                               },
-                                              "portName": {
-                                                "AstNode": {
-                                                  "data": "pOut",
-                                                  "id": 110
+                                              "portName" : {
+                                                "AstNode" : {
+                                                  "data" : "pOut",
+                                                  "id" : 110
                                                 }
                                               }
                                             },
-                                            "id": 112
+                                            "id" : 112
                                           }
                                         },
-                                        "fromIndex": "None",
-                                        "toPort": {
-                                          "AstNode": {
-                                            "data": {
-                                              "componentInstance": {
-                                                "AstNode": {
-                                                  "data": {
-                                                    "Unqualified": {
-                                                      "name": "c3"
+                                        "fromIndex" : "None",
+                                        "toPort" : {
+                                          "AstNode" : {
+                                            "data" : {
+                                              "componentInstance" : {
+                                                "AstNode" : {
+                                                  "data" : {
+                                                    "Unqualified" : {
+                                                      "name" : "c3"
                                                     }
                                                   },
-                                                  "id": 115
+                                                  "id" : 115
                                                 }
                                               },
-                                              "portName": {
-                                                "AstNode": {
-                                                  "data": "pIn",
-                                                  "id": 114
+                                              "portName" : {
+                                                "AstNode" : {
+                                                  "data" : "pIn",
+                                                  "id" : 114
                                                 }
                                               }
                                             },
-                                            "id": 116
+                                            "id" : 116
                                           }
                                         },
-                                        "toIndex": "None"
+                                        "toIndex" : "None"
                                       }
                                     ]
                                   }
                                 },
-                                "id": 117
+                                "id" : 117
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ]
                     ]
                   },
-                  "id": 118
+                  "id" : 118
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          ["A third Simple Topology"],
+          [
+            "A third Simple Topology"
+          ],
           {
-            "DefTopology": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "Simple3",
-                    "members": [
+            "DefTopology" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "Simple3",
+                    "members" : [
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "SpecTopImport": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "sym": {
-                                    "AstNode": {
-                                      "data": {
-                                        "Unqualified": {
-                                          "name": "Simple2"
+                          "SpecTopImport" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "sym" : {
+                                    "AstNode" : {
+                                      "data" : {
+                                        "Unqualified" : {
+                                          "name" : "Simple2"
                                         }
                                       },
-                                      "id": 126
+                                      "id" : 126
                                     }
                                   }
                                 },
-                                "id": 127
+                                "id" : 127
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ]
                     ]
                   },
-                  "id": 128
+                  "id" : 128
                 }
               }
             }
           },
-          []
+          [
+          ]
         ]
       ]
     }

--- a/tests/imported_topology/imported_topology_locations.json
+++ b/tests/imported_topology/imported_topology_locations.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion": "[ fpp version ]",
+  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
   "locationMap": {
     "0": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",

--- a/tests/imported_topology/imported_topology_locations.json
+++ b/tests/imported_topology/imported_topology_locations.json
@@ -1,650 +1,650 @@
 {
-  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
-  "locationMap": {
-    "0": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "1.1",
-      "includingLoc": "None"
-    },
-    "1": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "4.24",
-      "includingLoc": "None"
-    },
-    "2": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "4.24",
-      "includingLoc": "None"
-    },
-    "3": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "4.3",
-      "includingLoc": "None"
-    },
-    "4": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "5.21",
-      "includingLoc": "None"
-    },
-    "5": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "5.21",
-      "includingLoc": "None"
-    },
-    "6": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "5.3",
-      "includingLoc": "None"
-    },
-    "7": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "5.21",
-      "includingLoc": "None"
-    },
-    "8": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "5.21",
-      "includingLoc": "None"
-    },
-    "9": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "5.3",
-      "includingLoc": "None"
-    },
-    "10": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "5.21",
-      "includingLoc": "None"
-    },
-    "11": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "5.21",
-      "includingLoc": "None"
-    },
-    "12": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "5.3",
-      "includingLoc": "None"
-    },
-    "13": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "3.1",
-      "includingLoc": "None"
-    },
-    "14": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "8.14",
-      "includingLoc": "None"
-    },
-    "15": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "8.14",
-      "includingLoc": "None"
-    },
-    "16": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "8.24",
-      "includingLoc": "None"
-    },
-    "17": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "8.1",
-      "includingLoc": "None"
-    },
-    "18": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "9.14",
-      "includingLoc": "None"
-    },
-    "19": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "9.14",
-      "includingLoc": "None"
-    },
-    "20": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "9.24",
-      "includingLoc": "None"
-    },
-    "21": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "9.1",
-      "includingLoc": "None"
-    },
-    "22": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "10.14",
-      "includingLoc": "None"
-    },
-    "23": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "10.14",
-      "includingLoc": "None"
-    },
-    "24": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "10.24",
-      "includingLoc": "None"
-    },
-    "25": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "10.1",
-      "includingLoc": "None"
-    },
-    "26": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "11.14",
-      "includingLoc": "None"
-    },
-    "27": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "11.14",
-      "includingLoc": "None"
-    },
-    "28": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "11.24",
-      "includingLoc": "None"
-    },
-    "29": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "11.1",
-      "includingLoc": "None"
-    },
-    "30": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "17.12",
-      "includingLoc": "None"
-    },
-    "31": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "17.12",
-      "includingLoc": "None"
-    },
-    "32": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "17.3",
-      "includingLoc": "None"
-    },
-    "33": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "19.20",
-      "includingLoc": "None"
-    },
-    "34": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "19.20",
-      "includingLoc": "None"
-    },
-    "35": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "19.3",
-      "includingLoc": "None"
-    },
-    "36": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "23.5",
-      "includingLoc": "None"
-    },
-    "37": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "23.8",
-      "includingLoc": "None"
-    },
-    "38": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "23.5",
-      "includingLoc": "None"
-    },
-    "39": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "23.5",
-      "includingLoc": "None"
-    },
-    "40": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "23.16",
-      "includingLoc": "None"
-    },
-    "41": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "23.19",
-      "includingLoc": "None"
-    },
-    "42": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "23.16",
-      "includingLoc": "None"
-    },
-    "43": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "23.16",
-      "includingLoc": "None"
-    },
-    "44": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "22.3",
-      "includingLoc": "None"
-    },
-    "45": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "28.5",
-      "includingLoc": "None"
-    },
-    "46": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "28.8",
-      "includingLoc": "None"
-    },
-    "47": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "28.5",
-      "includingLoc": "None"
-    },
-    "48": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "28.5",
-      "includingLoc": "None"
-    },
-    "49": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "28.16",
-      "includingLoc": "None"
-    },
-    "50": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "28.19",
-      "includingLoc": "None"
-    },
-    "51": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "28.16",
-      "includingLoc": "None"
-    },
-    "52": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "28.16",
-      "includingLoc": "None"
-    },
-    "53": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "27.3",
-      "includingLoc": "None"
-    },
-    "54": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "28.5",
-      "includingLoc": "None"
-    },
-    "55": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "28.8",
-      "includingLoc": "None"
-    },
-    "56": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "28.5",
-      "includingLoc": "None"
-    },
-    "57": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "28.5",
-      "includingLoc": "None"
-    },
-    "58": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "28.16",
-      "includingLoc": "None"
-    },
-    "59": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "28.19",
-      "includingLoc": "None"
-    },
-    "60": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "28.16",
-      "includingLoc": "None"
-    },
-    "61": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "28.16",
-      "includingLoc": "None"
-    },
-    "62": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "27.3",
-      "includingLoc": "None"
-    },
-    "63": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "28.5",
-      "includingLoc": "None"
-    },
-    "64": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "28.8",
-      "includingLoc": "None"
-    },
-    "65": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "28.5",
-      "includingLoc": "None"
-    },
-    "66": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "28.5",
-      "includingLoc": "None"
-    },
-    "67": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "28.16",
-      "includingLoc": "None"
-    },
-    "68": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "28.19",
-      "includingLoc": "None"
-    },
-    "69": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "28.16",
-      "includingLoc": "None"
-    },
-    "70": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "28.16",
-      "includingLoc": "None"
-    },
-    "71": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "27.3",
-      "includingLoc": "None"
-    },
-    "72": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "14.1",
-      "includingLoc": "None"
-    },
-    "73": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "35.10",
-      "includingLoc": "None"
-    },
-    "74": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "35.10",
-      "includingLoc": "None"
-    },
-    "75": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "35.3",
-      "includingLoc": "None"
-    },
-    "76": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "37.12",
-      "includingLoc": "None"
-    },
-    "77": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "37.12",
-      "includingLoc": "None"
-    },
-    "78": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "37.3",
-      "includingLoc": "None"
-    },
-    "79": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "39.12",
-      "includingLoc": "None"
-    },
-    "80": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "39.12",
-      "includingLoc": "None"
-    },
-    "81": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "39.3",
-      "includingLoc": "None"
-    },
-    "82": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "43.5",
-      "includingLoc": "None"
-    },
-    "83": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "43.8",
-      "includingLoc": "None"
-    },
-    "84": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "43.5",
-      "includingLoc": "None"
-    },
-    "85": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "43.5",
-      "includingLoc": "None"
-    },
-    "86": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "43.16",
-      "includingLoc": "None"
-    },
-    "87": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "43.19",
-      "includingLoc": "None"
-    },
-    "88": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "43.16",
-      "includingLoc": "None"
-    },
-    "89": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "43.16",
-      "includingLoc": "None"
-    },
-    "90": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "42.3",
-      "includingLoc": "None"
-    },
-    "91": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "48.5",
-      "includingLoc": "None"
-    },
-    "92": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "48.8",
-      "includingLoc": "None"
-    },
-    "93": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "48.5",
-      "includingLoc": "None"
-    },
-    "94": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "48.5",
-      "includingLoc": "None"
-    },
-    "95": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "48.16",
-      "includingLoc": "None"
-    },
-    "96": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "48.19",
-      "includingLoc": "None"
-    },
-    "97": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "48.16",
-      "includingLoc": "None"
-    },
-    "98": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "48.16",
-      "includingLoc": "None"
-    },
-    "99": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "47.3",
-      "includingLoc": "None"
-    },
-    "100": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "48.5",
-      "includingLoc": "None"
-    },
-    "101": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "48.8",
-      "includingLoc": "None"
-    },
-    "102": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "48.5",
-      "includingLoc": "None"
-    },
-    "103": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "48.5",
-      "includingLoc": "None"
-    },
-    "104": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "48.16",
-      "includingLoc": "None"
-    },
-    "105": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "48.19",
-      "includingLoc": "None"
-    },
-    "106": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "48.16",
-      "includingLoc": "None"
-    },
-    "107": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "48.16",
-      "includingLoc": "None"
-    },
-    "108": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "47.3",
-      "includingLoc": "None"
-    },
-    "109": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "48.5",
-      "includingLoc": "None"
-    },
-    "110": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "48.8",
-      "includingLoc": "None"
-    },
-    "111": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "48.5",
-      "includingLoc": "None"
-    },
-    "112": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "48.5",
-      "includingLoc": "None"
-    },
-    "113": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "48.16",
-      "includingLoc": "None"
-    },
-    "114": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "48.19",
-      "includingLoc": "None"
-    },
-    "115": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "48.16",
-      "includingLoc": "None"
-    },
-    "116": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "48.16",
-      "includingLoc": "None"
-    },
-    "117": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "47.3",
-      "includingLoc": "None"
-    },
-    "118": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "34.1",
-      "includingLoc": "None"
-    },
-    "119": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "55.10",
-      "includingLoc": "None"
-    },
-    "120": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "55.10",
-      "includingLoc": "None"
-    },
-    "121": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "55.3",
-      "includingLoc": "None"
-    },
-    "122": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "55.10",
-      "includingLoc": "None"
-    },
-    "123": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "55.10",
-      "includingLoc": "None"
-    },
-    "124": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "55.3",
-      "includingLoc": "None"
-    },
-    "125": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "55.10",
-      "includingLoc": "None"
-    },
-    "126": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "55.10",
-      "includingLoc": "None"
-    },
-    "127": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "55.3",
-      "includingLoc": "None"
-    },
-    "128": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-      "pos": "54.1",
-      "includingLoc": "None"
+  "fppVersion" : "v3.1.0a10-54-g11243e778",
+  "locationMap" : {
+    "0" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "1.1",
+      "includingLoc" : "None"
+    },
+    "1" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "4.24",
+      "includingLoc" : "None"
+    },
+    "2" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "4.24",
+      "includingLoc" : "None"
+    },
+    "3" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "4.3",
+      "includingLoc" : "None"
+    },
+    "4" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "5.21",
+      "includingLoc" : "None"
+    },
+    "5" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "5.21",
+      "includingLoc" : "None"
+    },
+    "6" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "5.3",
+      "includingLoc" : "None"
+    },
+    "7" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "5.21",
+      "includingLoc" : "None"
+    },
+    "8" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "5.21",
+      "includingLoc" : "None"
+    },
+    "9" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "5.3",
+      "includingLoc" : "None"
+    },
+    "10" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "5.21",
+      "includingLoc" : "None"
+    },
+    "11" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "5.21",
+      "includingLoc" : "None"
+    },
+    "12" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "5.3",
+      "includingLoc" : "None"
+    },
+    "13" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "3.1",
+      "includingLoc" : "None"
+    },
+    "14" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "8.14",
+      "includingLoc" : "None"
+    },
+    "15" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "8.14",
+      "includingLoc" : "None"
+    },
+    "16" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "8.24",
+      "includingLoc" : "None"
+    },
+    "17" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "8.1",
+      "includingLoc" : "None"
+    },
+    "18" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "9.14",
+      "includingLoc" : "None"
+    },
+    "19" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "9.14",
+      "includingLoc" : "None"
+    },
+    "20" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "9.24",
+      "includingLoc" : "None"
+    },
+    "21" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "9.1",
+      "includingLoc" : "None"
+    },
+    "22" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "10.14",
+      "includingLoc" : "None"
+    },
+    "23" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "10.14",
+      "includingLoc" : "None"
+    },
+    "24" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "10.24",
+      "includingLoc" : "None"
+    },
+    "25" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "10.1",
+      "includingLoc" : "None"
+    },
+    "26" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "11.14",
+      "includingLoc" : "None"
+    },
+    "27" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "11.14",
+      "includingLoc" : "None"
+    },
+    "28" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "11.24",
+      "includingLoc" : "None"
+    },
+    "29" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "11.1",
+      "includingLoc" : "None"
+    },
+    "30" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "17.12",
+      "includingLoc" : "None"
+    },
+    "31" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "17.12",
+      "includingLoc" : "None"
+    },
+    "32" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "17.3",
+      "includingLoc" : "None"
+    },
+    "33" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "19.20",
+      "includingLoc" : "None"
+    },
+    "34" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "19.20",
+      "includingLoc" : "None"
+    },
+    "35" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "19.3",
+      "includingLoc" : "None"
+    },
+    "36" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "23.5",
+      "includingLoc" : "None"
+    },
+    "37" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "23.8",
+      "includingLoc" : "None"
+    },
+    "38" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "23.5",
+      "includingLoc" : "None"
+    },
+    "39" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "23.5",
+      "includingLoc" : "None"
+    },
+    "40" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "23.16",
+      "includingLoc" : "None"
+    },
+    "41" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "23.19",
+      "includingLoc" : "None"
+    },
+    "42" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "23.16",
+      "includingLoc" : "None"
+    },
+    "43" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "23.16",
+      "includingLoc" : "None"
+    },
+    "44" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "22.3",
+      "includingLoc" : "None"
+    },
+    "45" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "28.5",
+      "includingLoc" : "None"
+    },
+    "46" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "28.8",
+      "includingLoc" : "None"
+    },
+    "47" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "28.5",
+      "includingLoc" : "None"
+    },
+    "48" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "28.5",
+      "includingLoc" : "None"
+    },
+    "49" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "28.16",
+      "includingLoc" : "None"
+    },
+    "50" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "28.19",
+      "includingLoc" : "None"
+    },
+    "51" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "28.16",
+      "includingLoc" : "None"
+    },
+    "52" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "28.16",
+      "includingLoc" : "None"
+    },
+    "53" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "27.3",
+      "includingLoc" : "None"
+    },
+    "54" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "28.5",
+      "includingLoc" : "None"
+    },
+    "55" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "28.8",
+      "includingLoc" : "None"
+    },
+    "56" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "28.5",
+      "includingLoc" : "None"
+    },
+    "57" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "28.5",
+      "includingLoc" : "None"
+    },
+    "58" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "28.16",
+      "includingLoc" : "None"
+    },
+    "59" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "28.19",
+      "includingLoc" : "None"
+    },
+    "60" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "28.16",
+      "includingLoc" : "None"
+    },
+    "61" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "28.16",
+      "includingLoc" : "None"
+    },
+    "62" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "27.3",
+      "includingLoc" : "None"
+    },
+    "63" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "28.5",
+      "includingLoc" : "None"
+    },
+    "64" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "28.8",
+      "includingLoc" : "None"
+    },
+    "65" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "28.5",
+      "includingLoc" : "None"
+    },
+    "66" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "28.5",
+      "includingLoc" : "None"
+    },
+    "67" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "28.16",
+      "includingLoc" : "None"
+    },
+    "68" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "28.19",
+      "includingLoc" : "None"
+    },
+    "69" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "28.16",
+      "includingLoc" : "None"
+    },
+    "70" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "28.16",
+      "includingLoc" : "None"
+    },
+    "71" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "27.3",
+      "includingLoc" : "None"
+    },
+    "72" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "14.1",
+      "includingLoc" : "None"
+    },
+    "73" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "35.10",
+      "includingLoc" : "None"
+    },
+    "74" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "35.10",
+      "includingLoc" : "None"
+    },
+    "75" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "35.3",
+      "includingLoc" : "None"
+    },
+    "76" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "37.12",
+      "includingLoc" : "None"
+    },
+    "77" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "37.12",
+      "includingLoc" : "None"
+    },
+    "78" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "37.3",
+      "includingLoc" : "None"
+    },
+    "79" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "39.12",
+      "includingLoc" : "None"
+    },
+    "80" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "39.12",
+      "includingLoc" : "None"
+    },
+    "81" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "39.3",
+      "includingLoc" : "None"
+    },
+    "82" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "43.5",
+      "includingLoc" : "None"
+    },
+    "83" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "43.8",
+      "includingLoc" : "None"
+    },
+    "84" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "43.5",
+      "includingLoc" : "None"
+    },
+    "85" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "43.5",
+      "includingLoc" : "None"
+    },
+    "86" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "43.16",
+      "includingLoc" : "None"
+    },
+    "87" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "43.19",
+      "includingLoc" : "None"
+    },
+    "88" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "43.16",
+      "includingLoc" : "None"
+    },
+    "89" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "43.16",
+      "includingLoc" : "None"
+    },
+    "90" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "42.3",
+      "includingLoc" : "None"
+    },
+    "91" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "48.5",
+      "includingLoc" : "None"
+    },
+    "92" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "48.8",
+      "includingLoc" : "None"
+    },
+    "93" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "48.5",
+      "includingLoc" : "None"
+    },
+    "94" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "48.5",
+      "includingLoc" : "None"
+    },
+    "95" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "48.16",
+      "includingLoc" : "None"
+    },
+    "96" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "48.19",
+      "includingLoc" : "None"
+    },
+    "97" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "48.16",
+      "includingLoc" : "None"
+    },
+    "98" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "48.16",
+      "includingLoc" : "None"
+    },
+    "99" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "47.3",
+      "includingLoc" : "None"
+    },
+    "100" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "48.5",
+      "includingLoc" : "None"
+    },
+    "101" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "48.8",
+      "includingLoc" : "None"
+    },
+    "102" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "48.5",
+      "includingLoc" : "None"
+    },
+    "103" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "48.5",
+      "includingLoc" : "None"
+    },
+    "104" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "48.16",
+      "includingLoc" : "None"
+    },
+    "105" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "48.19",
+      "includingLoc" : "None"
+    },
+    "106" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "48.16",
+      "includingLoc" : "None"
+    },
+    "107" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "48.16",
+      "includingLoc" : "None"
+    },
+    "108" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "47.3",
+      "includingLoc" : "None"
+    },
+    "109" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "48.5",
+      "includingLoc" : "None"
+    },
+    "110" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "48.8",
+      "includingLoc" : "None"
+    },
+    "111" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "48.5",
+      "includingLoc" : "None"
+    },
+    "112" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "48.5",
+      "includingLoc" : "None"
+    },
+    "113" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "48.16",
+      "includingLoc" : "None"
+    },
+    "114" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "48.19",
+      "includingLoc" : "None"
+    },
+    "115" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "48.16",
+      "includingLoc" : "None"
+    },
+    "116" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "48.16",
+      "includingLoc" : "None"
+    },
+    "117" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "47.3",
+      "includingLoc" : "None"
+    },
+    "118" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "34.1",
+      "includingLoc" : "None"
+    },
+    "119" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "55.10",
+      "includingLoc" : "None"
+    },
+    "120" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "55.10",
+      "includingLoc" : "None"
+    },
+    "121" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "55.3",
+      "includingLoc" : "None"
+    },
+    "122" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "55.10",
+      "includingLoc" : "None"
+    },
+    "123" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "55.10",
+      "includingLoc" : "None"
+    },
+    "124" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "55.3",
+      "includingLoc" : "None"
+    },
+    "125" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "55.10",
+      "includingLoc" : "None"
+    },
+    "126" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "55.10",
+      "includingLoc" : "None"
+    },
+    "127" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "55.3",
+      "includingLoc" : "None"
+    },
+    "128" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+      "pos" : "54.1",
+      "includingLoc" : "None"
     }
   }
 }

--- a/tests/interfaces/interfaces_analysis.json
+++ b/tests/interfaces/interfaces_analysis.json
@@ -1,625 +1,725 @@
 {
-  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
-  "analysis": {
-    "componentInstanceMap": {},
-    "componentMap": {
-      "71": {
-        "aNode": {
-          "astNodeId": 71
+  "fppVersion" : "v3.1.0a10-54-g11243e778",
+  "analysis" : {
+    "componentInstanceMap" : {
+      
+    },
+    "componentMap" : {
+      "71" : {
+        "aNode" : {
+          "astNodeId" : 71
         },
-        "portMap": {
-          "cmdRegOut": {
-            "Special": {
-              "aNode": {
-                "astNodeId": 7
+        "portMap" : {
+          "cmdRegOut" : {
+            "Special" : {
+              "aNode" : {
+                "astNodeId" : 7
               },
-              "specifier": {
-                "inputKind": "None",
-                "kind": {
-                  "CommandReg": {}
-                },
-                "name": "cmdRegOut",
-                "priority": "None",
-                "queueFull": "None"
-              },
-              "symbol": {
-                "Port": {
-                  "nodeId": 1,
-                  "unqualifiedName": "CmdReg"
-                }
-              },
-              "priority": "None",
-              "queueFull": "None",
-              "importNodeIds": [25]
-            }
-          },
-          "cmdIn": {
-            "Special": {
-              "aNode": {
-                "astNodeId": 8
-              },
-              "specifier": {
-                "inputKind": "None",
-                "kind": {
-                  "CommandRecv": {}
-                },
-                "name": "cmdIn",
-                "priority": "None",
-                "queueFull": "None"
-              },
-              "symbol": {
-                "Port": {
-                  "nodeId": 0,
-                  "unqualifiedName": "Cmd"
-                }
-              },
-              "priority": "None",
-              "queueFull": "None",
-              "importNodeIds": [25]
-            }
-          },
-          "cmdResponseOut": {
-            "Special": {
-              "aNode": {
-                "astNodeId": 11
-              },
-              "specifier": {
-                "inputKind": "None",
-                "kind": {
-                  "CommandResp": {}
-                },
-                "name": "cmdResponseOut",
-                "priority": "None",
-                "queueFull": "None"
-              },
-              "symbol": {
-                "Port": {
-                  "nodeId": 4,
-                  "unqualifiedName": "CmdResponse"
-                }
-              },
-              "priority": "None",
-              "queueFull": "None",
-              "importNodeIds": [25]
-            }
-          },
-          "general": {
-            "General": {
-              "aNode": {
-                "astNodeId": 21
-              },
-              "specifier": {
-                "kind": {
-                  "AsyncInput": {}
-                },
-                "name": "general",
-                "size": "None",
-                "port": {
-                  "Some": {
-                    "astNodeId": 20
+              "specifier" : {
+                "inputKind" : "None",
+                "kind" : {
+                  "CommandReg" : {
+                    
                   }
                 },
-                "priority": "None",
-                "queueFull": "None"
+                "name" : "cmdRegOut",
+                "priority" : "None",
+                "queueFull" : "None"
               },
-              "kind": "AsyncInput",
-              "size": 1,
-              "ty": {
-                "DefPort": {
-                  "symbol": {
-                    "Port": {
-                      "nodeId": 6,
-                      "unqualifiedName": "General"
+              "symbol" : {
+                "Port" : {
+                  "nodeId" : 1,
+                  "unqualifiedName" : "CmdReg"
+                }
+              },
+              "priority" : "None",
+              "queueFull" : "None",
+              "importNodeIds" : [
+                25
+              ]
+            }
+          },
+          "cmdIn" : {
+            "Special" : {
+              "aNode" : {
+                "astNodeId" : 8
+              },
+              "specifier" : {
+                "inputKind" : "None",
+                "kind" : {
+                  "CommandRecv" : {
+                    
+                  }
+                },
+                "name" : "cmdIn",
+                "priority" : "None",
+                "queueFull" : "None"
+              },
+              "symbol" : {
+                "Port" : {
+                  "nodeId" : 0,
+                  "unqualifiedName" : "Cmd"
+                }
+              },
+              "priority" : "None",
+              "queueFull" : "None",
+              "importNodeIds" : [
+                25
+              ]
+            }
+          },
+          "cmdResponseOut" : {
+            "Special" : {
+              "aNode" : {
+                "astNodeId" : 11
+              },
+              "specifier" : {
+                "inputKind" : "None",
+                "kind" : {
+                  "CommandResp" : {
+                    
+                  }
+                },
+                "name" : "cmdResponseOut",
+                "priority" : "None",
+                "queueFull" : "None"
+              },
+              "symbol" : {
+                "Port" : {
+                  "nodeId" : 4,
+                  "unqualifiedName" : "CmdResponse"
+                }
+              },
+              "priority" : "None",
+              "queueFull" : "None",
+              "importNodeIds" : [
+                25
+              ]
+            }
+          },
+          "general" : {
+            "General" : {
+              "aNode" : {
+                "astNodeId" : 21
+              },
+              "specifier" : {
+                "kind" : {
+                  "AsyncInput" : {
+                    
+                  }
+                },
+                "name" : "general",
+                "size" : "None",
+                "port" : {
+                  "Some" : {
+                    "astNodeId" : 20
+                  }
+                },
+                "priority" : "None",
+                "queueFull" : "None"
+              },
+              "kind" : "AsyncInput",
+              "size" : 1,
+              "ty" : {
+                "DefPort" : {
+                  "symbol" : {
+                    "Port" : {
+                      "nodeId" : 6,
+                      "unqualifiedName" : "General"
                     }
                   }
                 }
               },
-              "importNodeIds": [28]
+              "importNodeIds" : [
+                28
+              ]
             }
           }
         },
-        "specialPortMap": {
-          "command reg": {
-            "aNode": {
-              "astNodeId": 7
+        "specialPortMap" : {
+          "command reg" : {
+            "aNode" : {
+              "astNodeId" : 7
             },
-            "specifier": {
-              "inputKind": "None",
-              "kind": {
-                "CommandReg": {}
+            "specifier" : {
+              "inputKind" : "None",
+              "kind" : {
+                "CommandReg" : {
+                  
+                }
               },
-              "name": "cmdRegOut",
-              "priority": "None",
-              "queueFull": "None"
+              "name" : "cmdRegOut",
+              "priority" : "None",
+              "queueFull" : "None"
             },
-            "symbol": {
-              "Port": {
-                "nodeId": 1,
-                "unqualifiedName": "CmdReg"
+            "symbol" : {
+              "Port" : {
+                "nodeId" : 1,
+                "unqualifiedName" : "CmdReg"
               }
             },
-            "priority": "None",
-            "queueFull": "None",
-            "importNodeIds": [25]
+            "priority" : "None",
+            "queueFull" : "None",
+            "importNodeIds" : [
+              25
+            ]
           },
-          "command recv": {
-            "aNode": {
-              "astNodeId": 8
+          "command recv" : {
+            "aNode" : {
+              "astNodeId" : 8
             },
-            "specifier": {
-              "inputKind": "None",
-              "kind": {
-                "CommandRecv": {}
+            "specifier" : {
+              "inputKind" : "None",
+              "kind" : {
+                "CommandRecv" : {
+                  
+                }
               },
-              "name": "cmdIn",
-              "priority": "None",
-              "queueFull": "None"
+              "name" : "cmdIn",
+              "priority" : "None",
+              "queueFull" : "None"
             },
-            "symbol": {
-              "Port": {
-                "nodeId": 0,
-                "unqualifiedName": "Cmd"
+            "symbol" : {
+              "Port" : {
+                "nodeId" : 0,
+                "unqualifiedName" : "Cmd"
               }
             },
-            "priority": "None",
-            "queueFull": "None",
-            "importNodeIds": [25]
+            "priority" : "None",
+            "queueFull" : "None",
+            "importNodeIds" : [
+              25
+            ]
           },
-          "command resp": {
-            "aNode": {
-              "astNodeId": 11
+          "command resp" : {
+            "aNode" : {
+              "astNodeId" : 11
             },
-            "specifier": {
-              "inputKind": "None",
-              "kind": {
-                "CommandResp": {}
+            "specifier" : {
+              "inputKind" : "None",
+              "kind" : {
+                "CommandResp" : {
+                  
+                }
               },
-              "name": "cmdResponseOut",
-              "priority": "None",
-              "queueFull": "None"
+              "name" : "cmdResponseOut",
+              "priority" : "None",
+              "queueFull" : "None"
             },
-            "symbol": {
-              "Port": {
-                "nodeId": 4,
-                "unqualifiedName": "CmdResponse"
+            "symbol" : {
+              "Port" : {
+                "nodeId" : 4,
+                "unqualifiedName" : "CmdResponse"
               }
             },
-            "priority": "None",
-            "queueFull": "None",
-            "importNodeIds": [25]
+            "priority" : "None",
+            "queueFull" : "None",
+            "importNodeIds" : [
+              25
+            ]
           }
         },
-        "commandMap": {
-          "0": {
-            "NonParam": {
-              "aNode": {
-                "astNodeId": 30
+        "commandMap" : {
+          "0" : {
+            "NonParam" : {
+              "aNode" : {
+                "astNodeId" : 30
               },
-              "kind": {
-                "Async": {
-                  "priority": {
-                    "Some": 10
+              "kind" : {
+                "Async" : {
+                  "priority" : {
+                    "Some" : 10
                   },
-                  "queueFull": {
-                    "Assert": {}
+                  "queueFull" : {
+                    "Assert" : {
+                      
+                    }
                   }
                 }
               }
             }
           },
-          "1": {
-            "NonParam": {
-              "aNode": {
-                "astNodeId": 40
+          "1" : {
+            "NonParam" : {
+              "aNode" : {
+                "astNodeId" : 40
               },
-              "kind": {
-                "Async": {
-                  "priority": {
-                    "Some": 20
+              "kind" : {
+                "Async" : {
+                  "priority" : {
+                    "Some" : 20
                   },
-                  "queueFull": {
-                    "Assert": {}
+                  "queueFull" : {
+                    "Assert" : {
+                      
+                    }
                   }
                 }
               }
             }
           },
-          "16": {
-            "NonParam": {
-              "aNode": {
-                "astNodeId": 70
+          "16" : {
+            "NonParam" : {
+              "aNode" : {
+                "astNodeId" : 70
               },
-              "kind": {
-                "Async": {
-                  "priority": {
-                    "Some": 30
+              "kind" : {
+                "Async" : {
+                  "priority" : {
+                    "Some" : 30
                   },
-                  "queueFull": {
-                    "Drop": {}
+                  "queueFull" : {
+                    "Drop" : {
+                      
+                    }
                   }
                 }
               }
             }
           }
         },
-        "defaultOpcode": 17,
-        "tlmChannelMap": {},
-        "tlmChannelNameMap": {},
-        "defaultTlmChannelId": 0,
-        "eventMap": {},
-        "defaultEventId": 0,
-        "paramMap": {},
-        "specPortMatchingList": [],
-        "stateMachineInstanceMap": {},
-        "portMatchingList": [],
-        "defaultParamId": 0,
-        "containerMap": {},
-        "defaultContainerId": 0,
-        "recordMap": {},
-        "defaultRecordId": 0
+        "defaultOpcode" : 17,
+        "tlmChannelMap" : {
+          
+        },
+        "tlmChannelNameMap" : {
+          
+        },
+        "defaultTlmChannelId" : 0,
+        "eventMap" : {
+          
+        },
+        "defaultEventId" : 0,
+        "paramMap" : {
+          
+        },
+        "specPortMatchingList" : [
+        ],
+        "stateMachineInstanceMap" : {
+          
+        },
+        "portMatchingList" : [
+        ],
+        "defaultParamId" : 0,
+        "containerMap" : {
+          
+        },
+        "defaultContainerId" : 0,
+        "recordMap" : {
+          
+        },
+        "defaultRecordId" : 0
       }
     },
-    "includedFileSet": [],
-    "inputFileSet": [
+    "includedFileSet" : [
+    ],
+    "inputFileSet" : [
       "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp"
     ],
-    "locationSpecifierMap": [],
-    "parentSymbolMap": {
-      "0": {
-        "Module": {
-          "nodeId": 5,
-          "unqualifiedName": "Fw"
+    "locationSpecifierMap" : [
+    ],
+    "parentSymbolMap" : {
+      "0" : {
+        "Module" : {
+          "nodeId" : 5,
+          "unqualifiedName" : "Fw"
         }
       },
-      "1": {
-        "Module": {
-          "nodeId": 5,
-          "unqualifiedName": "Fw"
+      "1" : {
+        "Module" : {
+          "nodeId" : 5,
+          "unqualifiedName" : "Fw"
         }
       },
-      "4": {
-        "Module": {
-          "nodeId": 5,
-          "unqualifiedName": "Fw"
+      "4" : {
+        "Module" : {
+          "nodeId" : 5,
+          "unqualifiedName" : "Fw"
         }
       }
     },
-    "symbolScopeMap": {
-      "5": {
-        "map": {
-          "Port": {
-            "map": {
-              "Cmd": {
-                "Port": {
-                  "nodeId": 0,
-                  "unqualifiedName": "Cmd"
+    "symbolScopeMap" : {
+      "5" : {
+        "map" : {
+          "Port" : {
+            "map" : {
+              "Cmd" : {
+                "Port" : {
+                  "nodeId" : 0,
+                  "unqualifiedName" : "Cmd"
                 }
               },
-              "CmdReg": {
-                "Port": {
-                  "nodeId": 1,
-                  "unqualifiedName": "CmdReg"
+              "CmdReg" : {
+                "Port" : {
+                  "nodeId" : 1,
+                  "unqualifiedName" : "CmdReg"
                 }
               },
-              "CmdResponse": {
-                "Port": {
-                  "nodeId": 4,
-                  "unqualifiedName": "CmdResponse"
+              "CmdResponse" : {
+                "Port" : {
+                  "nodeId" : 4,
+                  "unqualifiedName" : "CmdResponse"
                 }
               }
             }
           }
         }
       },
-      "71": {
-        "map": {}
+      "71" : {
+        "map" : {
+          
+        }
       }
     },
-    "topologyMap": {},
-    "typeMap": {
-      "67": {
-        "Int": {
-          "Integer": {}
+    "topologyMap" : {
+      
+    },
+    "typeMap" : {
+      "67" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "65": {
-        "String": {
-          "size": "None"
+      "65" : {
+        "String" : {
+          "size" : "None"
         }
       },
-      "39": {
-        "Int": {
-          "Integer": {}
+      "39" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "31": {
-        "Int": {
-          "PrimitiveInt": {
-            "kind": {
-              "U32": {}
+      "31" : {
+        "Int" : {
+          "PrimitiveInt" : {
+            "kind" : {
+              "U32" : {
+                
+              }
             }
           }
         }
       },
-      "29": {
-        "Int": {
-          "Integer": {}
+      "29" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "37": {
-        "Primitive": {
-          "Float": {
-            "kind": {
-              "F32": {}
+      "37" : {
+        "Primitive" : {
+          "Float" : {
+            "kind" : {
+              "F32" : {
+                
+              }
             }
           }
         }
       },
-      "68": {
-        "Int": {
-          "Integer": {}
+      "68" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       }
     },
-    "useDefMap": {
-      "8": {
-        "Port": {
-          "nodeId": 0,
-          "unqualifiedName": "Cmd"
+    "useDefMap" : {
+      "8" : {
+        "Port" : {
+          "nodeId" : 0,
+          "unqualifiedName" : "Cmd"
         }
       },
-      "11": {
-        "Port": {
-          "nodeId": 4,
-          "unqualifiedName": "CmdResponse"
+      "11" : {
+        "Port" : {
+          "nodeId" : 4,
+          "unqualifiedName" : "CmdResponse"
         }
       },
-      "24": {
-        "Interface": {
-          "nodeId": 12,
-          "unqualifiedName": "ICmd"
+      "24" : {
+        "Interface" : {
+          "nodeId" : 12,
+          "unqualifiedName" : "ICmd"
         }
       },
-      "7": {
-        "Port": {
-          "nodeId": 1,
-          "unqualifiedName": "CmdReg"
+      "7" : {
+        "Port" : {
+          "nodeId" : 1,
+          "unqualifiedName" : "CmdReg"
         }
       },
-      "20": {
-        "Port": {
-          "nodeId": 6,
-          "unqualifiedName": "General"
+      "20" : {
+        "Port" : {
+          "nodeId" : 6,
+          "unqualifiedName" : "General"
         }
       },
-      "27": {
-        "Interface": {
-          "nodeId": 22,
-          "unqualifiedName": "IPort"
+      "27" : {
+        "Interface" : {
+          "nodeId" : 22,
+          "unqualifiedName" : "IPort"
         }
       }
     },
-    "valueMap": {
-      "29": {
-        "Integer": {
-          "value": 10
+    "valueMap" : {
+      "29" : {
+        "Integer" : {
+          "value" : 10
         }
       },
-      "39": {
-        "Integer": {
-          "value": 20
+      "39" : {
+        "Integer" : {
+          "value" : 20
         }
       },
-      "67": {
-        "Integer": {
-          "value": 16
+      "67" : {
+        "Integer" : {
+          "value" : 16
         }
       },
-      "68": {
-        "Integer": {
-          "value": 30
+      "68" : {
+        "Integer" : {
+          "value" : 30
         }
       }
     },
-    "stateMachineMap": {},
-    "dictionarySymbolSet": [],
-    "interfaceMap": {
-      "12": {
-        "aNode": {
-          "astNodeId": 12
+    "stateMachineMap" : {
+      
+    },
+    "dictionarySymbolSet" : [
+    ],
+    "interfaceMap" : {
+      "12" : {
+        "aNode" : {
+          "astNodeId" : 12
         },
-        "importMap": {},
-        "portMap": {
-          "cmdRegOut": {
-            "Special": {
-              "aNode": {
-                "astNodeId": 7
-              },
-              "specifier": {
-                "inputKind": "None",
-                "kind": {
-                  "CommandReg": {}
-                },
-                "name": "cmdRegOut",
-                "priority": "None",
-                "queueFull": "None"
-              },
-              "symbol": {
-                "Port": {
-                  "nodeId": 1,
-                  "unqualifiedName": "CmdReg"
-                }
-              },
-              "priority": "None",
-              "queueFull": "None",
-              "importNodeIds": []
-            }
-          },
-          "cmdIn": {
-            "Special": {
-              "aNode": {
-                "astNodeId": 8
-              },
-              "specifier": {
-                "inputKind": "None",
-                "kind": {
-                  "CommandRecv": {}
-                },
-                "name": "cmdIn",
-                "priority": "None",
-                "queueFull": "None"
-              },
-              "symbol": {
-                "Port": {
-                  "nodeId": 0,
-                  "unqualifiedName": "Cmd"
-                }
-              },
-              "priority": "None",
-              "queueFull": "None",
-              "importNodeIds": []
-            }
-          },
-          "cmdResponseOut": {
-            "Special": {
-              "aNode": {
-                "astNodeId": 11
-              },
-              "specifier": {
-                "inputKind": "None",
-                "kind": {
-                  "CommandResp": {}
-                },
-                "name": "cmdResponseOut",
-                "priority": "None",
-                "queueFull": "None"
-              },
-              "symbol": {
-                "Port": {
-                  "nodeId": 4,
-                  "unqualifiedName": "CmdResponse"
-                }
-              },
-              "priority": "None",
-              "queueFull": "None",
-              "importNodeIds": []
-            }
-          }
+        "importMap" : {
+          
         },
-        "specialPortMap": {
-          "command reg": {
-            "aNode": {
-              "astNodeId": 7
-            },
-            "specifier": {
-              "inputKind": "None",
-              "kind": {
-                "CommandReg": {}
+        "portMap" : {
+          "cmdRegOut" : {
+            "Special" : {
+              "aNode" : {
+                "astNodeId" : 7
               },
-              "name": "cmdRegOut",
-              "priority": "None",
-              "queueFull": "None"
-            },
-            "symbol": {
-              "Port": {
-                "nodeId": 1,
-                "unqualifiedName": "CmdReg"
-              }
-            },
-            "priority": "None",
-            "queueFull": "None",
-            "importNodeIds": []
-          },
-          "command recv": {
-            "aNode": {
-              "astNodeId": 8
-            },
-            "specifier": {
-              "inputKind": "None",
-              "kind": {
-                "CommandRecv": {}
-              },
-              "name": "cmdIn",
-              "priority": "None",
-              "queueFull": "None"
-            },
-            "symbol": {
-              "Port": {
-                "nodeId": 0,
-                "unqualifiedName": "Cmd"
-              }
-            },
-            "priority": "None",
-            "queueFull": "None",
-            "importNodeIds": []
-          },
-          "command resp": {
-            "aNode": {
-              "astNodeId": 11
-            },
-            "specifier": {
-              "inputKind": "None",
-              "kind": {
-                "CommandResp": {}
-              },
-              "name": "cmdResponseOut",
-              "priority": "None",
-              "queueFull": "None"
-            },
-            "symbol": {
-              "Port": {
-                "nodeId": 4,
-                "unqualifiedName": "CmdResponse"
-              }
-            },
-            "priority": "None",
-            "queueFull": "None",
-            "importNodeIds": []
-          }
-        }
-      },
-      "22": {
-        "aNode": {
-          "astNodeId": 22
-        },
-        "importMap": {},
-        "portMap": {
-          "general": {
-            "General": {
-              "aNode": {
-                "astNodeId": 21
-              },
-              "specifier": {
-                "kind": {
-                  "AsyncInput": {}
-                },
-                "name": "general",
-                "size": "None",
-                "port": {
-                  "Some": {
-                    "astNodeId": 20
+              "specifier" : {
+                "inputKind" : "None",
+                "kind" : {
+                  "CommandReg" : {
+                    
                   }
                 },
-                "priority": "None",
-                "queueFull": "None"
+                "name" : "cmdRegOut",
+                "priority" : "None",
+                "queueFull" : "None"
               },
-              "kind": "AsyncInput",
-              "size": 1,
-              "ty": {
-                "DefPort": {
-                  "symbol": {
-                    "Port": {
-                      "nodeId": 6,
-                      "unqualifiedName": "General"
+              "symbol" : {
+                "Port" : {
+                  "nodeId" : 1,
+                  "unqualifiedName" : "CmdReg"
+                }
+              },
+              "priority" : "None",
+              "queueFull" : "None",
+              "importNodeIds" : [
+              ]
+            }
+          },
+          "cmdIn" : {
+            "Special" : {
+              "aNode" : {
+                "astNodeId" : 8
+              },
+              "specifier" : {
+                "inputKind" : "None",
+                "kind" : {
+                  "CommandRecv" : {
+                    
+                  }
+                },
+                "name" : "cmdIn",
+                "priority" : "None",
+                "queueFull" : "None"
+              },
+              "symbol" : {
+                "Port" : {
+                  "nodeId" : 0,
+                  "unqualifiedName" : "Cmd"
+                }
+              },
+              "priority" : "None",
+              "queueFull" : "None",
+              "importNodeIds" : [
+              ]
+            }
+          },
+          "cmdResponseOut" : {
+            "Special" : {
+              "aNode" : {
+                "astNodeId" : 11
+              },
+              "specifier" : {
+                "inputKind" : "None",
+                "kind" : {
+                  "CommandResp" : {
+                    
+                  }
+                },
+                "name" : "cmdResponseOut",
+                "priority" : "None",
+                "queueFull" : "None"
+              },
+              "symbol" : {
+                "Port" : {
+                  "nodeId" : 4,
+                  "unqualifiedName" : "CmdResponse"
+                }
+              },
+              "priority" : "None",
+              "queueFull" : "None",
+              "importNodeIds" : [
+              ]
+            }
+          }
+        },
+        "specialPortMap" : {
+          "command reg" : {
+            "aNode" : {
+              "astNodeId" : 7
+            },
+            "specifier" : {
+              "inputKind" : "None",
+              "kind" : {
+                "CommandReg" : {
+                  
+                }
+              },
+              "name" : "cmdRegOut",
+              "priority" : "None",
+              "queueFull" : "None"
+            },
+            "symbol" : {
+              "Port" : {
+                "nodeId" : 1,
+                "unqualifiedName" : "CmdReg"
+              }
+            },
+            "priority" : "None",
+            "queueFull" : "None",
+            "importNodeIds" : [
+            ]
+          },
+          "command recv" : {
+            "aNode" : {
+              "astNodeId" : 8
+            },
+            "specifier" : {
+              "inputKind" : "None",
+              "kind" : {
+                "CommandRecv" : {
+                  
+                }
+              },
+              "name" : "cmdIn",
+              "priority" : "None",
+              "queueFull" : "None"
+            },
+            "symbol" : {
+              "Port" : {
+                "nodeId" : 0,
+                "unqualifiedName" : "Cmd"
+              }
+            },
+            "priority" : "None",
+            "queueFull" : "None",
+            "importNodeIds" : [
+            ]
+          },
+          "command resp" : {
+            "aNode" : {
+              "astNodeId" : 11
+            },
+            "specifier" : {
+              "inputKind" : "None",
+              "kind" : {
+                "CommandResp" : {
+                  
+                }
+              },
+              "name" : "cmdResponseOut",
+              "priority" : "None",
+              "queueFull" : "None"
+            },
+            "symbol" : {
+              "Port" : {
+                "nodeId" : 4,
+                "unqualifiedName" : "CmdResponse"
+              }
+            },
+            "priority" : "None",
+            "queueFull" : "None",
+            "importNodeIds" : [
+            ]
+          }
+        }
+      },
+      "22" : {
+        "aNode" : {
+          "astNodeId" : 22
+        },
+        "importMap" : {
+          
+        },
+        "portMap" : {
+          "general" : {
+            "General" : {
+              "aNode" : {
+                "astNodeId" : 21
+              },
+              "specifier" : {
+                "kind" : {
+                  "AsyncInput" : {
+                    
+                  }
+                },
+                "name" : "general",
+                "size" : "None",
+                "port" : {
+                  "Some" : {
+                    "astNodeId" : 20
+                  }
+                },
+                "priority" : "None",
+                "queueFull" : "None"
+              },
+              "kind" : "AsyncInput",
+              "size" : 1,
+              "ty" : {
+                "DefPort" : {
+                  "symbol" : {
+                    "Port" : {
+                      "nodeId" : 6,
+                      "unqualifiedName" : "General"
                     }
                   }
                 }
               },
-              "importNodeIds": []
+              "importNodeIds" : [
+              ]
             }
           }
         },
-        "specialPortMap": {}
+        "specialPortMap" : {
+          
+        }
       }
     }
   }

--- a/tests/interfaces/interfaces_analysis.json
+++ b/tests/interfaces/interfaces_analysis.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion": "[ fpp version ]",
+  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
   "analysis": {
     "componentInstanceMap": {},
     "componentMap": {

--- a/tests/interfaces/interfaces_ast.json
+++ b/tests/interfaces/interfaces_ast.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion": "[ fpp version ]",
+  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
   "ast": [
     {
       "members": [

--- a/tests/interfaces/interfaces_ast.json
+++ b/tests/interfaces/interfaces_ast.json
@@ -1,97 +1,111 @@
 {
-  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
-  "ast": [
+  "fppVersion" : "v3.1.0a10-54-g11243e778",
+  "ast" : [
     {
-      "members": [
+      "members" : [
         [
-          [],
+          [
+          ],
           {
-            "DefModule": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "Fw",
-                    "members": [
+            "DefModule" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "Fw",
+                    "members" : [
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "DefPort": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "name": "Cmd",
-                                  "params": [],
-                                  "returnType": "None"
+                          "DefPort" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "name" : "Cmd",
+                                  "params" : [
+                                  ],
+                                  "returnType" : "None"
                                 },
-                                "id": 0
+                                "id" : 0
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "DefPort": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "name": "CmdReg",
-                                  "params": [],
-                                  "returnType": "None"
+                          "DefPort" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "name" : "CmdReg",
+                                  "params" : [
+                                  ],
+                                  "returnType" : "None"
                                 },
-                                "id": 1
+                                "id" : 1
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "DefPort": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "name": "CmdResponse",
-                                  "params": [],
-                                  "returnType": "None"
+                          "DefPort" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "name" : "CmdResponse",
+                                  "params" : [
+                                  ],
+                                  "returnType" : "None"
                                 },
-                                "id": 4
+                                "id" : 4
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ]
                     ]
                   },
-                  "id": 5
+                  "id" : 5
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          [],
+          [
+          ],
           {
-            "DefPort": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "General",
-                    "params": [],
-                    "returnType": "None"
+            "DefPort" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "General",
+                    "params" : [
+                    ],
+                    "returnType" : "None"
                   },
-                  "id": 6
+                  "id" : 6
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
           [
@@ -99,422 +113,484 @@
             "into a component."
           ],
           {
-            "DefInterface": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "ICmd",
-                    "members": [
+            "DefInterface" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "ICmd",
+                    "members" : [
                       [
-                        ["Command registration"],
+                        [
+                          "Command registration"
+                        ],
                         {
-                          "SpecPortInstance": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "Special": {
-                                    "inputKind": "None",
-                                    "kind": {
-                                      "CommandReg": {}
+                          "SpecPortInstance" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "Special" : {
+                                    "inputKind" : "None",
+                                    "kind" : {
+                                      "CommandReg" : {
+                                        
+                                      }
                                     },
-                                    "name": "cmdRegOut",
-                                    "priority": "None",
-                                    "queueFull": "None"
+                                    "name" : "cmdRegOut",
+                                    "priority" : "None",
+                                    "queueFull" : "None"
                                   }
                                 },
-                                "id": 7
+                                "id" : 7
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        ["Command input"],
+                        [
+                          "Command input"
+                        ],
                         {
-                          "SpecPortInstance": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "Special": {
-                                    "inputKind": "None",
-                                    "kind": {
-                                      "CommandRecv": {}
+                          "SpecPortInstance" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "Special" : {
+                                    "inputKind" : "None",
+                                    "kind" : {
+                                      "CommandRecv" : {
+                                        
+                                      }
                                     },
-                                    "name": "cmdIn",
-                                    "priority": "None",
-                                    "queueFull": "None"
+                                    "name" : "cmdIn",
+                                    "priority" : "None",
+                                    "queueFull" : "None"
                                   }
                                 },
-                                "id": 8
+                                "id" : 8
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        ["Command response"],
+                        [
+                          "Command response"
+                        ],
                         {
-                          "SpecPortInstance": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "Special": {
-                                    "inputKind": "None",
-                                    "kind": {
-                                      "CommandResp": {}
+                          "SpecPortInstance" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "Special" : {
+                                    "inputKind" : "None",
+                                    "kind" : {
+                                      "CommandResp" : {
+                                        
+                                      }
                                     },
-                                    "name": "cmdResponseOut",
-                                    "priority": "None",
-                                    "queueFull": "None"
+                                    "name" : "cmdResponseOut",
+                                    "priority" : "None",
+                                    "queueFull" : "None"
                                   }
                                 },
-                                "id": 11
+                                "id" : 11
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ]
                     ]
                   },
-                  "id": 12
+                  "id" : 12
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          [],
+          [
+          ],
           {
-            "DefInterface": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "IPort",
-                    "members": [
+            "DefInterface" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "IPort",
+                    "members" : [
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "SpecPortInstance": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "General": {
-                                    "kind": {
-                                      "AsyncInput": {}
+                          "SpecPortInstance" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "General" : {
+                                    "kind" : {
+                                      "AsyncInput" : {
+                                        
+                                      }
                                     },
-                                    "name": "general",
-                                    "size": "None",
-                                    "port": {
-                                      "Some": {
-                                        "AstNode": {
-                                          "data": {
-                                            "Unqualified": {
-                                              "name": "General"
+                                    "name" : "general",
+                                    "size" : "None",
+                                    "port" : {
+                                      "Some" : {
+                                        "AstNode" : {
+                                          "data" : {
+                                            "Unqualified" : {
+                                              "name" : "General"
                                             }
                                           },
-                                          "id": 20
+                                          "id" : 20
                                         }
                                       }
                                     },
-                                    "priority": "None",
-                                    "queueFull": "None"
+                                    "priority" : "None",
+                                    "queueFull" : "None"
                                   }
                                 },
-                                "id": 21
+                                "id" : 21
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ]
                     ]
                   },
-                  "id": 22
+                  "id" : 22
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          [],
+          [
+          ],
           {
-            "DefComponent": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "kind": {
-                      "Active": {}
+            "DefComponent" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "kind" : {
+                      "Active" : {
+                        
+                      }
                     },
-                    "name": "PriorityQueueFull",
-                    "members": [
+                    "name" : "PriorityQueueFull",
+                    "members" : [
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "SpecImportInterface": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "sym": {
-                                    "AstNode": {
-                                      "data": {
-                                        "Unqualified": {
-                                          "name": "ICmd"
+                          "SpecImportInterface" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "sym" : {
+                                    "AstNode" : {
+                                      "data" : {
+                                        "Unqualified" : {
+                                          "name" : "ICmd"
                                         }
                                       },
-                                      "id": 24
+                                      "id" : 24
                                     }
                                   }
                                 },
-                                "id": 25
+                                "id" : 25
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "SpecImportInterface": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "sym": {
-                                    "AstNode": {
-                                      "data": {
-                                        "Unqualified": {
-                                          "name": "IPort"
+                          "SpecImportInterface" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "sym" : {
+                                    "AstNode" : {
+                                      "data" : {
+                                        "Unqualified" : {
+                                          "name" : "IPort"
                                         }
                                       },
-                                      "id": 27
+                                      "id" : 27
                                     }
                                   }
                                 },
-                                "id": 28
+                                "id" : 28
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        ["Command with priority"],
+                        [
+                          "Command with priority"
+                        ],
                         {
-                          "SpecCommand": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "kind": {
-                                    "Async": {}
+                          "SpecCommand" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "kind" : {
+                                    "Async" : {
+                                      
+                                    }
                                   },
-                                  "name": "COMMAND_1",
-                                  "params": [],
-                                  "opcode": "None",
-                                  "priority": {
-                                    "Some": {
-                                      "AstNode": {
-                                        "data": {
-                                          "ExprLiteralInt": {
-                                            "value": "10"
+                                  "name" : "COMMAND_1",
+                                  "params" : [
+                                  ],
+                                  "opcode" : "None",
+                                  "priority" : {
+                                    "Some" : {
+                                      "AstNode" : {
+                                        "data" : {
+                                          "ExprLiteralInt" : {
+                                            "value" : "10"
                                           }
                                         },
-                                        "id": 29
+                                        "id" : 29
                                       }
                                     }
                                   },
-                                  "queueFull": "None"
+                                  "queueFull" : "None"
                                 },
-                                "id": 30
+                                "id" : 30
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        ["Command with formal parameters and priority"],
+                        [
+                          "Command with formal parameters and priority"
+                        ],
                         {
-                          "SpecCommand": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "kind": {
-                                    "Async": {}
+                          "SpecCommand" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "kind" : {
+                                    "Async" : {
+                                      
+                                    }
                                   },
-                                  "name": "COMMAND_2",
-                                  "params": [
+                                  "name" : "COMMAND_2",
+                                  "params" : [
                                     [
-                                      [],
+                                      [
+                                      ],
                                       {
-                                        "AstNode": {
-                                          "data": {
-                                            "kind": {
-                                              "Value": {}
+                                        "AstNode" : {
+                                          "data" : {
+                                            "kind" : {
+                                              "Value" : {
+                                                
+                                              }
                                             },
-                                            "name": "a",
-                                            "typeName": {
-                                              "AstNode": {
-                                                "data": {
-                                                  "TypeNameInt": {
-                                                    "name": {
-                                                      "U32": {}
+                                            "name" : "a",
+                                            "typeName" : {
+                                              "AstNode" : {
+                                                "data" : {
+                                                  "TypeNameInt" : {
+                                                    "name" : {
+                                                      "U32" : {
+                                                        
+                                                      }
                                                     }
                                                   }
                                                 },
-                                                "id": 31
+                                                "id" : 31
                                               }
                                             }
                                           },
-                                          "id": 32
+                                          "id" : 32
                                         }
                                       },
-                                      []
+                                      [
+                                      ]
                                     ],
                                     [
-                                      [],
+                                      [
+                                      ],
                                       {
-                                        "AstNode": {
-                                          "data": {
-                                            "kind": {
-                                              "Value": {}
+                                        "AstNode" : {
+                                          "data" : {
+                                            "kind" : {
+                                              "Value" : {
+                                                
+                                              }
                                             },
-                                            "name": "b",
-                                            "typeName": {
-                                              "AstNode": {
-                                                "data": {
-                                                  "TypeNameFloat": {
-                                                    "name": {
-                                                      "F32": {}
+                                            "name" : "b",
+                                            "typeName" : {
+                                              "AstNode" : {
+                                                "data" : {
+                                                  "TypeNameFloat" : {
+                                                    "name" : {
+                                                      "F32" : {
+                                                        
+                                                      }
                                                     }
                                                   }
                                                 },
-                                                "id": 37
+                                                "id" : 37
                                               }
                                             }
                                           },
-                                          "id": 38
+                                          "id" : 38
                                         }
                                       },
-                                      []
+                                      [
+                                      ]
                                     ]
                                   ],
-                                  "opcode": "None",
-                                  "priority": {
-                                    "Some": {
-                                      "AstNode": {
-                                        "data": {
-                                          "ExprLiteralInt": {
-                                            "value": "20"
+                                  "opcode" : "None",
+                                  "priority" : {
+                                    "Some" : {
+                                      "AstNode" : {
+                                        "data" : {
+                                          "ExprLiteralInt" : {
+                                            "value" : "20"
                                           }
                                         },
-                                        "id": 39
+                                        "id" : 39
                                       }
                                     }
                                   },
-                                  "queueFull": "None"
+                                  "queueFull" : "None"
                                 },
-                                "id": 40
+                                "id" : 40
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
                         [
                           "Command with formal parameters, opcode, priority, and queue full behavior"
                         ],
                         {
-                          "SpecCommand": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "kind": {
-                                    "Async": {}
+                          "SpecCommand" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "kind" : {
+                                    "Async" : {
+                                      
+                                    }
                                   },
-                                  "name": "COMMAND_3",
-                                  "params": [
+                                  "name" : "COMMAND_3",
+                                  "params" : [
                                     [
-                                      [],
+                                      [
+                                      ],
                                       {
-                                        "AstNode": {
-                                          "data": {
-                                            "kind": {
-                                              "Value": {}
+                                        "AstNode" : {
+                                          "data" : {
+                                            "kind" : {
+                                              "Value" : {
+                                                
+                                              }
                                             },
-                                            "name": "a",
-                                            "typeName": {
-                                              "AstNode": {
-                                                "data": {
-                                                  "TypeNameString": {
-                                                    "size": "None"
+                                            "name" : "a",
+                                            "typeName" : {
+                                              "AstNode" : {
+                                                "data" : {
+                                                  "TypeNameString" : {
+                                                    "size" : "None"
                                                   }
                                                 },
-                                                "id": 65
+                                                "id" : 65
                                               }
                                             }
                                           },
-                                          "id": 66
+                                          "id" : 66
                                         }
                                       },
-                                      []
+                                      [
+                                      ]
                                     ]
                                   ],
-                                  "opcode": {
-                                    "Some": {
-                                      "AstNode": {
-                                        "data": {
-                                          "ExprLiteralInt": {
-                                            "value": "0x10"
+                                  "opcode" : {
+                                    "Some" : {
+                                      "AstNode" : {
+                                        "data" : {
+                                          "ExprLiteralInt" : {
+                                            "value" : "0x10"
                                           }
                                         },
-                                        "id": 67
+                                        "id" : 67
                                       }
                                     }
                                   },
-                                  "priority": {
-                                    "Some": {
-                                      "AstNode": {
-                                        "data": {
-                                          "ExprLiteralInt": {
-                                            "value": "30"
+                                  "priority" : {
+                                    "Some" : {
+                                      "AstNode" : {
+                                        "data" : {
+                                          "ExprLiteralInt" : {
+                                            "value" : "30"
                                           }
                                         },
-                                        "id": 68
+                                        "id" : 68
                                       }
                                     }
                                   },
-                                  "queueFull": {
-                                    "Some": {
-                                      "AstNode": {
-                                        "data": {
-                                          "Drop": {}
+                                  "queueFull" : {
+                                    "Some" : {
+                                      "AstNode" : {
+                                        "data" : {
+                                          "Drop" : {
+                                            
+                                          }
                                         },
-                                        "id": 69
+                                        "id" : 69
                                       }
                                     }
                                   }
                                 },
-                                "id": 70
+                                "id" : 70
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ]
                     ]
                   },
-                  "id": 71
+                  "id" : 71
                 }
               }
             }
           },
-          []
+          [
+          ]
         ]
       ]
     }

--- a/tests/interfaces/interfaces_locations.json
+++ b/tests/interfaces/interfaces_locations.json
@@ -1,365 +1,365 @@
 {
-  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
-  "locationMap": {
-    "0": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
-      "pos": "2.3",
-      "includingLoc": "None"
-    },
-    "1": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
-      "pos": "3.3",
-      "includingLoc": "None"
-    },
-    "2": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
-      "pos": "4.3",
-      "includingLoc": "None"
-    },
-    "3": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
-      "pos": "4.3",
-      "includingLoc": "None"
-    },
-    "4": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
-      "pos": "4.3",
-      "includingLoc": "None"
-    },
-    "5": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
-      "pos": "1.1",
-      "includingLoc": "None"
-    },
-    "6": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
-      "pos": "7.1",
-      "includingLoc": "None"
-    },
-    "7": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
-      "pos": "17.3",
-      "includingLoc": "None"
-    },
-    "8": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
-      "pos": "20.3",
-      "includingLoc": "None"
-    },
-    "9": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
-      "pos": "23.3",
-      "includingLoc": "None"
-    },
-    "10": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
-      "pos": "23.3",
-      "includingLoc": "None"
-    },
-    "11": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
-      "pos": "23.3",
-      "includingLoc": "None"
-    },
-    "12": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
-      "pos": "11.1",
-      "includingLoc": "None"
-    },
-    "13": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
-      "pos": "27.29",
-      "includingLoc": "None"
-    },
-    "14": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
-      "pos": "27.29",
-      "includingLoc": "None"
-    },
-    "15": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
-      "pos": "27.3",
-      "includingLoc": "None"
-    },
-    "16": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
-      "pos": "27.29",
-      "includingLoc": "None"
-    },
-    "17": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
-      "pos": "27.29",
-      "includingLoc": "None"
-    },
-    "18": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
-      "pos": "27.3",
-      "includingLoc": "None"
-    },
-    "19": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
-      "pos": "27.29",
-      "includingLoc": "None"
-    },
-    "20": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
-      "pos": "27.29",
-      "includingLoc": "None"
-    },
-    "21": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
-      "pos": "27.3",
-      "includingLoc": "None"
-    },
-    "22": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
-      "pos": "26.1",
-      "includingLoc": "None"
-    },
-    "23": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
-      "pos": "31.10",
-      "includingLoc": "None"
-    },
-    "24": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
-      "pos": "31.10",
-      "includingLoc": "None"
-    },
-    "25": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
-      "pos": "31.3",
-      "includingLoc": "None"
-    },
-    "26": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
-      "pos": "32.10",
-      "includingLoc": "None"
-    },
-    "27": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
-      "pos": "32.10",
-      "includingLoc": "None"
-    },
-    "28": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
-      "pos": "32.3",
-      "includingLoc": "None"
-    },
-    "29": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
-      "pos": "39.36",
-      "includingLoc": "None"
-    },
-    "30": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
-      "pos": "39.3",
-      "includingLoc": "None"
-    },
-    "31": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
-      "pos": "42.30",
-      "includingLoc": "None"
-    },
-    "32": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
-      "pos": "42.27",
-      "includingLoc": "None"
-    },
-    "33": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
-      "pos": "42.38",
-      "includingLoc": "None"
-    },
-    "34": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
-      "pos": "42.35",
-      "includingLoc": "None"
-    },
-    "35": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
-      "pos": "42.38",
-      "includingLoc": "None"
-    },
-    "36": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
-      "pos": "42.35",
-      "includingLoc": "None"
-    },
-    "37": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
-      "pos": "42.38",
-      "includingLoc": "None"
-    },
-    "38": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
-      "pos": "42.35",
-      "includingLoc": "None"
-    },
-    "39": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
-      "pos": "42.52",
-      "includingLoc": "None"
-    },
-    "40": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
-      "pos": "42.3",
-      "includingLoc": "None"
-    },
-    "41": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
-      "pos": "45.30",
-      "includingLoc": "None"
-    },
-    "42": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
-      "pos": "45.27",
-      "includingLoc": "None"
-    },
-    "43": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
-      "pos": "45.30",
-      "includingLoc": "None"
-    },
-    "44": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
-      "pos": "45.27",
-      "includingLoc": "None"
-    },
-    "45": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
-      "pos": "45.30",
-      "includingLoc": "None"
-    },
-    "46": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
-      "pos": "45.27",
-      "includingLoc": "None"
-    },
-    "47": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
-      "pos": "45.45",
-      "includingLoc": "None"
-    },
-    "48": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
-      "pos": "45.59",
-      "includingLoc": "None"
-    },
-    "49": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
-      "pos": "45.62",
-      "includingLoc": "None"
-    },
-    "50": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
-      "pos": "45.3",
-      "includingLoc": "None"
-    },
-    "51": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
-      "pos": "45.30",
-      "includingLoc": "None"
-    },
-    "52": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
-      "pos": "45.27",
-      "includingLoc": "None"
-    },
-    "53": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
-      "pos": "45.30",
-      "includingLoc": "None"
-    },
-    "54": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
-      "pos": "45.27",
-      "includingLoc": "None"
-    },
-    "55": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
-      "pos": "45.30",
-      "includingLoc": "None"
-    },
-    "56": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
-      "pos": "45.27",
-      "includingLoc": "None"
-    },
-    "57": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
-      "pos": "45.45",
-      "includingLoc": "None"
-    },
-    "58": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
-      "pos": "45.59",
-      "includingLoc": "None"
-    },
-    "59": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
-      "pos": "45.62",
-      "includingLoc": "None"
-    },
-    "60": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
-      "pos": "45.3",
-      "includingLoc": "None"
-    },
-    "61": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
-      "pos": "45.30",
-      "includingLoc": "None"
-    },
-    "62": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
-      "pos": "45.27",
-      "includingLoc": "None"
-    },
-    "63": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
-      "pos": "45.30",
-      "includingLoc": "None"
-    },
-    "64": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
-      "pos": "45.27",
-      "includingLoc": "None"
-    },
-    "65": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
-      "pos": "45.30",
-      "includingLoc": "None"
-    },
-    "66": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
-      "pos": "45.27",
-      "includingLoc": "None"
-    },
-    "67": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
-      "pos": "45.45",
-      "includingLoc": "None"
-    },
-    "68": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
-      "pos": "45.59",
-      "includingLoc": "None"
-    },
-    "69": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
-      "pos": "45.62",
-      "includingLoc": "None"
-    },
-    "70": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
-      "pos": "45.3",
-      "includingLoc": "None"
-    },
-    "71": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
-      "pos": "30.1",
-      "includingLoc": "None"
+  "fppVersion" : "v3.1.0a10-54-g11243e778",
+  "locationMap" : {
+    "0" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
+      "pos" : "2.3",
+      "includingLoc" : "None"
+    },
+    "1" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
+      "pos" : "3.3",
+      "includingLoc" : "None"
+    },
+    "2" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
+      "pos" : "4.3",
+      "includingLoc" : "None"
+    },
+    "3" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
+      "pos" : "4.3",
+      "includingLoc" : "None"
+    },
+    "4" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
+      "pos" : "4.3",
+      "includingLoc" : "None"
+    },
+    "5" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
+      "pos" : "1.1",
+      "includingLoc" : "None"
+    },
+    "6" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
+      "pos" : "7.1",
+      "includingLoc" : "None"
+    },
+    "7" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
+      "pos" : "17.3",
+      "includingLoc" : "None"
+    },
+    "8" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
+      "pos" : "20.3",
+      "includingLoc" : "None"
+    },
+    "9" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
+      "pos" : "23.3",
+      "includingLoc" : "None"
+    },
+    "10" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
+      "pos" : "23.3",
+      "includingLoc" : "None"
+    },
+    "11" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
+      "pos" : "23.3",
+      "includingLoc" : "None"
+    },
+    "12" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
+      "pos" : "11.1",
+      "includingLoc" : "None"
+    },
+    "13" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
+      "pos" : "27.29",
+      "includingLoc" : "None"
+    },
+    "14" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
+      "pos" : "27.29",
+      "includingLoc" : "None"
+    },
+    "15" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
+      "pos" : "27.3",
+      "includingLoc" : "None"
+    },
+    "16" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
+      "pos" : "27.29",
+      "includingLoc" : "None"
+    },
+    "17" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
+      "pos" : "27.29",
+      "includingLoc" : "None"
+    },
+    "18" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
+      "pos" : "27.3",
+      "includingLoc" : "None"
+    },
+    "19" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
+      "pos" : "27.29",
+      "includingLoc" : "None"
+    },
+    "20" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
+      "pos" : "27.29",
+      "includingLoc" : "None"
+    },
+    "21" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
+      "pos" : "27.3",
+      "includingLoc" : "None"
+    },
+    "22" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
+      "pos" : "26.1",
+      "includingLoc" : "None"
+    },
+    "23" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
+      "pos" : "31.10",
+      "includingLoc" : "None"
+    },
+    "24" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
+      "pos" : "31.10",
+      "includingLoc" : "None"
+    },
+    "25" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
+      "pos" : "31.3",
+      "includingLoc" : "None"
+    },
+    "26" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
+      "pos" : "32.10",
+      "includingLoc" : "None"
+    },
+    "27" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
+      "pos" : "32.10",
+      "includingLoc" : "None"
+    },
+    "28" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
+      "pos" : "32.3",
+      "includingLoc" : "None"
+    },
+    "29" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
+      "pos" : "39.36",
+      "includingLoc" : "None"
+    },
+    "30" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
+      "pos" : "39.3",
+      "includingLoc" : "None"
+    },
+    "31" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
+      "pos" : "42.30",
+      "includingLoc" : "None"
+    },
+    "32" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
+      "pos" : "42.27",
+      "includingLoc" : "None"
+    },
+    "33" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
+      "pos" : "42.38",
+      "includingLoc" : "None"
+    },
+    "34" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
+      "pos" : "42.35",
+      "includingLoc" : "None"
+    },
+    "35" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
+      "pos" : "42.38",
+      "includingLoc" : "None"
+    },
+    "36" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
+      "pos" : "42.35",
+      "includingLoc" : "None"
+    },
+    "37" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
+      "pos" : "42.38",
+      "includingLoc" : "None"
+    },
+    "38" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
+      "pos" : "42.35",
+      "includingLoc" : "None"
+    },
+    "39" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
+      "pos" : "42.52",
+      "includingLoc" : "None"
+    },
+    "40" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
+      "pos" : "42.3",
+      "includingLoc" : "None"
+    },
+    "41" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
+      "pos" : "45.30",
+      "includingLoc" : "None"
+    },
+    "42" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
+      "pos" : "45.27",
+      "includingLoc" : "None"
+    },
+    "43" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
+      "pos" : "45.30",
+      "includingLoc" : "None"
+    },
+    "44" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
+      "pos" : "45.27",
+      "includingLoc" : "None"
+    },
+    "45" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
+      "pos" : "45.30",
+      "includingLoc" : "None"
+    },
+    "46" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
+      "pos" : "45.27",
+      "includingLoc" : "None"
+    },
+    "47" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
+      "pos" : "45.45",
+      "includingLoc" : "None"
+    },
+    "48" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
+      "pos" : "45.59",
+      "includingLoc" : "None"
+    },
+    "49" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
+      "pos" : "45.62",
+      "includingLoc" : "None"
+    },
+    "50" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
+      "pos" : "45.3",
+      "includingLoc" : "None"
+    },
+    "51" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
+      "pos" : "45.30",
+      "includingLoc" : "None"
+    },
+    "52" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
+      "pos" : "45.27",
+      "includingLoc" : "None"
+    },
+    "53" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
+      "pos" : "45.30",
+      "includingLoc" : "None"
+    },
+    "54" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
+      "pos" : "45.27",
+      "includingLoc" : "None"
+    },
+    "55" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
+      "pos" : "45.30",
+      "includingLoc" : "None"
+    },
+    "56" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
+      "pos" : "45.27",
+      "includingLoc" : "None"
+    },
+    "57" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
+      "pos" : "45.45",
+      "includingLoc" : "None"
+    },
+    "58" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
+      "pos" : "45.59",
+      "includingLoc" : "None"
+    },
+    "59" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
+      "pos" : "45.62",
+      "includingLoc" : "None"
+    },
+    "60" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
+      "pos" : "45.3",
+      "includingLoc" : "None"
+    },
+    "61" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
+      "pos" : "45.30",
+      "includingLoc" : "None"
+    },
+    "62" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
+      "pos" : "45.27",
+      "includingLoc" : "None"
+    },
+    "63" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
+      "pos" : "45.30",
+      "includingLoc" : "None"
+    },
+    "64" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
+      "pos" : "45.27",
+      "includingLoc" : "None"
+    },
+    "65" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
+      "pos" : "45.30",
+      "includingLoc" : "None"
+    },
+    "66" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
+      "pos" : "45.27",
+      "includingLoc" : "None"
+    },
+    "67" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
+      "pos" : "45.45",
+      "includingLoc" : "None"
+    },
+    "68" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
+      "pos" : "45.59",
+      "includingLoc" : "None"
+    },
+    "69" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
+      "pos" : "45.62",
+      "includingLoc" : "None"
+    },
+    "70" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
+      "pos" : "45.3",
+      "includingLoc" : "None"
+    },
+    "71" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",
+      "pos" : "30.1",
+      "includingLoc" : "None"
     }
   }
 }

--- a/tests/interfaces/interfaces_locations.json
+++ b/tests/interfaces/interfaces_locations.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion": "[ fpp version ]",
+  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
   "locationMap": {
     "0": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",

--- a/tests/internal_ports/internal_ports_analysis.json
+++ b/tests/internal_ports/internal_ports_analysis.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion": "[ fpp version ]",
+  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
   "analysis": {
     "componentInstanceMap": {},
     "componentMap": {

--- a/tests/internal_ports/internal_ports_analysis.json
+++ b/tests/internal_ports/internal_ports_analysis.json
@@ -1,102 +1,141 @@
 {
-  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
-  "analysis": {
-    "componentInstanceMap": {},
-    "componentMap": {
-      "43": {
-        "aNode": {
-          "astNodeId": 43
+  "fppVersion" : "v3.1.0a10-54-g11243e778",
+  "analysis" : {
+    "componentInstanceMap" : {
+      
+    },
+    "componentMap" : {
+      "43" : {
+        "aNode" : {
+          "astNodeId" : 43
         },
-        "portMap": {
-          "pInternal": {
-            "Internal": {
-              "aNode": {
-                "astNodeId": 42
+        "portMap" : {
+          "pInternal" : {
+            "Internal" : {
+              "aNode" : {
+                "astNodeId" : 42
               },
-              "priority": {
-                "Some": 10
+              "priority" : {
+                "Some" : 10
               },
-              "queueFull": {
-                "Drop": {}
+              "queueFull" : {
+                "Drop" : {
+                  
+                }
               }
             }
           }
         },
-        "specialPortMap": {},
-        "commandMap": {},
-        "defaultOpcode": 0,
-        "tlmChannelMap": {},
-        "tlmChannelNameMap": {},
-        "defaultTlmChannelId": 0,
-        "eventMap": {},
-        "defaultEventId": 0,
-        "paramMap": {},
-        "specPortMatchingList": [],
-        "stateMachineInstanceMap": {},
-        "portMatchingList": [],
-        "defaultParamId": 0,
-        "containerMap": {},
-        "defaultContainerId": 0,
-        "recordMap": {},
-        "defaultRecordId": 0
+        "specialPortMap" : {
+          
+        },
+        "commandMap" : {
+          
+        },
+        "defaultOpcode" : 0,
+        "tlmChannelMap" : {
+          
+        },
+        "tlmChannelNameMap" : {
+          
+        },
+        "defaultTlmChannelId" : 0,
+        "eventMap" : {
+          
+        },
+        "defaultEventId" : 0,
+        "paramMap" : {
+          
+        },
+        "specPortMatchingList" : [
+        ],
+        "stateMachineInstanceMap" : {
+          
+        },
+        "portMatchingList" : [
+        ],
+        "defaultParamId" : 0,
+        "containerMap" : {
+          
+        },
+        "defaultContainerId" : 0,
+        "recordMap" : {
+          
+        },
+        "defaultRecordId" : 0
       }
     },
-    "includedFileSet": [],
-    "inputFileSet": [
+    "includedFileSet" : [
+    ],
+    "inputFileSet" : [
       "[ local path prefix ]/compiler/tools/fpp-to-json/test/internalPorts.fpp"
     ],
-    "locationSpecifierMap": [],
-    "parentSymbolMap": {},
-    "symbolScopeMap": {
-      "43": {
-        "map": {}
+    "locationSpecifierMap" : [
+    ],
+    "parentSymbolMap" : {
+      
+    },
+    "symbolScopeMap" : {
+      "43" : {
+        "map" : {
+          
+        }
       }
     },
-    "topologyMap": {},
-    "typeMap": {
-      "0": {
-        "AbsType": {
-          "node": {
-            "astNodeId": 0
+    "topologyMap" : {
+      
+    },
+    "typeMap" : {
+      "0" : {
+        "AbsType" : {
+          "node" : {
+            "astNodeId" : 0
           }
         }
       },
-      "39": {
-        "AbsType": {
-          "node": {
-            "astNodeId": 0
+      "39" : {
+        "AbsType" : {
+          "node" : {
+            "astNodeId" : 0
           }
         }
       },
-      "41": {
-        "Int": {
-          "Integer": {}
+      "41" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       }
     },
-    "useDefMap": {
-      "38": {
-        "AbsType": {
-          "nodeId": 0,
-          "unqualifiedName": "T"
+    "useDefMap" : {
+      "38" : {
+        "AbsType" : {
+          "nodeId" : 0,
+          "unqualifiedName" : "T"
         }
       },
-      "39": {
-        "AbsType": {
-          "nodeId": 0,
-          "unqualifiedName": "T"
+      "39" : {
+        "AbsType" : {
+          "nodeId" : 0,
+          "unqualifiedName" : "T"
         }
       }
     },
-    "valueMap": {
-      "41": {
-        "Integer": {
-          "value": 10
+    "valueMap" : {
+      "41" : {
+        "Integer" : {
+          "value" : 10
         }
       }
     },
-    "stateMachineMap": {},
-    "dictionarySymbolSet": [],
-    "interfaceMap": {}
+    "stateMachineMap" : {
+      
+    },
+    "dictionarySymbolSet" : [
+    ],
+    "interfaceMap" : {
+      
+    }
   }
 }

--- a/tests/internal_ports/internal_ports_ast.json
+++ b/tests/internal_ports/internal_ports_ast.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion": "[ fpp version ]",
+  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
   "ast": [
     {
       "members": [

--- a/tests/internal_ports/internal_ports_ast.json
+++ b/tests/internal_ports/internal_ports_ast.json
@@ -1,23 +1,26 @@
 {
-  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
-  "ast": [
+  "fppVersion" : "v3.1.0a10-54-g11243e778",
+  "ast" : [
     {
-      "members": [
+      "members" : [
         [
-          ["A data type T"],
+          [
+            "A data type T"
+          ],
           {
-            "DefAbsType": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "T"
+            "DefAbsType" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "T"
                   },
-                  "id": 0
+                  "id" : 0
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
           [
@@ -25,92 +28,104 @@
             "with priority and queue full behavior"
           ],
           {
-            "DefComponent": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "kind": {
-                      "Active": {}
+            "DefComponent" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "kind" : {
+                      "Active" : {
+                        
+                      }
                     },
-                    "name": "InternalSelfMessage",
-                    "members": [
+                    "name" : "InternalSelfMessage",
+                    "members" : [
                       [
-                        ["An internal port for sending data of type T"],
+                        [
+                          "An internal port for sending data of type T"
+                        ],
                         {
-                          "SpecInternalPort": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "name": "pInternal",
-                                  "params": [
+                          "SpecInternalPort" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "name" : "pInternal",
+                                  "params" : [
                                     [
-                                      [],
+                                      [
+                                      ],
                                       {
-                                        "AstNode": {
-                                          "data": {
-                                            "kind": {
-                                              "Value": {}
+                                        "AstNode" : {
+                                          "data" : {
+                                            "kind" : {
+                                              "Value" : {
+                                                
+                                              }
                                             },
-                                            "name": "t",
-                                            "typeName": {
-                                              "AstNode": {
-                                                "data": {
-                                                  "TypeNameQualIdent": {
-                                                    "name": {
-                                                      "AstNode": {
-                                                        "data": {
-                                                          "Unqualified": {
-                                                            "name": "T"
+                                            "name" : "t",
+                                            "typeName" : {
+                                              "AstNode" : {
+                                                "data" : {
+                                                  "TypeNameQualIdent" : {
+                                                    "name" : {
+                                                      "AstNode" : {
+                                                        "data" : {
+                                                          "Unqualified" : {
+                                                            "name" : "T"
                                                           }
                                                         },
-                                                        "id": 38
+                                                        "id" : 38
                                                       }
                                                     }
                                                   }
                                                 },
-                                                "id": 39
+                                                "id" : 39
                                               }
                                             }
                                           },
-                                          "id": 40
+                                          "id" : 40
                                         }
                                       },
-                                      []
+                                      [
+                                      ]
                                     ]
                                   ],
-                                  "priority": {
-                                    "Some": {
-                                      "AstNode": {
-                                        "data": {
-                                          "ExprLiteralInt": {
-                                            "value": "10"
+                                  "priority" : {
+                                    "Some" : {
+                                      "AstNode" : {
+                                        "data" : {
+                                          "ExprLiteralInt" : {
+                                            "value" : "10"
                                           }
                                         },
-                                        "id": 41
+                                        "id" : 41
                                       }
                                     }
                                   },
-                                  "queueFull": {
-                                    "Some": {
-                                      "Drop": {}
+                                  "queueFull" : {
+                                    "Some" : {
+                                      "Drop" : {
+                                        
+                                      }
                                     }
                                   }
                                 },
-                                "id": 42
+                                "id" : 42
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ]
                     ]
                   },
-                  "id": 43
+                  "id" : 43
                 }
               }
             }
           },
-          []
+          [
+          ]
         ]
       ]
     }

--- a/tests/internal_ports/internal_ports_locations.json
+++ b/tests/internal_ports/internal_ports_locations.json
@@ -1,225 +1,225 @@
 {
-  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
-  "locationMap": {
-    "0": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/internalPorts.fpp",
-      "pos": "2.1",
-      "includingLoc": "None"
+  "fppVersion" : "v3.1.0a10-54-g11243e778",
+  "locationMap" : {
+    "0" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/internalPorts.fpp",
+      "pos" : "2.1",
+      "includingLoc" : "None"
     },
-    "1": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/internalPorts.fpp",
-      "pos": "9.30",
-      "includingLoc": "None"
+    "1" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/internalPorts.fpp",
+      "pos" : "9.30",
+      "includingLoc" : "None"
     },
-    "2": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/internalPorts.fpp",
-      "pos": "9.30",
-      "includingLoc": "None"
+    "2" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/internalPorts.fpp",
+      "pos" : "9.30",
+      "includingLoc" : "None"
     },
-    "3": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/internalPorts.fpp",
-      "pos": "9.30",
-      "includingLoc": "None"
+    "3" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/internalPorts.fpp",
+      "pos" : "9.30",
+      "includingLoc" : "None"
     },
-    "4": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/internalPorts.fpp",
-      "pos": "9.27",
-      "includingLoc": "None"
+    "4" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/internalPorts.fpp",
+      "pos" : "9.27",
+      "includingLoc" : "None"
     },
-    "5": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/internalPorts.fpp",
-      "pos": "9.30",
-      "includingLoc": "None"
+    "5" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/internalPorts.fpp",
+      "pos" : "9.30",
+      "includingLoc" : "None"
     },
-    "6": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/internalPorts.fpp",
-      "pos": "9.30",
-      "includingLoc": "None"
+    "6" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/internalPorts.fpp",
+      "pos" : "9.30",
+      "includingLoc" : "None"
     },
-    "7": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/internalPorts.fpp",
-      "pos": "9.30",
-      "includingLoc": "None"
+    "7" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/internalPorts.fpp",
+      "pos" : "9.30",
+      "includingLoc" : "None"
     },
-    "8": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/internalPorts.fpp",
-      "pos": "9.27",
-      "includingLoc": "None"
+    "8" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/internalPorts.fpp",
+      "pos" : "9.27",
+      "includingLoc" : "None"
     },
-    "9": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/internalPorts.fpp",
-      "pos": "9.30",
-      "includingLoc": "None"
+    "9" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/internalPorts.fpp",
+      "pos" : "9.30",
+      "includingLoc" : "None"
     },
-    "10": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/internalPorts.fpp",
-      "pos": "9.30",
-      "includingLoc": "None"
+    "10" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/internalPorts.fpp",
+      "pos" : "9.30",
+      "includingLoc" : "None"
     },
-    "11": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/internalPorts.fpp",
-      "pos": "9.30",
-      "includingLoc": "None"
+    "11" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/internalPorts.fpp",
+      "pos" : "9.30",
+      "includingLoc" : "None"
     },
-    "12": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/internalPorts.fpp",
-      "pos": "9.27",
-      "includingLoc": "None"
+    "12" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/internalPorts.fpp",
+      "pos" : "9.27",
+      "includingLoc" : "None"
     },
-    "13": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/internalPorts.fpp",
-      "pos": "9.42",
-      "includingLoc": "None"
+    "13" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/internalPorts.fpp",
+      "pos" : "9.42",
+      "includingLoc" : "None"
     },
-    "14": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/internalPorts.fpp",
-      "pos": "9.3",
-      "includingLoc": "None"
+    "14" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/internalPorts.fpp",
+      "pos" : "9.3",
+      "includingLoc" : "None"
     },
-    "15": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/internalPorts.fpp",
-      "pos": "9.30",
-      "includingLoc": "None"
+    "15" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/internalPorts.fpp",
+      "pos" : "9.30",
+      "includingLoc" : "None"
     },
-    "16": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/internalPorts.fpp",
-      "pos": "9.30",
-      "includingLoc": "None"
+    "16" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/internalPorts.fpp",
+      "pos" : "9.30",
+      "includingLoc" : "None"
     },
-    "17": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/internalPorts.fpp",
-      "pos": "9.30",
-      "includingLoc": "None"
+    "17" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/internalPorts.fpp",
+      "pos" : "9.30",
+      "includingLoc" : "None"
     },
-    "18": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/internalPorts.fpp",
-      "pos": "9.27",
-      "includingLoc": "None"
+    "18" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/internalPorts.fpp",
+      "pos" : "9.27",
+      "includingLoc" : "None"
     },
-    "19": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/internalPorts.fpp",
-      "pos": "9.30",
-      "includingLoc": "None"
+    "19" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/internalPorts.fpp",
+      "pos" : "9.30",
+      "includingLoc" : "None"
     },
-    "20": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/internalPorts.fpp",
-      "pos": "9.30",
-      "includingLoc": "None"
+    "20" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/internalPorts.fpp",
+      "pos" : "9.30",
+      "includingLoc" : "None"
     },
-    "21": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/internalPorts.fpp",
-      "pos": "9.30",
-      "includingLoc": "None"
+    "21" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/internalPorts.fpp",
+      "pos" : "9.30",
+      "includingLoc" : "None"
     },
-    "22": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/internalPorts.fpp",
-      "pos": "9.27",
-      "includingLoc": "None"
+    "22" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/internalPorts.fpp",
+      "pos" : "9.27",
+      "includingLoc" : "None"
     },
-    "23": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/internalPorts.fpp",
-      "pos": "9.30",
-      "includingLoc": "None"
+    "23" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/internalPorts.fpp",
+      "pos" : "9.30",
+      "includingLoc" : "None"
     },
-    "24": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/internalPorts.fpp",
-      "pos": "9.30",
-      "includingLoc": "None"
+    "24" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/internalPorts.fpp",
+      "pos" : "9.30",
+      "includingLoc" : "None"
     },
-    "25": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/internalPorts.fpp",
-      "pos": "9.30",
-      "includingLoc": "None"
+    "25" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/internalPorts.fpp",
+      "pos" : "9.30",
+      "includingLoc" : "None"
     },
-    "26": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/internalPorts.fpp",
-      "pos": "9.27",
-      "includingLoc": "None"
+    "26" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/internalPorts.fpp",
+      "pos" : "9.27",
+      "includingLoc" : "None"
     },
-    "27": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/internalPorts.fpp",
-      "pos": "9.42",
-      "includingLoc": "None"
+    "27" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/internalPorts.fpp",
+      "pos" : "9.42",
+      "includingLoc" : "None"
     },
-    "28": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/internalPorts.fpp",
-      "pos": "9.3",
-      "includingLoc": "None"
+    "28" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/internalPorts.fpp",
+      "pos" : "9.3",
+      "includingLoc" : "None"
     },
-    "29": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/internalPorts.fpp",
-      "pos": "9.30",
-      "includingLoc": "None"
+    "29" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/internalPorts.fpp",
+      "pos" : "9.30",
+      "includingLoc" : "None"
     },
-    "30": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/internalPorts.fpp",
-      "pos": "9.30",
-      "includingLoc": "None"
+    "30" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/internalPorts.fpp",
+      "pos" : "9.30",
+      "includingLoc" : "None"
     },
-    "31": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/internalPorts.fpp",
-      "pos": "9.30",
-      "includingLoc": "None"
+    "31" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/internalPorts.fpp",
+      "pos" : "9.30",
+      "includingLoc" : "None"
     },
-    "32": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/internalPorts.fpp",
-      "pos": "9.27",
-      "includingLoc": "None"
+    "32" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/internalPorts.fpp",
+      "pos" : "9.27",
+      "includingLoc" : "None"
     },
-    "33": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/internalPorts.fpp",
-      "pos": "9.30",
-      "includingLoc": "None"
+    "33" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/internalPorts.fpp",
+      "pos" : "9.30",
+      "includingLoc" : "None"
     },
-    "34": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/internalPorts.fpp",
-      "pos": "9.30",
-      "includingLoc": "None"
+    "34" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/internalPorts.fpp",
+      "pos" : "9.30",
+      "includingLoc" : "None"
     },
-    "35": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/internalPorts.fpp",
-      "pos": "9.30",
-      "includingLoc": "None"
+    "35" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/internalPorts.fpp",
+      "pos" : "9.30",
+      "includingLoc" : "None"
     },
-    "36": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/internalPorts.fpp",
-      "pos": "9.27",
-      "includingLoc": "None"
+    "36" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/internalPorts.fpp",
+      "pos" : "9.27",
+      "includingLoc" : "None"
     },
-    "37": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/internalPorts.fpp",
-      "pos": "9.30",
-      "includingLoc": "None"
+    "37" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/internalPorts.fpp",
+      "pos" : "9.30",
+      "includingLoc" : "None"
     },
-    "38": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/internalPorts.fpp",
-      "pos": "9.30",
-      "includingLoc": "None"
+    "38" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/internalPorts.fpp",
+      "pos" : "9.30",
+      "includingLoc" : "None"
     },
-    "39": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/internalPorts.fpp",
-      "pos": "9.30",
-      "includingLoc": "None"
+    "39" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/internalPorts.fpp",
+      "pos" : "9.30",
+      "includingLoc" : "None"
     },
-    "40": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/internalPorts.fpp",
-      "pos": "9.27",
-      "includingLoc": "None"
+    "40" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/internalPorts.fpp",
+      "pos" : "9.27",
+      "includingLoc" : "None"
     },
-    "41": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/internalPorts.fpp",
-      "pos": "9.42",
-      "includingLoc": "None"
+    "41" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/internalPorts.fpp",
+      "pos" : "9.42",
+      "includingLoc" : "None"
     },
-    "42": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/internalPorts.fpp",
-      "pos": "9.3",
-      "includingLoc": "None"
+    "42" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/internalPorts.fpp",
+      "pos" : "9.3",
+      "includingLoc" : "None"
     },
-    "43": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/internalPorts.fpp",
-      "pos": "6.1",
-      "includingLoc": "None"
+    "43" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/internalPorts.fpp",
+      "pos" : "6.1",
+      "includingLoc" : "None"
     }
   }
 }

--- a/tests/internal_ports/internal_ports_locations.json
+++ b/tests/internal_ports/internal_ports_locations.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion": "[ fpp version ]",
+  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
   "locationMap": {
     "0": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/internalPorts.fpp",

--- a/tests/location_specifier/location_specifier.fpp
+++ b/tests/location_specifier/location_specifier.fpp
@@ -1,0 +1,7 @@
+locate dictionary constant c1 at "c.fpp"
+
+locate constant c2 at "c.fpp"
+
+locate dictionary type t1 at "t.fpp"
+
+locate type t2 at "t.fpp"

--- a/tests/location_specifier/location_specifier.fpp
+++ b/tests/location_specifier/location_specifier.fpp
@@ -1,7 +1,3 @@
-locate dictionary constant c1 at "c.fpp"
+locate dictionary constant c at "dictionary_c.fpp"
 
-locate constant c2 at "c.fpp"
-
-locate dictionary type t1 at "t.fpp"
-
-locate type t2 at "t.fpp"
+locate dictionary type T1 at "dictionary_T1.fpp"

--- a/tests/location_specifier/location_specifier_analysis.json
+++ b/tests/location_specifier/location_specifier_analysis.json
@@ -1,0 +1,78 @@
+{
+  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
+  "analysis": {
+    "componentInstanceMap": {},
+    "componentMap": {},
+    "includedFileSet": [],
+    "inputFileSet": [
+      "[ local path prefix ]/compiler/tools/fpp-to-json/test/location_specifier.fpp"
+    ],
+    "locationSpecifierMap": [
+      [
+        [
+          {
+            "Constant": {}
+          },
+          {
+            "qualifier": [],
+            "base": "c1"
+          }
+        ],
+        {
+          "astNodeId": 3
+        }
+      ],
+      [
+        [
+          {
+            "Constant": {}
+          },
+          {
+            "qualifier": [],
+            "base": "c2"
+          }
+        ],
+        {
+          "astNodeId": 7
+        }
+      ],
+      [
+        [
+          {
+            "Type": {}
+          },
+          {
+            "qualifier": [],
+            "base": "t1"
+          }
+        ],
+        {
+          "astNodeId": 11
+        }
+      ],
+      [
+        [
+          {
+            "Type": {}
+          },
+          {
+            "qualifier": [],
+            "base": "t2"
+          }
+        ],
+        {
+          "astNodeId": 15
+        }
+      ]
+    ],
+    "parentSymbolMap": {},
+    "symbolScopeMap": {},
+    "topologyMap": {},
+    "typeMap": {},
+    "useDefMap": {},
+    "valueMap": {},
+    "stateMachineMap": {},
+    "dictionarySymbolSet": [],
+    "interfaceMap": {}
+  }
+}

--- a/tests/location_specifier/location_specifier_analysis.json
+++ b/tests/location_specifier/location_specifier_analysis.json
@@ -1,78 +1,78 @@
 {
-  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
-  "analysis": {
-    "componentInstanceMap": {},
-    "componentMap": {},
-    "includedFileSet": [],
-    "inputFileSet": [
-      "[ local path prefix ]/compiler/tools/fpp-to-json/test/location_specifier.fpp"
+  "fppVersion" : "v3.1.0a10-54-g11243e778",
+  "analysis" : {
+    "componentInstanceMap" : {
+      
+    },
+    "componentMap" : {
+      
+    },
+    "includedFileSet" : [
     ],
-    "locationSpecifierMap": [
+    "inputFileSet" : [
+      "[ local path prefix ]/compiler/tools/fpp-depend/test/dictionary_no_top.fpp"
+    ],
+    "locationSpecifierMap" : [
       [
         [
           {
-            "Constant": {}
+            "Constant" : {
+              
+            }
           },
           {
-            "qualifier": [],
-            "base": "c1"
+            "qualifier" : [
+            ],
+            "base" : "c"
           }
         ],
         {
-          "astNodeId": 3
+          "astNodeId" : 3
         }
       ],
       [
         [
           {
-            "Constant": {}
+            "Type" : {
+              
+            }
           },
           {
-            "qualifier": [],
-            "base": "c2"
+            "qualifier" : [
+            ],
+            "base" : "T1"
           }
         ],
         {
-          "astNodeId": 7
-        }
-      ],
-      [
-        [
-          {
-            "Type": {}
-          },
-          {
-            "qualifier": [],
-            "base": "t1"
-          }
-        ],
-        {
-          "astNodeId": 11
-        }
-      ],
-      [
-        [
-          {
-            "Type": {}
-          },
-          {
-            "qualifier": [],
-            "base": "t2"
-          }
-        ],
-        {
-          "astNodeId": 15
+          "astNodeId" : 7
         }
       ]
     ],
-    "parentSymbolMap": {},
-    "symbolScopeMap": {},
-    "topologyMap": {},
-    "typeMap": {},
-    "useDefMap": {},
-    "valueMap": {},
-    "stateMachineMap": {},
-    "dictionarySymbolSet": [],
-    "interfaceMap": {}
+    "parentSymbolMap" : {
+      
+    },
+    "symbolScopeMap" : {
+      
+    },
+    "topologyMap" : {
+      
+    },
+    "typeMap" : {
+      
+    },
+    "useDefMap" : {
+      
+    },
+    "valueMap" : {
+      
+    },
+    "stateMachineMap" : {
+      
+    },
+    "dictionarySymbolSet" : [
+    ],
+    "interfaceMap" : {
+      
+    }
   }
 }

--- a/tests/location_specifier/location_specifier_ast.json
+++ b/tests/location_specifier/location_specifier_ast.json
@@ -1,0 +1,149 @@
+{
+  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
+  "ast": [
+    {
+      "members": [
+        [
+          [],
+          {
+            "SpecLoc": {
+              "node": {
+                "AstNode": {
+                  "data": {
+                    "kind": {
+                      "Constant": {}
+                    },
+                    "symbol": {
+                      "AstNode": {
+                        "data": {
+                          "Unqualified": {
+                            "name": "c1"
+                          }
+                        },
+                        "id": 1
+                      }
+                    },
+                    "file": {
+                      "AstNode": {
+                        "data": "c.fpp",
+                        "id": 2
+                      }
+                    },
+                    "isDictionaryDef": true
+                  },
+                  "id": 3
+                }
+              }
+            }
+          },
+          []
+        ],
+        [
+          [],
+          {
+            "SpecLoc": {
+              "node": {
+                "AstNode": {
+                  "data": {
+                    "kind": {
+                      "Constant": {}
+                    },
+                    "symbol": {
+                      "AstNode": {
+                        "data": {
+                          "Unqualified": {
+                            "name": "c2"
+                          }
+                        },
+                        "id": 5
+                      }
+                    },
+                    "file": {
+                      "AstNode": {
+                        "data": "c.fpp",
+                        "id": 6
+                      }
+                    },
+                    "isDictionaryDef": false
+                  },
+                  "id": 7
+                }
+              }
+            }
+          },
+          []
+        ],
+        [
+          [],
+          {
+            "SpecLoc": {
+              "node": {
+                "AstNode": {
+                  "data": {
+                    "kind": {
+                      "Type": {}
+                    },
+                    "symbol": {
+                      "AstNode": {
+                        "data": {
+                          "Unqualified": {
+                            "name": "t1"
+                          }
+                        },
+                        "id": 9
+                      }
+                    },
+                    "file": {
+                      "AstNode": {
+                        "data": "t.fpp",
+                        "id": 10
+                      }
+                    },
+                    "isDictionaryDef": true
+                  },
+                  "id": 11
+                }
+              }
+            }
+          },
+          []
+        ],
+        [
+          [],
+          {
+            "SpecLoc": {
+              "node": {
+                "AstNode": {
+                  "data": {
+                    "kind": {
+                      "Type": {}
+                    },
+                    "symbol": {
+                      "AstNode": {
+                        "data": {
+                          "Unqualified": {
+                            "name": "t2"
+                          }
+                        },
+                        "id": 13
+                      }
+                    },
+                    "file": {
+                      "AstNode": {
+                        "data": "t.fpp",
+                        "id": 14
+                      }
+                    },
+                    "isDictionaryDef": false
+                  },
+                  "id": 15
+                }
+              }
+            }
+          },
+          []
+        ]
+      ]
+    }
+  ]
+}

--- a/tests/location_specifier/location_specifier_ast.json
+++ b/tests/location_specifier/location_specifier_ast.json
@@ -1,147 +1,85 @@
 {
-  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
-  "ast": [
+  "fppVersion" : "v3.1.0a10-54-g11243e778",
+  "ast" : [
     {
-      "members": [
+      "members" : [
         [
-          [],
+          [
+          ],
           {
-            "SpecLoc": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "kind": {
-                      "Constant": {}
+            "SpecLoc" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "kind" : {
+                      "Constant" : {
+                        
+                      }
                     },
-                    "symbol": {
-                      "AstNode": {
-                        "data": {
-                          "Unqualified": {
-                            "name": "c1"
+                    "symbol" : {
+                      "AstNode" : {
+                        "data" : {
+                          "Unqualified" : {
+                            "name" : "c"
                           }
                         },
-                        "id": 1
+                        "id" : 1
                       }
                     },
-                    "file": {
-                      "AstNode": {
-                        "data": "c.fpp",
-                        "id": 2
+                    "file" : {
+                      "AstNode" : {
+                        "data" : "dictionary_c.fpp",
+                        "id" : 2
                       }
                     },
-                    "isDictionaryDef": true
+                    "isDictionaryDef" : true
                   },
-                  "id": 3
+                  "id" : 3
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          [],
+          [
+          ],
           {
-            "SpecLoc": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "kind": {
-                      "Constant": {}
+            "SpecLoc" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "kind" : {
+                      "Type" : {
+                        
+                      }
                     },
-                    "symbol": {
-                      "AstNode": {
-                        "data": {
-                          "Unqualified": {
-                            "name": "c2"
+                    "symbol" : {
+                      "AstNode" : {
+                        "data" : {
+                          "Unqualified" : {
+                            "name" : "T1"
                           }
                         },
-                        "id": 5
+                        "id" : 5
                       }
                     },
-                    "file": {
-                      "AstNode": {
-                        "data": "c.fpp",
-                        "id": 6
+                    "file" : {
+                      "AstNode" : {
+                        "data" : "dictionary_T1.fpp",
+                        "id" : 6
                       }
                     },
-                    "isDictionaryDef": false
+                    "isDictionaryDef" : true
                   },
-                  "id": 7
+                  "id" : 7
                 }
               }
             }
           },
-          []
-        ],
-        [
-          [],
-          {
-            "SpecLoc": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "kind": {
-                      "Type": {}
-                    },
-                    "symbol": {
-                      "AstNode": {
-                        "data": {
-                          "Unqualified": {
-                            "name": "t1"
-                          }
-                        },
-                        "id": 9
-                      }
-                    },
-                    "file": {
-                      "AstNode": {
-                        "data": "t.fpp",
-                        "id": 10
-                      }
-                    },
-                    "isDictionaryDef": true
-                  },
-                  "id": 11
-                }
-              }
-            }
-          },
-          []
-        ],
-        [
-          [],
-          {
-            "SpecLoc": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "kind": {
-                      "Type": {}
-                    },
-                    "symbol": {
-                      "AstNode": {
-                        "data": {
-                          "Unqualified": {
-                            "name": "t2"
-                          }
-                        },
-                        "id": 13
-                      }
-                    },
-                    "file": {
-                      "AstNode": {
-                        "data": "t.fpp",
-                        "id": 14
-                      }
-                    },
-                    "isDictionaryDef": false
-                  },
-                  "id": 15
-                }
-              }
-            }
-          },
-          []
+          [
+          ]
         ]
       ]
     }

--- a/tests/location_specifier/location_specifier_locations.json
+++ b/tests/location_specifier/location_specifier_locations.json
@@ -1,0 +1,85 @@
+{
+  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
+  "locationMap": {
+    "0": {
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/location_specifier.fpp",
+      "pos": "1.28",
+      "includingLoc": "None"
+    },
+    "1": {
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/location_specifier.fpp",
+      "pos": "1.28",
+      "includingLoc": "None"
+    },
+    "2": {
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/location_specifier.fpp",
+      "pos": "1.34",
+      "includingLoc": "None"
+    },
+    "3": {
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/location_specifier.fpp",
+      "pos": "1.1",
+      "includingLoc": "None"
+    },
+    "4": {
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/location_specifier.fpp",
+      "pos": "3.17",
+      "includingLoc": "None"
+    },
+    "5": {
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/location_specifier.fpp",
+      "pos": "3.17",
+      "includingLoc": "None"
+    },
+    "6": {
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/location_specifier.fpp",
+      "pos": "3.23",
+      "includingLoc": "None"
+    },
+    "7": {
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/location_specifier.fpp",
+      "pos": "3.1",
+      "includingLoc": "None"
+    },
+    "8": {
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/location_specifier.fpp",
+      "pos": "5.24",
+      "includingLoc": "None"
+    },
+    "9": {
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/location_specifier.fpp",
+      "pos": "5.24",
+      "includingLoc": "None"
+    },
+    "10": {
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/location_specifier.fpp",
+      "pos": "5.30",
+      "includingLoc": "None"
+    },
+    "11": {
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/location_specifier.fpp",
+      "pos": "5.1",
+      "includingLoc": "None"
+    },
+    "12": {
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/location_specifier.fpp",
+      "pos": "7.13",
+      "includingLoc": "None"
+    },
+    "13": {
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/location_specifier.fpp",
+      "pos": "7.13",
+      "includingLoc": "None"
+    },
+    "14": {
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/location_specifier.fpp",
+      "pos": "7.19",
+      "includingLoc": "None"
+    },
+    "15": {
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/location_specifier.fpp",
+      "pos": "7.1",
+      "includingLoc": "None"
+    }
+  }
+}

--- a/tests/location_specifier/location_specifier_locations.json
+++ b/tests/location_specifier/location_specifier_locations.json
@@ -1,85 +1,45 @@
 {
-  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
-  "locationMap": {
-    "0": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/location_specifier.fpp",
-      "pos": "1.28",
-      "includingLoc": "None"
+  "fppVersion" : "v3.1.0a10-54-g11243e778",
+  "locationMap" : {
+    "0" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-depend/test/dictionary_no_top.fpp",
+      "pos" : "4.28",
+      "includingLoc" : "None"
     },
-    "1": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/location_specifier.fpp",
-      "pos": "1.28",
-      "includingLoc": "None"
+    "1" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-depend/test/dictionary_no_top.fpp",
+      "pos" : "4.28",
+      "includingLoc" : "None"
     },
-    "2": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/location_specifier.fpp",
-      "pos": "1.34",
-      "includingLoc": "None"
+    "2" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-depend/test/dictionary_no_top.fpp",
+      "pos" : "4.33",
+      "includingLoc" : "None"
     },
-    "3": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/location_specifier.fpp",
-      "pos": "1.1",
-      "includingLoc": "None"
+    "3" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-depend/test/dictionary_no_top.fpp",
+      "pos" : "4.1",
+      "includingLoc" : "None"
     },
-    "4": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/location_specifier.fpp",
-      "pos": "3.17",
-      "includingLoc": "None"
+    "4" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-depend/test/dictionary_no_top.fpp",
+      "pos" : "5.24",
+      "includingLoc" : "None"
     },
-    "5": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/location_specifier.fpp",
-      "pos": "3.17",
-      "includingLoc": "None"
+    "5" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-depend/test/dictionary_no_top.fpp",
+      "pos" : "5.24",
+      "includingLoc" : "None"
     },
-    "6": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/location_specifier.fpp",
-      "pos": "3.23",
-      "includingLoc": "None"
+    "6" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-depend/test/dictionary_no_top.fpp",
+      "pos" : "5.30",
+      "includingLoc" : "None"
     },
-    "7": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/location_specifier.fpp",
-      "pos": "3.1",
-      "includingLoc": "None"
-    },
-    "8": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/location_specifier.fpp",
-      "pos": "5.24",
-      "includingLoc": "None"
-    },
-    "9": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/location_specifier.fpp",
-      "pos": "5.24",
-      "includingLoc": "None"
-    },
-    "10": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/location_specifier.fpp",
-      "pos": "5.30",
-      "includingLoc": "None"
-    },
-    "11": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/location_specifier.fpp",
-      "pos": "5.1",
-      "includingLoc": "None"
-    },
-    "12": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/location_specifier.fpp",
-      "pos": "7.13",
-      "includingLoc": "None"
-    },
-    "13": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/location_specifier.fpp",
-      "pos": "7.13",
-      "includingLoc": "None"
-    },
-    "14": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/location_specifier.fpp",
-      "pos": "7.19",
-      "includingLoc": "None"
-    },
-    "15": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/location_specifier.fpp",
-      "pos": "7.1",
-      "includingLoc": "None"
+    "7" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-depend/test/dictionary_no_top.fpp",
+      "pos" : "5.1",
+      "includingLoc" : "None"
     }
   }
 }

--- a/tests/matched_ports/matched_ports_analysis.json
+++ b/tests/matched_ports/matched_ports_analysis.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion": "[ fpp version ]",
+  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
   "analysis": {
     "componentInstanceMap": {},
     "componentMap": {

--- a/tests/matched_ports/matched_ports_analysis.json
+++ b/tests/matched_ports/matched_ports_analysis.json
@@ -1,216 +1,252 @@
 {
-  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
-  "analysis": {
-    "componentInstanceMap": {},
-    "componentMap": {
-      "21": {
-        "aNode": {
-          "astNodeId": 21
+  "fppVersion" : "v3.1.0a10-54-g11243e778",
+  "analysis" : {
+    "componentInstanceMap" : {
+      
+    },
+    "componentMap" : {
+      "21" : {
+        "aNode" : {
+          "astNodeId" : 21
         },
-        "portMap": {
-          "pingOut": {
-            "General": {
-              "aNode": {
-                "astNodeId": 6
+        "portMap" : {
+          "pingOut" : {
+            "General" : {
+              "aNode" : {
+                "astNodeId" : 6
               },
-              "specifier": {
-                "kind": {
-                  "Output": {}
-                },
-                "name": "pingOut",
-                "size": {
-                  "Some": {
-                    "astNodeId": 2
+              "specifier" : {
+                "kind" : {
+                  "Output" : {
+                    
                   }
                 },
-                "port": {
-                  "Some": {
-                    "astNodeId": 5
+                "name" : "pingOut",
+                "size" : {
+                  "Some" : {
+                    "astNodeId" : 2
                   }
                 },
-                "priority": "None",
-                "queueFull": "None"
+                "port" : {
+                  "Some" : {
+                    "astNodeId" : 5
+                  }
+                },
+                "priority" : "None",
+                "queueFull" : "None"
               },
-              "kind": "Output",
-              "size": 10,
-              "ty": {
-                "DefPort": {
-                  "symbol": {
-                    "Port": {
-                      "nodeId": 24,
-                      "unqualifiedName": "Ping"
+              "kind" : "Output",
+              "size" : 10,
+              "ty" : {
+                "DefPort" : {
+                  "symbol" : {
+                    "Port" : {
+                      "nodeId" : 24,
+                      "unqualifiedName" : "Ping"
                     }
                   }
                 }
               },
-              "importNodeIds": []
+              "importNodeIds" : [
+              ]
             }
           },
-          "pingIn": {
-            "General": {
-              "aNode": {
-                "astNodeId": 11
+          "pingIn" : {
+            "General" : {
+              "aNode" : {
+                "astNodeId" : 11
               },
-              "specifier": {
-                "kind": {
-                  "AsyncInput": {}
-                },
-                "name": "pingIn",
-                "size": {
-                  "Some": {
-                    "astNodeId": 7
+              "specifier" : {
+                "kind" : {
+                  "AsyncInput" : {
+                    
                   }
                 },
-                "port": {
-                  "Some": {
-                    "astNodeId": 10
+                "name" : "pingIn",
+                "size" : {
+                  "Some" : {
+                    "astNodeId" : 7
                   }
                 },
-                "priority": "None",
-                "queueFull": "None"
+                "port" : {
+                  "Some" : {
+                    "astNodeId" : 10
+                  }
+                },
+                "priority" : "None",
+                "queueFull" : "None"
               },
-              "kind": "AsyncInput",
-              "size": 10,
-              "ty": {
-                "DefPort": {
-                  "symbol": {
-                    "Port": {
-                      "nodeId": 24,
-                      "unqualifiedName": "Ping"
+              "kind" : "AsyncInput",
+              "size" : 10,
+              "ty" : {
+                "DefPort" : {
+                  "symbol" : {
+                    "Port" : {
+                      "nodeId" : 24,
+                      "unqualifiedName" : "Ping"
                     }
                   }
                 }
               },
-              "importNodeIds": []
+              "importNodeIds" : [
+              ]
             }
           }
         },
-        "specialPortMap": {},
-        "commandMap": {},
-        "defaultOpcode": 0,
-        "tlmChannelMap": {},
-        "tlmChannelNameMap": {},
-        "defaultTlmChannelId": 0,
-        "eventMap": {},
-        "defaultEventId": 0,
-        "paramMap": {},
-        "specPortMatchingList": [
+        "specialPortMap" : {
+          
+        },
+        "commandMap" : {
+          
+        },
+        "defaultOpcode" : 0,
+        "tlmChannelMap" : {
+          
+        },
+        "tlmChannelNameMap" : {
+          
+        },
+        "defaultTlmChannelId" : 0,
+        "eventMap" : {
+          
+        },
+        "defaultEventId" : 0,
+        "paramMap" : {
+          
+        },
+        "specPortMatchingList" : [
           {
-            "astNodeId": 20
+            "astNodeId" : 20
           }
         ],
-        "stateMachineInstanceMap": {},
-        "portMatchingList": [
+        "stateMachineInstanceMap" : {
+          
+        },
+        "portMatchingList" : [
           {
-            "aNode": {
-              "astNodeId": 20
+            "aNode" : {
+              "astNodeId" : 20
             },
-            "instance1": {
-              "aNode": {
-                "astNodeId": 6
+            "instance1" : {
+              "aNode" : {
+                "astNodeId" : 6
               },
-              "specifier": {
-                "kind": {
-                  "Output": {}
-                },
-                "name": "pingOut",
-                "size": {
-                  "Some": {
-                    "astNodeId": 2
+              "specifier" : {
+                "kind" : {
+                  "Output" : {
+                    
                   }
                 },
-                "port": {
-                  "Some": {
-                    "astNodeId": 5
+                "name" : "pingOut",
+                "size" : {
+                  "Some" : {
+                    "astNodeId" : 2
                   }
                 },
-                "priority": "None",
-                "queueFull": "None"
+                "port" : {
+                  "Some" : {
+                    "astNodeId" : 5
+                  }
+                },
+                "priority" : "None",
+                "queueFull" : "None"
               },
-              "kind": "Output",
-              "size": 10,
-              "ty": {
-                "DefPort": {
-                  "symbol": {
-                    "Port": {
-                      "nodeId": 24,
-                      "unqualifiedName": "Ping"
+              "kind" : "Output",
+              "size" : 10,
+              "ty" : {
+                "DefPort" : {
+                  "symbol" : {
+                    "Port" : {
+                      "nodeId" : 24,
+                      "unqualifiedName" : "Ping"
                     }
                   }
                 }
               },
-              "importNodeIds": []
+              "importNodeIds" : [
+              ]
             },
-            "instance2": {
-              "aNode": {
-                "astNodeId": 11
+            "instance2" : {
+              "aNode" : {
+                "astNodeId" : 11
               },
-              "specifier": {
-                "kind": {
-                  "AsyncInput": {}
-                },
-                "name": "pingIn",
-                "size": {
-                  "Some": {
-                    "astNodeId": 7
+              "specifier" : {
+                "kind" : {
+                  "AsyncInput" : {
+                    
                   }
                 },
-                "port": {
-                  "Some": {
-                    "astNodeId": 10
+                "name" : "pingIn",
+                "size" : {
+                  "Some" : {
+                    "astNodeId" : 7
                   }
                 },
-                "priority": "None",
-                "queueFull": "None"
+                "port" : {
+                  "Some" : {
+                    "astNodeId" : 10
+                  }
+                },
+                "priority" : "None",
+                "queueFull" : "None"
               },
-              "kind": "AsyncInput",
-              "size": 10,
-              "ty": {
-                "DefPort": {
-                  "symbol": {
-                    "Port": {
-                      "nodeId": 24,
-                      "unqualifiedName": "Ping"
+              "kind" : "AsyncInput",
+              "size" : 10,
+              "ty" : {
+                "DefPort" : {
+                  "symbol" : {
+                    "Port" : {
+                      "nodeId" : 24,
+                      "unqualifiedName" : "Ping"
                     }
                   }
                 }
               },
-              "importNodeIds": []
+              "importNodeIds" : [
+              ]
             }
           }
         ],
-        "defaultParamId": 0,
-        "containerMap": {},
-        "defaultContainerId": 0,
-        "recordMap": {},
-        "defaultRecordId": 0
+        "defaultParamId" : 0,
+        "containerMap" : {
+          
+        },
+        "defaultContainerId" : 0,
+        "recordMap" : {
+          
+        },
+        "defaultRecordId" : 0
       }
     },
-    "includedFileSet": [],
-    "inputFileSet": [
+    "includedFileSet" : [
+    ],
+    "inputFileSet" : [
       "[ local path prefix ]/compiler/tools/fpp-to-json/test/matchedPorts.fpp"
     ],
-    "locationSpecifierMap": [],
-    "parentSymbolMap": {
-      "24": {
-        "Module": {
-          "nodeId": 25,
-          "unqualifiedName": "Svc"
+    "locationSpecifierMap" : [
+    ],
+    "parentSymbolMap" : {
+      "24" : {
+        "Module" : {
+          "nodeId" : 25,
+          "unqualifiedName" : "Svc"
         }
       }
     },
-    "symbolScopeMap": {
-      "21": {
-        "map": {}
+    "symbolScopeMap" : {
+      "21" : {
+        "map" : {
+          
+        }
       },
-      "25": {
-        "map": {
-          "Port": {
-            "map": {
-              "Ping": {
-                "Port": {
-                  "nodeId": 24,
-                  "unqualifiedName": "Ping"
+      "25" : {
+        "map" : {
+          "Port" : {
+            "map" : {
+              "Ping" : {
+                "Port" : {
+                  "nodeId" : 24,
+                  "unqualifiedName" : "Ping"
                 }
               }
             }
@@ -218,91 +254,106 @@
         }
       }
     },
-    "topologyMap": {},
-    "typeMap": {
-      "0": {
-        "Int": {
-          "Integer": {}
+    "topologyMap" : {
+      
+    },
+    "typeMap" : {
+      "0" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "1": {
-        "Int": {
-          "Integer": {}
+      "1" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "2": {
-        "Int": {
-          "Integer": {}
+      "2" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "7": {
-        "Int": {
-          "Integer": {}
+      "7" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       }
     },
-    "useDefMap": {
-      "8": {
-        "Module": {
-          "nodeId": 25,
-          "unqualifiedName": "Svc"
+    "useDefMap" : {
+      "8" : {
+        "Module" : {
+          "nodeId" : 25,
+          "unqualifiedName" : "Svc"
         }
       },
-      "5": {
-        "Port": {
-          "nodeId": 24,
-          "unqualifiedName": "Ping"
+      "5" : {
+        "Port" : {
+          "nodeId" : 24,
+          "unqualifiedName" : "Ping"
         }
       },
-      "10": {
-        "Port": {
-          "nodeId": 24,
-          "unqualifiedName": "Ping"
+      "10" : {
+        "Port" : {
+          "nodeId" : 24,
+          "unqualifiedName" : "Ping"
         }
       },
-      "2": {
-        "Constant": {
-          "nodeId": 1,
-          "unqualifiedName": "numPingPorts"
+      "2" : {
+        "Constant" : {
+          "nodeId" : 1,
+          "unqualifiedName" : "numPingPorts"
         }
       },
-      "7": {
-        "Constant": {
-          "nodeId": 1,
-          "unqualifiedName": "numPingPorts"
+      "7" : {
+        "Constant" : {
+          "nodeId" : 1,
+          "unqualifiedName" : "numPingPorts"
         }
       },
-      "3": {
-        "Module": {
-          "nodeId": 25,
-          "unqualifiedName": "Svc"
+      "3" : {
+        "Module" : {
+          "nodeId" : 25,
+          "unqualifiedName" : "Svc"
         }
       }
     },
-    "valueMap": {
-      "0": {
-        "Integer": {
-          "value": 10
+    "valueMap" : {
+      "0" : {
+        "Integer" : {
+          "value" : 10
         }
       },
-      "1": {
-        "Integer": {
-          "value": 10
+      "1" : {
+        "Integer" : {
+          "value" : 10
         }
       },
-      "2": {
-        "Integer": {
-          "value": 10
+      "2" : {
+        "Integer" : {
+          "value" : 10
         }
       },
-      "7": {
-        "Integer": {
-          "value": 10
+      "7" : {
+        "Integer" : {
+          "value" : 10
         }
       }
     },
-    "stateMachineMap": {},
-    "dictionarySymbolSet": [],
-    "interfaceMap": {}
+    "stateMachineMap" : {
+      
+    },
+    "dictionarySymbolSet" : [
+    ],
+    "interfaceMap" : {
+      
+    }
   }
 }

--- a/tests/matched_ports/matched_ports_ast.json
+++ b/tests/matched_ports/matched_ports_ast.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion": "[ fpp version ]",
+  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
   "ast": [
     {
       "members": [

--- a/tests/matched_ports/matched_ports_ast.json
+++ b/tests/matched_ports/matched_ports_ast.json
@@ -1,244 +1,267 @@
 {
-  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
-  "ast": [
+  "fppVersion" : "v3.1.0a10-54-g11243e778",
+  "ast" : [
     {
-      "members": [
+      "members" : [
         [
-          ["Number of health ping ports"],
+          [
+            "Number of health ping ports"
+          ],
           {
-            "DefConstant": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "numPingPorts",
-                    "value": {
-                      "AstNode": {
-                        "data": {
-                          "ExprLiteralInt": {
-                            "value": "10"
+            "DefConstant" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "numPingPorts",
+                    "value" : {
+                      "AstNode" : {
+                        "data" : {
+                          "ExprLiteralInt" : {
+                            "value" : "10"
                           }
                         },
-                        "id": 0
+                        "id" : 0
                       }
                     },
-                    "isDictionaryDef": false
+                    "isDictionaryDef" : false
                   },
-                  "id": 1
+                  "id" : 1
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          [],
+          [
+          ],
           {
-            "DefComponent": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "kind": {
-                      "Queued": {}
+            "DefComponent" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "kind" : {
+                      "Queued" : {
+                        
+                      }
                     },
-                    "name": "Health",
-                    "members": [
+                    "name" : "Health",
+                    "members" : [
                       [
-                        ["Ping output port"],
+                        [
+                          "Ping output port"
+                        ],
                         {
-                          "SpecPortInstance": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "General": {
-                                    "kind": {
-                                      "Output": {}
+                          "SpecPortInstance" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "General" : {
+                                    "kind" : {
+                                      "Output" : {
+                                        
+                                      }
                                     },
-                                    "name": "pingOut",
-                                    "size": {
-                                      "Some": {
-                                        "AstNode": {
-                                          "data": {
-                                            "ExprIdent": {
-                                              "value": "numPingPorts"
+                                    "name" : "pingOut",
+                                    "size" : {
+                                      "Some" : {
+                                        "AstNode" : {
+                                          "data" : {
+                                            "ExprIdent" : {
+                                              "value" : "numPingPorts"
                                             }
                                           },
-                                          "id": 2
+                                          "id" : 2
                                         }
                                       }
                                     },
-                                    "port": {
-                                      "Some": {
-                                        "AstNode": {
-                                          "data": {
-                                            "Qualified": {
-                                              "qualifier": {
-                                                "AstNode": {
-                                                  "data": {
-                                                    "Unqualified": {
-                                                      "name": "Svc"
+                                    "port" : {
+                                      "Some" : {
+                                        "AstNode" : {
+                                          "data" : {
+                                            "Qualified" : {
+                                              "qualifier" : {
+                                                "AstNode" : {
+                                                  "data" : {
+                                                    "Unqualified" : {
+                                                      "name" : "Svc"
                                                     }
                                                   },
-                                                  "id": 3
+                                                  "id" : 3
                                                 }
                                               },
-                                              "name": {
-                                                "AstNode": {
-                                                  "data": "Ping",
-                                                  "id": 4
+                                              "name" : {
+                                                "AstNode" : {
+                                                  "data" : "Ping",
+                                                  "id" : 4
                                                 }
                                               }
                                             }
                                           },
-                                          "id": 5
+                                          "id" : 5
                                         }
                                       }
                                     },
-                                    "priority": "None",
-                                    "queueFull": "None"
+                                    "priority" : "None",
+                                    "queueFull" : "None"
                                   }
                                 },
-                                "id": 6
+                                "id" : 6
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        ["Ping input port"],
+                        [
+                          "Ping input port"
+                        ],
                         {
-                          "SpecPortInstance": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "General": {
-                                    "kind": {
-                                      "AsyncInput": {}
+                          "SpecPortInstance" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "General" : {
+                                    "kind" : {
+                                      "AsyncInput" : {
+                                        
+                                      }
                                     },
-                                    "name": "pingIn",
-                                    "size": {
-                                      "Some": {
-                                        "AstNode": {
-                                          "data": {
-                                            "ExprIdent": {
-                                              "value": "numPingPorts"
+                                    "name" : "pingIn",
+                                    "size" : {
+                                      "Some" : {
+                                        "AstNode" : {
+                                          "data" : {
+                                            "ExprIdent" : {
+                                              "value" : "numPingPorts"
                                             }
                                           },
-                                          "id": 7
+                                          "id" : 7
                                         }
                                       }
                                     },
-                                    "port": {
-                                      "Some": {
-                                        "AstNode": {
-                                          "data": {
-                                            "Qualified": {
-                                              "qualifier": {
-                                                "AstNode": {
-                                                  "data": {
-                                                    "Unqualified": {
-                                                      "name": "Svc"
+                                    "port" : {
+                                      "Some" : {
+                                        "AstNode" : {
+                                          "data" : {
+                                            "Qualified" : {
+                                              "qualifier" : {
+                                                "AstNode" : {
+                                                  "data" : {
+                                                    "Unqualified" : {
+                                                      "name" : "Svc"
                                                     }
                                                   },
-                                                  "id": 8
+                                                  "id" : 8
                                                 }
                                               },
-                                              "name": {
-                                                "AstNode": {
-                                                  "data": "Ping",
-                                                  "id": 9
+                                              "name" : {
+                                                "AstNode" : {
+                                                  "data" : "Ping",
+                                                  "id" : 9
                                                 }
                                               }
                                             }
                                           },
-                                          "id": 10
+                                          "id" : 10
                                         }
                                       }
                                     },
-                                    "priority": "None",
-                                    "queueFull": "None"
+                                    "priority" : "None",
+                                    "queueFull" : "None"
                                   }
                                 },
-                                "id": 11
+                                "id" : 11
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
                         [
                           "Corresponding port numbers of pingOut and pingIn must match"
                         ],
                         {
-                          "SpecPortMatching": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "port1": {
-                                    "AstNode": {
-                                      "data": "pingOut",
-                                      "id": 18
+                          "SpecPortMatching" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "port1" : {
+                                    "AstNode" : {
+                                      "data" : "pingOut",
+                                      "id" : 18
                                     }
                                   },
-                                  "port2": {
-                                    "AstNode": {
-                                      "data": "pingIn",
-                                      "id": 19
+                                  "port2" : {
+                                    "AstNode" : {
+                                      "data" : "pingIn",
+                                      "id" : 19
                                     }
                                   }
                                 },
-                                "id": 20
+                                "id" : 20
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ]
                     ]
                   },
-                  "id": 21
+                  "id" : 21
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          [],
+          [
+          ],
           {
-            "DefModule": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "Svc",
-                    "members": [
+            "DefModule" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "Svc",
+                    "members" : [
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "DefPort": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "name": "Ping",
-                                  "params": [],
-                                  "returnType": "None"
+                          "DefPort" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "name" : "Ping",
+                                  "params" : [
+                                  ],
+                                  "returnType" : "None"
                                 },
-                                "id": 24
+                                "id" : 24
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ]
                     ]
                   },
-                  "id": 25
+                  "id" : 25
                 }
               }
             }
           },
-          []
+          [
+          ]
         ]
       ]
     }

--- a/tests/matched_ports/matched_ports_locations.json
+++ b/tests/matched_ports/matched_ports_locations.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion": "[ fpp version ]",
+  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
   "locationMap": {
     "0": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/matchedPorts.fpp",

--- a/tests/matched_ports/matched_ports_locations.json
+++ b/tests/matched_ports/matched_ports_locations.json
@@ -1,135 +1,135 @@
 {
-  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
-  "locationMap": {
-    "0": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/matchedPorts.fpp",
-      "pos": "2.25",
-      "includingLoc": "None"
+  "fppVersion" : "v3.1.0a10-54-g11243e778",
+  "locationMap" : {
+    "0" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/matchedPorts.fpp",
+      "pos" : "2.25",
+      "includingLoc" : "None"
     },
-    "1": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/matchedPorts.fpp",
-      "pos": "2.1",
-      "includingLoc": "None"
+    "1" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/matchedPorts.fpp",
+      "pos" : "2.1",
+      "includingLoc" : "None"
     },
-    "2": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/matchedPorts.fpp",
-      "pos": "7.25",
-      "includingLoc": "None"
+    "2" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/matchedPorts.fpp",
+      "pos" : "7.25",
+      "includingLoc" : "None"
     },
-    "3": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/matchedPorts.fpp",
-      "pos": "7.39",
-      "includingLoc": "None"
+    "3" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/matchedPorts.fpp",
+      "pos" : "7.39",
+      "includingLoc" : "None"
     },
-    "4": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/matchedPorts.fpp",
-      "pos": "7.43",
-      "includingLoc": "None"
+    "4" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/matchedPorts.fpp",
+      "pos" : "7.43",
+      "includingLoc" : "None"
     },
-    "5": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/matchedPorts.fpp",
-      "pos": "7.39",
-      "includingLoc": "None"
+    "5" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/matchedPorts.fpp",
+      "pos" : "7.39",
+      "includingLoc" : "None"
     },
-    "6": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/matchedPorts.fpp",
-      "pos": "7.3",
-      "includingLoc": "None"
+    "6" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/matchedPorts.fpp",
+      "pos" : "7.3",
+      "includingLoc" : "None"
     },
-    "7": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/matchedPorts.fpp",
-      "pos": "10.29",
-      "includingLoc": "None"
+    "7" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/matchedPorts.fpp",
+      "pos" : "10.29",
+      "includingLoc" : "None"
     },
-    "8": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/matchedPorts.fpp",
-      "pos": "10.43",
-      "includingLoc": "None"
+    "8" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/matchedPorts.fpp",
+      "pos" : "10.43",
+      "includingLoc" : "None"
     },
-    "9": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/matchedPorts.fpp",
-      "pos": "10.47",
-      "includingLoc": "None"
+    "9" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/matchedPorts.fpp",
+      "pos" : "10.47",
+      "includingLoc" : "None"
     },
-    "10": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/matchedPorts.fpp",
-      "pos": "10.43",
-      "includingLoc": "None"
+    "10" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/matchedPorts.fpp",
+      "pos" : "10.43",
+      "includingLoc" : "None"
     },
-    "11": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/matchedPorts.fpp",
-      "pos": "10.3",
-      "includingLoc": "None"
+    "11" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/matchedPorts.fpp",
+      "pos" : "10.3",
+      "includingLoc" : "None"
     },
-    "12": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/matchedPorts.fpp",
-      "pos": "13.9",
-      "includingLoc": "None"
+    "12" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/matchedPorts.fpp",
+      "pos" : "13.9",
+      "includingLoc" : "None"
     },
-    "13": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/matchedPorts.fpp",
-      "pos": "13.22",
-      "includingLoc": "None"
+    "13" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/matchedPorts.fpp",
+      "pos" : "13.22",
+      "includingLoc" : "None"
     },
-    "14": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/matchedPorts.fpp",
-      "pos": "13.3",
-      "includingLoc": "None"
+    "14" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/matchedPorts.fpp",
+      "pos" : "13.3",
+      "includingLoc" : "None"
     },
-    "15": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/matchedPorts.fpp",
-      "pos": "13.9",
-      "includingLoc": "None"
+    "15" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/matchedPorts.fpp",
+      "pos" : "13.9",
+      "includingLoc" : "None"
     },
-    "16": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/matchedPorts.fpp",
-      "pos": "13.22",
-      "includingLoc": "None"
+    "16" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/matchedPorts.fpp",
+      "pos" : "13.22",
+      "includingLoc" : "None"
     },
-    "17": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/matchedPorts.fpp",
-      "pos": "13.3",
-      "includingLoc": "None"
+    "17" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/matchedPorts.fpp",
+      "pos" : "13.3",
+      "includingLoc" : "None"
     },
-    "18": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/matchedPorts.fpp",
-      "pos": "13.9",
-      "includingLoc": "None"
+    "18" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/matchedPorts.fpp",
+      "pos" : "13.9",
+      "includingLoc" : "None"
     },
-    "19": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/matchedPorts.fpp",
-      "pos": "13.22",
-      "includingLoc": "None"
+    "19" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/matchedPorts.fpp",
+      "pos" : "13.22",
+      "includingLoc" : "None"
     },
-    "20": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/matchedPorts.fpp",
-      "pos": "13.3",
-      "includingLoc": "None"
+    "20" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/matchedPorts.fpp",
+      "pos" : "13.3",
+      "includingLoc" : "None"
     },
-    "21": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/matchedPorts.fpp",
-      "pos": "4.1",
-      "includingLoc": "None"
+    "21" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/matchedPorts.fpp",
+      "pos" : "4.1",
+      "includingLoc" : "None"
     },
-    "22": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/matchedPorts.fpp",
-      "pos": "18.3",
-      "includingLoc": "None"
+    "22" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/matchedPorts.fpp",
+      "pos" : "18.3",
+      "includingLoc" : "None"
     },
-    "23": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/matchedPorts.fpp",
-      "pos": "18.3",
-      "includingLoc": "None"
+    "23" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/matchedPorts.fpp",
+      "pos" : "18.3",
+      "includingLoc" : "None"
     },
-    "24": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/matchedPorts.fpp",
-      "pos": "18.3",
-      "includingLoc": "None"
+    "24" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/matchedPorts.fpp",
+      "pos" : "18.3",
+      "includingLoc" : "None"
     },
-    "25": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/matchedPorts.fpp",
-      "pos": "17.1",
-      "includingLoc": "None"
+    "25" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/matchedPorts.fpp",
+      "pos" : "17.1",
+      "includingLoc" : "None"
     }
   }
 }

--- a/tests/parameters/parameters_analysis.json
+++ b/tests/parameters/parameters_analysis.json
@@ -1,700 +1,804 @@
 {
-  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
-  "analysis": {
-    "componentInstanceMap": {},
-    "componentMap": {
-      "35": {
-        "aNode": {
-          "astNodeId": 35
+  "fppVersion" : "v3.1.0a10-54-g11243e778",
+  "analysis" : {
+    "componentInstanceMap" : {
+      
+    },
+    "componentMap" : {
+      "35" : {
+        "aNode" : {
+          "astNodeId" : 35
         },
-        "portMap": {
-          "cmdIn": {
-            "Special": {
-              "aNode": {
-                "astNodeId": 3
+        "portMap" : {
+          "cmdIn" : {
+            "Special" : {
+              "aNode" : {
+                "astNodeId" : 3
               },
-              "specifier": {
-                "inputKind": "None",
-                "kind": {
-                  "CommandRecv": {}
+              "specifier" : {
+                "inputKind" : "None",
+                "kind" : {
+                  "CommandRecv" : {
+                    
+                  }
                 },
-                "name": "cmdIn",
-                "priority": "None",
-                "queueFull": "None"
+                "name" : "cmdIn",
+                "priority" : "None",
+                "queueFull" : "None"
               },
-              "symbol": {
-                "Port": {
-                  "nodeId": 38,
-                  "unqualifiedName": "Cmd"
+              "symbol" : {
+                "Port" : {
+                  "nodeId" : 38,
+                  "unqualifiedName" : "Cmd"
                 }
               },
-              "priority": "None",
-              "queueFull": "None",
-              "importNodeIds": []
+              "priority" : "None",
+              "queueFull" : "None",
+              "importNodeIds" : [
+              ]
             }
           },
-          "prmGetOut": {
-            "Special": {
-              "aNode": {
-                "astNodeId": 6
+          "prmGetOut" : {
+            "Special" : {
+              "aNode" : {
+                "astNodeId" : 6
               },
-              "specifier": {
-                "inputKind": "None",
-                "kind": {
-                  "ParamGet": {}
+              "specifier" : {
+                "inputKind" : "None",
+                "kind" : {
+                  "ParamGet" : {
+                    
+                  }
                 },
-                "name": "prmGetOut",
-                "priority": "None",
-                "queueFull": "None"
+                "name" : "prmGetOut",
+                "priority" : "None",
+                "queueFull" : "None"
               },
-              "symbol": {
-                "Port": {
-                  "nodeId": 36,
-                  "unqualifiedName": "PrmGet"
+              "symbol" : {
+                "Port" : {
+                  "nodeId" : 36,
+                  "unqualifiedName" : "PrmGet"
                 }
               },
-              "priority": "None",
-              "queueFull": "None",
-              "importNodeIds": []
+              "priority" : "None",
+              "queueFull" : "None",
+              "importNodeIds" : [
+              ]
             }
           },
-          "cmdResponseOut": {
-            "Special": {
-              "aNode": {
-                "astNodeId": 5
+          "cmdResponseOut" : {
+            "Special" : {
+              "aNode" : {
+                "astNodeId" : 5
               },
-              "specifier": {
-                "inputKind": "None",
-                "kind": {
-                  "CommandResp": {}
+              "specifier" : {
+                "inputKind" : "None",
+                "kind" : {
+                  "CommandResp" : {
+                    
+                  }
                 },
-                "name": "cmdResponseOut",
-                "priority": "None",
-                "queueFull": "None"
+                "name" : "cmdResponseOut",
+                "priority" : "None",
+                "queueFull" : "None"
               },
-              "symbol": {
-                "Port": {
-                  "nodeId": 42,
-                  "unqualifiedName": "CmdResponse"
+              "symbol" : {
+                "Port" : {
+                  "nodeId" : 42,
+                  "unqualifiedName" : "CmdResponse"
                 }
               },
-              "priority": "None",
-              "queueFull": "None",
-              "importNodeIds": []
+              "priority" : "None",
+              "queueFull" : "None",
+              "importNodeIds" : [
+              ]
             }
           },
-          "prmSetOut": {
-            "Special": {
-              "aNode": {
-                "astNodeId": 7
+          "prmSetOut" : {
+            "Special" : {
+              "aNode" : {
+                "astNodeId" : 7
               },
-              "specifier": {
-                "inputKind": "None",
-                "kind": {
-                  "ParamSet": {}
+              "specifier" : {
+                "inputKind" : "None",
+                "kind" : {
+                  "ParamSet" : {
+                    
+                  }
                 },
-                "name": "prmSetOut",
-                "priority": "None",
-                "queueFull": "None"
+                "name" : "prmSetOut",
+                "priority" : "None",
+                "queueFull" : "None"
               },
-              "symbol": {
-                "Port": {
-                  "nodeId": 37,
-                  "unqualifiedName": "PrmSet"
+              "symbol" : {
+                "Port" : {
+                  "nodeId" : 37,
+                  "unqualifiedName" : "PrmSet"
                 }
               },
-              "priority": "None",
-              "queueFull": "None",
-              "importNodeIds": []
+              "priority" : "None",
+              "queueFull" : "None",
+              "importNodeIds" : [
+              ]
             }
           },
-          "cmdRegOut": {
-            "Special": {
-              "aNode": {
-                "astNodeId": 4
+          "cmdRegOut" : {
+            "Special" : {
+              "aNode" : {
+                "astNodeId" : 4
               },
-              "specifier": {
-                "inputKind": "None",
-                "kind": {
-                  "CommandReg": {}
+              "specifier" : {
+                "inputKind" : "None",
+                "kind" : {
+                  "CommandReg" : {
+                    
+                  }
                 },
-                "name": "cmdRegOut",
-                "priority": "None",
-                "queueFull": "None"
+                "name" : "cmdRegOut",
+                "priority" : "None",
+                "queueFull" : "None"
               },
-              "symbol": {
-                "Port": {
-                  "nodeId": 39,
-                  "unqualifiedName": "CmdReg"
+              "symbol" : {
+                "Port" : {
+                  "nodeId" : 39,
+                  "unqualifiedName" : "CmdReg"
                 }
               },
-              "priority": "None",
-              "queueFull": "None",
-              "importNodeIds": []
+              "priority" : "None",
+              "queueFull" : "None",
+              "importNodeIds" : [
+              ]
             }
           }
         },
-        "specialPortMap": {
-          "param set": {
-            "aNode": {
-              "astNodeId": 7
+        "specialPortMap" : {
+          "param set" : {
+            "aNode" : {
+              "astNodeId" : 7
             },
-            "specifier": {
-              "inputKind": "None",
-              "kind": {
-                "ParamSet": {}
+            "specifier" : {
+              "inputKind" : "None",
+              "kind" : {
+                "ParamSet" : {
+                  
+                }
               },
-              "name": "prmSetOut",
-              "priority": "None",
-              "queueFull": "None"
+              "name" : "prmSetOut",
+              "priority" : "None",
+              "queueFull" : "None"
             },
-            "symbol": {
-              "Port": {
-                "nodeId": 37,
-                "unqualifiedName": "PrmSet"
+            "symbol" : {
+              "Port" : {
+                "nodeId" : 37,
+                "unqualifiedName" : "PrmSet"
               }
             },
-            "priority": "None",
-            "queueFull": "None",
-            "importNodeIds": []
+            "priority" : "None",
+            "queueFull" : "None",
+            "importNodeIds" : [
+            ]
           },
-          "command recv": {
-            "aNode": {
-              "astNodeId": 3
+          "command recv" : {
+            "aNode" : {
+              "astNodeId" : 3
             },
-            "specifier": {
-              "inputKind": "None",
-              "kind": {
-                "CommandRecv": {}
+            "specifier" : {
+              "inputKind" : "None",
+              "kind" : {
+                "CommandRecv" : {
+                  
+                }
               },
-              "name": "cmdIn",
-              "priority": "None",
-              "queueFull": "None"
+              "name" : "cmdIn",
+              "priority" : "None",
+              "queueFull" : "None"
             },
-            "symbol": {
-              "Port": {
-                "nodeId": 38,
-                "unqualifiedName": "Cmd"
+            "symbol" : {
+              "Port" : {
+                "nodeId" : 38,
+                "unqualifiedName" : "Cmd"
               }
             },
-            "priority": "None",
-            "queueFull": "None",
-            "importNodeIds": []
+            "priority" : "None",
+            "queueFull" : "None",
+            "importNodeIds" : [
+            ]
           },
-          "command reg": {
-            "aNode": {
-              "astNodeId": 4
+          "command reg" : {
+            "aNode" : {
+              "astNodeId" : 4
             },
-            "specifier": {
-              "inputKind": "None",
-              "kind": {
-                "CommandReg": {}
+            "specifier" : {
+              "inputKind" : "None",
+              "kind" : {
+                "CommandReg" : {
+                  
+                }
               },
-              "name": "cmdRegOut",
-              "priority": "None",
-              "queueFull": "None"
+              "name" : "cmdRegOut",
+              "priority" : "None",
+              "queueFull" : "None"
             },
-            "symbol": {
-              "Port": {
-                "nodeId": 39,
-                "unqualifiedName": "CmdReg"
+            "symbol" : {
+              "Port" : {
+                "nodeId" : 39,
+                "unqualifiedName" : "CmdReg"
               }
             },
-            "priority": "None",
-            "queueFull": "None",
-            "importNodeIds": []
+            "priority" : "None",
+            "queueFull" : "None",
+            "importNodeIds" : [
+            ]
           },
-          "command resp": {
-            "aNode": {
-              "astNodeId": 5
+          "command resp" : {
+            "aNode" : {
+              "astNodeId" : 5
             },
-            "specifier": {
-              "inputKind": "None",
-              "kind": {
-                "CommandResp": {}
+            "specifier" : {
+              "inputKind" : "None",
+              "kind" : {
+                "CommandResp" : {
+                  
+                }
               },
-              "name": "cmdResponseOut",
-              "priority": "None",
-              "queueFull": "None"
+              "name" : "cmdResponseOut",
+              "priority" : "None",
+              "queueFull" : "None"
             },
-            "symbol": {
-              "Port": {
-                "nodeId": 42,
-                "unqualifiedName": "CmdResponse"
+            "symbol" : {
+              "Port" : {
+                "nodeId" : 42,
+                "unqualifiedName" : "CmdResponse"
               }
             },
-            "priority": "None",
-            "queueFull": "None",
-            "importNodeIds": []
+            "priority" : "None",
+            "queueFull" : "None",
+            "importNodeIds" : [
+            ]
           },
-          "param get": {
-            "aNode": {
-              "astNodeId": 6
+          "param get" : {
+            "aNode" : {
+              "astNodeId" : 6
             },
-            "specifier": {
-              "inputKind": "None",
-              "kind": {
-                "ParamGet": {}
+            "specifier" : {
+              "inputKind" : "None",
+              "kind" : {
+                "ParamGet" : {
+                  
+                }
               },
-              "name": "prmGetOut",
-              "priority": "None",
-              "queueFull": "None"
+              "name" : "prmGetOut",
+              "priority" : "None",
+              "queueFull" : "None"
             },
-            "symbol": {
-              "Port": {
-                "nodeId": 36,
-                "unqualifiedName": "PrmGet"
+            "symbol" : {
+              "Port" : {
+                "nodeId" : 36,
+                "unqualifiedName" : "PrmGet"
               }
             },
-            "priority": "None",
-            "queueFull": "None",
-            "importNodeIds": []
+            "priority" : "None",
+            "queueFull" : "None",
+            "importNodeIds" : [
+            ]
           }
         },
-        "commandMap": {
-          "34": {
-            "Param": {
-              "aNode": {
-                "astNodeId": 34
+        "commandMap" : {
+          "34" : {
+            "Param" : {
+              "aNode" : {
+                "astNodeId" : 34
               },
-              "kind": {
-                "Save": {}
+              "kind" : {
+                "Save" : {
+                  
+                }
               }
             }
           },
-          "33": {
-            "Param": {
-              "aNode": {
-                "astNodeId": 34
+          "33" : {
+            "Param" : {
+              "aNode" : {
+                "astNodeId" : 34
               },
-              "kind": {
-                "Set": {}
+              "kind" : {
+                "Set" : {
+                  
+                }
               }
             }
           },
-          "16": {
-            "Param": {
-              "aNode": {
-                "astNodeId": 16
+          "16" : {
+            "Param" : {
+              "aNode" : {
+                "astNodeId" : 16
               },
-              "kind": {
-                "Set": {}
+              "kind" : {
+                "Set" : {
+                  
+                }
               }
             }
           },
-          "32": {
-            "Param": {
-              "aNode": {
-                "astNodeId": 25
+          "32" : {
+            "Param" : {
+              "aNode" : {
+                "astNodeId" : 25
               },
-              "kind": {
-                "Save": {}
+              "kind" : {
+                "Save" : {
+                  
+                }
               }
             }
           },
-          "1": {
-            "Param": {
-              "aNode": {
-                "astNodeId": 10
+          "1" : {
+            "Param" : {
+              "aNode" : {
+                "astNodeId" : 10
               },
-              "kind": {
-                "Save": {}
+              "kind" : {
+                "Save" : {
+                  
+                }
               }
             }
           },
-          "17": {
-            "Param": {
-              "aNode": {
-                "astNodeId": 16
+          "17" : {
+            "Param" : {
+              "aNode" : {
+                "astNodeId" : 16
               },
-              "kind": {
-                "Save": {}
+              "kind" : {
+                "Save" : {
+                  
+                }
               }
             }
           },
-          "0": {
-            "Param": {
-              "aNode": {
-                "astNodeId": 10
+          "0" : {
+            "Param" : {
+              "aNode" : {
+                "astNodeId" : 10
               },
-              "kind": {
-                "Set": {}
+              "kind" : {
+                "Set" : {
+                  
+                }
               }
             }
           },
-          "18": {
-            "Param": {
-              "aNode": {
-                "astNodeId": 25
+          "18" : {
+            "Param" : {
+              "aNode" : {
+                "astNodeId" : 25
               },
-              "kind": {
-                "Set": {}
+              "kind" : {
+                "Set" : {
+                  
+                }
               }
             }
           }
         },
-        "defaultOpcode": 35,
-        "tlmChannelMap": {},
-        "tlmChannelNameMap": {},
-        "defaultTlmChannelId": 0,
-        "eventMap": {},
-        "defaultEventId": 0,
-        "paramMap": {
-          "0": {
-            "aNode": {
-              "astNodeId": 10
+        "defaultOpcode" : 35,
+        "tlmChannelMap" : {
+          
+        },
+        "tlmChannelNameMap" : {
+          
+        },
+        "defaultTlmChannelId" : 0,
+        "eventMap" : {
+          
+        },
+        "defaultEventId" : 0,
+        "paramMap" : {
+          "0" : {
+            "aNode" : {
+              "astNodeId" : 10
             },
-            "paramType": {
-              "Int": {
-                "PrimitiveInt": {
-                  "kind": {
-                    "U32": {}
+            "paramType" : {
+              "Int" : {
+                "PrimitiveInt" : {
+                  "kind" : {
+                    "U32" : {
+                      
+                    }
                   }
                 }
               }
             },
-            "default": {
-              "Some": {
-                "PrimitiveInt": {
-                  "value": 1,
-                  "kind": {
-                    "U32": {}
+            "default" : {
+              "Some" : {
+                "PrimitiveInt" : {
+                  "value" : 1,
+                  "kind" : {
+                    "U32" : {
+                      
+                    }
                   }
                 }
               }
             },
-            "setOpcode": 0,
-            "saveOpcode": 1,
-            "isExternal": false
+            "setOpcode" : 0,
+            "saveOpcode" : 1,
+            "isExternal" : false
           },
-          "16": {
-            "aNode": {
-              "astNodeId": 16
+          "16" : {
+            "aNode" : {
+              "astNodeId" : 16
             },
-            "paramType": {
-              "Primitive": {
-                "Float": {
-                  "kind": {
-                    "F64": {}
+            "paramType" : {
+              "Primitive" : {
+                "Float" : {
+                  "kind" : {
+                    "F64" : {
+                      
+                    }
                   }
                 }
               }
             },
-            "default": {
-              "Some": {
-                "Float": {
-                  "value": 2.0,
-                  "kind": {
-                    "F64": {}
+            "default" : {
+              "Some" : {
+                "Float" : {
+                  "value" : 2.0,
+                  "kind" : {
+                    "F64" : {
+                      
+                    }
                   }
                 }
               }
             },
-            "setOpcode": 16,
-            "saveOpcode": 17,
-            "isExternal": false
+            "setOpcode" : 16,
+            "saveOpcode" : 17,
+            "isExternal" : false
           },
-          "17": {
-            "aNode": {
-              "astNodeId": 25
+          "17" : {
+            "aNode" : {
+              "astNodeId" : 25
             },
-            "paramType": {
-              "Array": {
-                "node": {
-                  "astNodeId": 2
+            "paramType" : {
+              "Array" : {
+                "node" : {
+                  "astNodeId" : 2
                 },
-                "anonArray": {
-                  "size": {
-                    "Some": 3
+                "anonArray" : {
+                  "size" : {
+                    "Some" : 3
                   },
-                  "eltType": {
-                    "Primitive": {
-                      "Float": {
-                        "kind": {
-                          "F64": {}
+                  "eltType" : {
+                    "Primitive" : {
+                      "Float" : {
+                        "kind" : {
+                          "F64" : {
+                            
+                          }
                         }
                       }
                     }
                   }
                 },
-                "default": {
-                  "Some": {
-                    "anonArray": {
-                      "elements": [
+                "default" : {
+                  "Some" : {
+                    "anonArray" : {
+                      "elements" : [
                         {
-                          "Float": {
-                            "value": 0.0,
-                            "kind": {
-                              "F64": {}
+                          "Float" : {
+                            "value" : 0.0,
+                            "kind" : {
+                              "F64" : {
+                                
+                              }
                             }
                           }
                         },
                         {
-                          "Float": {
-                            "value": 0.0,
-                            "kind": {
-                              "F64": {}
+                          "Float" : {
+                            "value" : 0.0,
+                            "kind" : {
+                              "F64" : {
+                                
+                              }
                             }
                           }
                         },
                         {
-                          "Float": {
-                            "value": 0.0,
-                            "kind": {
-                              "F64": {}
+                          "Float" : {
+                            "value" : 0.0,
+                            "kind" : {
+                              "F64" : {
+                                
+                              }
                             }
                           }
                         }
                       ]
                     },
-                    "t": {
-                      "node": {
-                        "astNodeId": 2
+                    "t" : {
+                      "node" : {
+                        "astNodeId" : 2
                       },
-                      "anonArray": {
-                        "size": {
-                          "Some": 3
+                      "anonArray" : {
+                        "size" : {
+                          "Some" : 3
                         },
-                        "eltType": {
-                          "Primitive": {
-                            "Float": {
-                              "kind": {
-                                "F64": {}
+                        "eltType" : {
+                          "Primitive" : {
+                            "Float" : {
+                              "kind" : {
+                                "F64" : {
+                                  
+                                }
                               }
                             }
                           }
                         }
                       },
-                      "default": "None",
-                      "format": "None"
+                      "default" : "None",
+                      "format" : "None"
                     }
                   }
                 },
-                "format": "None"
+                "format" : "None"
               }
             },
-            "default": {
-              "Some": {
-                "Array": {
-                  "anonArray": {
-                    "elements": [
+            "default" : {
+              "Some" : {
+                "Array" : {
+                  "anonArray" : {
+                    "elements" : [
                       {
-                        "Float": {
-                          "value": 1.0,
-                          "kind": {
-                            "F64": {}
+                        "Float" : {
+                          "value" : 1.0,
+                          "kind" : {
+                            "F64" : {
+                              
+                            }
                           }
                         }
                       },
                       {
-                        "Float": {
-                          "value": 2.0,
-                          "kind": {
-                            "F64": {}
+                        "Float" : {
+                          "value" : 2.0,
+                          "kind" : {
+                            "F64" : {
+                              
+                            }
                           }
                         }
                       },
                       {
-                        "Float": {
-                          "value": 3.0,
-                          "kind": {
-                            "F64": {}
+                        "Float" : {
+                          "value" : 3.0,
+                          "kind" : {
+                            "F64" : {
+                              
+                            }
                           }
                         }
                       }
                     ]
                   },
-                  "t": {
-                    "node": {
-                      "astNodeId": 2
+                  "t" : {
+                    "node" : {
+                      "astNodeId" : 2
                     },
-                    "anonArray": {
-                      "size": {
-                        "Some": 3
+                    "anonArray" : {
+                      "size" : {
+                        "Some" : 3
                       },
-                      "eltType": {
-                        "Primitive": {
-                          "Float": {
-                            "kind": {
-                              "F64": {}
+                      "eltType" : {
+                        "Primitive" : {
+                          "Float" : {
+                            "kind" : {
+                              "F64" : {
+                                
+                              }
                             }
                           }
                         }
                       }
                     },
-                    "default": {
-                      "Some": {
-                        "anonArray": {
-                          "elements": [
+                    "default" : {
+                      "Some" : {
+                        "anonArray" : {
+                          "elements" : [
                             {
-                              "Float": {
-                                "value": 0.0,
-                                "kind": {
-                                  "F64": {}
+                              "Float" : {
+                                "value" : 0.0,
+                                "kind" : {
+                                  "F64" : {
+                                    
+                                  }
                                 }
                               }
                             },
                             {
-                              "Float": {
-                                "value": 0.0,
-                                "kind": {
-                                  "F64": {}
+                              "Float" : {
+                                "value" : 0.0,
+                                "kind" : {
+                                  "F64" : {
+                                    
+                                  }
                                 }
                               }
                             },
                             {
-                              "Float": {
-                                "value": 0.0,
-                                "kind": {
-                                  "F64": {}
+                              "Float" : {
+                                "value" : 0.0,
+                                "kind" : {
+                                  "F64" : {
+                                    
+                                  }
                                 }
                               }
                             }
                           ]
                         },
-                        "t": {
-                          "node": {
-                            "astNodeId": 2
+                        "t" : {
+                          "node" : {
+                            "astNodeId" : 2
                           },
-                          "anonArray": {
-                            "size": {
-                              "Some": 3
+                          "anonArray" : {
+                            "size" : {
+                              "Some" : 3
                             },
-                            "eltType": {
-                              "Primitive": {
-                                "Float": {
-                                  "kind": {
-                                    "F64": {}
+                            "eltType" : {
+                              "Primitive" : {
+                                "Float" : {
+                                  "kind" : {
+                                    "F64" : {
+                                      
+                                    }
                                   }
                                 }
                               }
                             }
                           },
-                          "default": "None",
-                          "format": "None"
+                          "default" : "None",
+                          "format" : "None"
                         }
                       }
                     },
-                    "format": "None"
+                    "format" : "None"
                   }
                 }
               }
             },
-            "setOpcode": 18,
-            "saveOpcode": 32,
-            "isExternal": false
+            "setOpcode" : 18,
+            "saveOpcode" : 32,
+            "isExternal" : false
           },
-          "18": {
-            "aNode": {
-              "astNodeId": 34
+          "18" : {
+            "aNode" : {
+              "astNodeId" : 34
             },
-            "paramType": {
-              "Int": {
-                "PrimitiveInt": {
-                  "kind": {
-                    "I16": {}
+            "paramType" : {
+              "Int" : {
+                "PrimitiveInt" : {
+                  "kind" : {
+                    "I16" : {
+                      
+                    }
                   }
                 }
               }
             },
-            "default": {
-              "Some": {
-                "PrimitiveInt": {
-                  "value": 42,
-                  "kind": {
-                    "I16": {}
+            "default" : {
+              "Some" : {
+                "PrimitiveInt" : {
+                  "value" : 42,
+                  "kind" : {
+                    "I16" : {
+                      
+                    }
                   }
                 }
               }
             },
-            "setOpcode": 33,
-            "saveOpcode": 34,
-            "isExternal": true
+            "setOpcode" : 33,
+            "saveOpcode" : 34,
+            "isExternal" : true
           }
         },
-        "specPortMatchingList": [],
-        "stateMachineInstanceMap": {},
-        "portMatchingList": [],
-        "defaultParamId": 19,
-        "containerMap": {},
-        "defaultContainerId": 0,
-        "recordMap": {},
-        "defaultRecordId": 0
+        "specPortMatchingList" : [
+        ],
+        "stateMachineInstanceMap" : {
+          
+        },
+        "portMatchingList" : [
+        ],
+        "defaultParamId" : 19,
+        "containerMap" : {
+          
+        },
+        "defaultContainerId" : 0,
+        "recordMap" : {
+          
+        },
+        "defaultRecordId" : 0
       }
     },
-    "includedFileSet": [],
-    "inputFileSet": [
+    "includedFileSet" : [
+    ],
+    "inputFileSet" : [
       "[ local path prefix ]/compiler/tools/fpp-to-json/test/parameters.fpp"
     ],
-    "locationSpecifierMap": [],
-    "parentSymbolMap": {
-      "37": {
-        "Module": {
-          "nodeId": 43,
-          "unqualifiedName": "Fw"
+    "locationSpecifierMap" : [
+    ],
+    "parentSymbolMap" : {
+      "37" : {
+        "Module" : {
+          "nodeId" : 43,
+          "unqualifiedName" : "Fw"
         }
       },
-      "42": {
-        "Module": {
-          "nodeId": 43,
-          "unqualifiedName": "Fw"
+      "42" : {
+        "Module" : {
+          "nodeId" : 43,
+          "unqualifiedName" : "Fw"
         }
       },
-      "38": {
-        "Module": {
-          "nodeId": 43,
-          "unqualifiedName": "Fw"
+      "38" : {
+        "Module" : {
+          "nodeId" : 43,
+          "unqualifiedName" : "Fw"
         }
       },
-      "36": {
-        "Module": {
-          "nodeId": 43,
-          "unqualifiedName": "Fw"
+      "36" : {
+        "Module" : {
+          "nodeId" : 43,
+          "unqualifiedName" : "Fw"
         }
       },
-      "39": {
-        "Module": {
-          "nodeId": 43,
-          "unqualifiedName": "Fw"
+      "39" : {
+        "Module" : {
+          "nodeId" : 43,
+          "unqualifiedName" : "Fw"
         }
       }
     },
-    "symbolScopeMap": {
-      "35": {
-        "map": {}
+    "symbolScopeMap" : {
+      "35" : {
+        "map" : {
+          
+        }
       },
-      "43": {
-        "map": {
-          "Port": {
-            "map": {
-              "CmdReg": {
-                "Port": {
-                  "nodeId": 39,
-                  "unqualifiedName": "CmdReg"
+      "43" : {
+        "map" : {
+          "Port" : {
+            "map" : {
+              "CmdReg" : {
+                "Port" : {
+                  "nodeId" : 39,
+                  "unqualifiedName" : "CmdReg"
                 }
               },
-              "PrmGet": {
-                "Port": {
-                  "nodeId": 36,
-                  "unqualifiedName": "PrmGet"
+              "PrmGet" : {
+                "Port" : {
+                  "nodeId" : 36,
+                  "unqualifiedName" : "PrmGet"
                 }
               },
-              "PrmSet": {
-                "Port": {
-                  "nodeId": 37,
-                  "unqualifiedName": "PrmSet"
+              "PrmSet" : {
+                "Port" : {
+                  "nodeId" : 37,
+                  "unqualifiedName" : "PrmSet"
                 }
               },
-              "Cmd": {
-                "Port": {
-                  "nodeId": 38,
-                  "unqualifiedName": "Cmd"
+              "Cmd" : {
+                "Port" : {
+                  "nodeId" : 38,
+                  "unqualifiedName" : "Cmd"
                 }
               },
-              "CmdResponse": {
-                "Port": {
-                  "nodeId": 42,
-                  "unqualifiedName": "CmdResponse"
+              "CmdResponse" : {
+                "Port" : {
+                  "nodeId" : 42,
+                  "unqualifiedName" : "CmdResponse"
                 }
               }
             }
@@ -702,427 +806,500 @@
         }
       }
     },
-    "topologyMap": {},
-    "typeMap": {
-      "12": {
-        "Primitive": {
-          "Float": {
-            "kind": {
-              "F64": {}
+    "topologyMap" : {
+      
+    },
+    "typeMap" : {
+      "12" : {
+        "Primitive" : {
+          "Float" : {
+            "kind" : {
+              "F64" : {
+                
+              }
             }
           }
         }
       },
-      "8": {
-        "Int": {
-          "PrimitiveInt": {
-            "kind": {
-              "U32": {}
+      "8" : {
+        "Int" : {
+          "PrimitiveInt" : {
+            "kind" : {
+              "U32" : {
+                
+              }
             }
           }
         }
       },
-      "33": {
-        "Int": {
-          "Integer": {}
+      "33" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "22": {
-        "Primitive": {
-          "Float": {
-            "kind": {
-              "F64": {}
+      "22" : {
+        "Primitive" : {
+          "Float" : {
+            "kind" : {
+              "F64" : {
+                
+              }
             }
           }
         }
       },
-      "13": {
-        "Int": {
-          "Integer": {}
+      "13" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "24": {
-        "Int": {
-          "Integer": {}
+      "24" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "21": {
-        "Primitive": {
-          "Float": {
-            "kind": {
-              "F64": {}
+      "21" : {
+        "Primitive" : {
+          "Float" : {
+            "kind" : {
+              "F64" : {
+                
+              }
             }
           }
         }
       },
-      "32": {
-        "Int": {
-          "PrimitiveInt": {
-            "kind": {
-              "I16": {}
+      "32" : {
+        "Int" : {
+          "PrimitiveInt" : {
+            "kind" : {
+              "I16" : {
+                
+              }
             }
           }
         }
       },
-      "1": {
-        "Primitive": {
-          "Float": {
-            "kind": {
-              "F64": {}
+      "1" : {
+        "Primitive" : {
+          "Float" : {
+            "kind" : {
+              "F64" : {
+                
+              }
             }
           }
         }
       },
-      "14": {
-        "Int": {
-          "Integer": {}
+      "14" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "2": {
-        "Array": {
-          "node": {
-            "astNodeId": 2
+      "2" : {
+        "Array" : {
+          "node" : {
+            "astNodeId" : 2
           },
-          "anonArray": {
-            "size": {
-              "Some": 3
+          "anonArray" : {
+            "size" : {
+              "Some" : 3
             },
-            "eltType": {
-              "Primitive": {
-                "Float": {
-                  "kind": {
-                    "F64": {}
+            "eltType" : {
+              "Primitive" : {
+                "Float" : {
+                  "kind" : {
+                    "F64" : {
+                      
+                    }
                   }
                 }
               }
             }
           },
-          "default": {
-            "Some": {
-              "anonArray": {
-                "elements": [
+          "default" : {
+            "Some" : {
+              "anonArray" : {
+                "elements" : [
                   {
-                    "Float": {
-                      "value": 0.0,
-                      "kind": {
-                        "F64": {}
+                    "Float" : {
+                      "value" : 0.0,
+                      "kind" : {
+                        "F64" : {
+                          
+                        }
                       }
                     }
                   },
                   {
-                    "Float": {
-                      "value": 0.0,
-                      "kind": {
-                        "F64": {}
+                    "Float" : {
+                      "value" : 0.0,
+                      "kind" : {
+                        "F64" : {
+                          
+                        }
                       }
                     }
                   },
                   {
-                    "Float": {
-                      "value": 0.0,
-                      "kind": {
-                        "F64": {}
+                    "Float" : {
+                      "value" : 0.0,
+                      "kind" : {
+                        "F64" : {
+                          
+                        }
                       }
                     }
                   }
                 ]
               },
-              "t": {
-                "node": {
-                  "astNodeId": 2
+              "t" : {
+                "node" : {
+                  "astNodeId" : 2
                 },
-                "anonArray": {
-                  "size": {
-                    "Some": 3
+                "anonArray" : {
+                  "size" : {
+                    "Some" : 3
                   },
-                  "eltType": {
-                    "Primitive": {
-                      "Float": {
-                        "kind": {
-                          "F64": {}
+                  "eltType" : {
+                    "Primitive" : {
+                      "Float" : {
+                        "kind" : {
+                          "F64" : {
+                            
+                          }
                         }
                       }
                     }
                   }
                 },
-                "default": "None",
-                "format": "None"
+                "default" : "None",
+                "format" : "None"
               }
             }
           },
-          "format": "None"
+          "format" : "None"
         }
       },
-      "19": {
-        "Array": {
-          "node": {
-            "astNodeId": 2
+      "19" : {
+        "Array" : {
+          "node" : {
+            "astNodeId" : 2
           },
-          "anonArray": {
-            "size": {
-              "Some": 3
+          "anonArray" : {
+            "size" : {
+              "Some" : 3
             },
-            "eltType": {
-              "Primitive": {
-                "Float": {
-                  "kind": {
-                    "F64": {}
+            "eltType" : {
+              "Primitive" : {
+                "Float" : {
+                  "kind" : {
+                    "F64" : {
+                      
+                    }
                   }
                 }
               }
             }
           },
-          "default": {
-            "Some": {
-              "anonArray": {
-                "elements": [
+          "default" : {
+            "Some" : {
+              "anonArray" : {
+                "elements" : [
                   {
-                    "Float": {
-                      "value": 0.0,
-                      "kind": {
-                        "F64": {}
+                    "Float" : {
+                      "value" : 0.0,
+                      "kind" : {
+                        "F64" : {
+                          
+                        }
                       }
                     }
                   },
                   {
-                    "Float": {
-                      "value": 0.0,
-                      "kind": {
-                        "F64": {}
+                    "Float" : {
+                      "value" : 0.0,
+                      "kind" : {
+                        "F64" : {
+                          
+                        }
                       }
                     }
                   },
                   {
-                    "Float": {
-                      "value": 0.0,
-                      "kind": {
-                        "F64": {}
+                    "Float" : {
+                      "value" : 0.0,
+                      "kind" : {
+                        "F64" : {
+                          
+                        }
                       }
                     }
                   }
                 ]
               },
-              "t": {
-                "node": {
-                  "astNodeId": 2
+              "t" : {
+                "node" : {
+                  "astNodeId" : 2
                 },
-                "anonArray": {
-                  "size": {
-                    "Some": 3
+                "anonArray" : {
+                  "size" : {
+                    "Some" : 3
                   },
-                  "eltType": {
-                    "Primitive": {
-                      "Float": {
-                        "kind": {
-                          "F64": {}
+                  "eltType" : {
+                    "Primitive" : {
+                      "Float" : {
+                        "kind" : {
+                          "F64" : {
+                            
+                          }
                         }
                       }
                     }
                   }
                 },
-                "default": "None",
-                "format": "None"
+                "default" : "None",
+                "format" : "None"
               }
             }
           },
-          "format": "None"
+          "format" : "None"
         }
       },
-      "23": {
-        "AnonArray": {
-          "size": {
-            "Some": 3
+      "23" : {
+        "AnonArray" : {
+          "size" : {
+            "Some" : 3
           },
-          "eltType": {
-            "Primitive": {
-              "Float": {
-                "kind": {
-                  "F64": {}
+          "eltType" : {
+            "Primitive" : {
+              "Float" : {
+                "kind" : {
+                  "F64" : {
+                    
+                  }
                 }
               }
             }
           }
         }
       },
-      "15": {
-        "Int": {
-          "Integer": {}
+      "15" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "11": {
-        "Primitive": {
-          "Float": {
-            "kind": {
-              "F64": {}
+      "11" : {
+        "Primitive" : {
+          "Float" : {
+            "kind" : {
+              "F64" : {
+                
+              }
             }
           }
         }
       },
-      "9": {
-        "Int": {
-          "Integer": {}
+      "9" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "0": {
-        "Int": {
-          "Integer": {}
+      "0" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "20": {
-        "Primitive": {
-          "Float": {
-            "kind": {
-              "F64": {}
+      "20" : {
+        "Primitive" : {
+          "Float" : {
+            "kind" : {
+              "F64" : {
+                
+              }
             }
           }
         }
       }
     },
-    "useDefMap": {
-      "19": {
-        "Array": {
-          "nodeId": 2,
-          "unqualifiedName": "F64x3"
+    "useDefMap" : {
+      "19" : {
+        "Array" : {
+          "nodeId" : 2,
+          "unqualifiedName" : "F64x3"
         }
       },
-      "4": {
-        "Port": {
-          "nodeId": 39,
-          "unqualifiedName": "CmdReg"
+      "4" : {
+        "Port" : {
+          "nodeId" : 39,
+          "unqualifiedName" : "CmdReg"
         }
       },
-      "5": {
-        "Port": {
-          "nodeId": 42,
-          "unqualifiedName": "CmdResponse"
+      "5" : {
+        "Port" : {
+          "nodeId" : 42,
+          "unqualifiedName" : "CmdResponse"
         }
       },
-      "6": {
-        "Port": {
-          "nodeId": 36,
-          "unqualifiedName": "PrmGet"
+      "6" : {
+        "Port" : {
+          "nodeId" : 36,
+          "unqualifiedName" : "PrmGet"
         }
       },
-      "18": {
-        "Array": {
-          "nodeId": 2,
-          "unqualifiedName": "F64x3"
+      "18" : {
+        "Array" : {
+          "nodeId" : 2,
+          "unqualifiedName" : "F64x3"
         }
       },
-      "7": {
-        "Port": {
-          "nodeId": 37,
-          "unqualifiedName": "PrmSet"
+      "7" : {
+        "Port" : {
+          "nodeId" : 37,
+          "unqualifiedName" : "PrmSet"
         }
       },
-      "3": {
-        "Port": {
-          "nodeId": 38,
-          "unqualifiedName": "Cmd"
+      "3" : {
+        "Port" : {
+          "nodeId" : 38,
+          "unqualifiedName" : "Cmd"
         }
       }
     },
-    "valueMap": {
-      "12": {
-        "Float": {
-          "value": 2.0,
-          "kind": {
-            "F64": {}
+    "valueMap" : {
+      "12" : {
+        "Float" : {
+          "value" : 2.0,
+          "kind" : {
+            "F64" : {
+              
+            }
           }
         }
       },
-      "23": {
-        "AnonArray": {
-          "elements": [
+      "23" : {
+        "AnonArray" : {
+          "elements" : [
             {
-              "Float": {
-                "value": 1.0,
-                "kind": {
-                  "F64": {}
+              "Float" : {
+                "value" : 1.0,
+                "kind" : {
+                  "F64" : {
+                    
+                  }
                 }
               }
             },
             {
-              "Float": {
-                "value": 2.0,
-                "kind": {
-                  "F64": {}
+              "Float" : {
+                "value" : 2.0,
+                "kind" : {
+                  "F64" : {
+                    
+                  }
                 }
               }
             },
             {
-              "Float": {
-                "value": 3.0,
-                "kind": {
-                  "F64": {}
+              "Float" : {
+                "value" : 3.0,
+                "kind" : {
+                  "F64" : {
+                    
+                  }
                 }
               }
             }
           ]
         }
       },
-      "33": {
-        "Integer": {
-          "value": 42
+      "33" : {
+        "Integer" : {
+          "value" : 42
         }
       },
-      "22": {
-        "Float": {
-          "value": 3.0,
-          "kind": {
-            "F64": {}
+      "22" : {
+        "Float" : {
+          "value" : 3.0,
+          "kind" : {
+            "F64" : {
+              
+            }
           }
         }
       },
-      "13": {
-        "Integer": {
-          "value": 16
+      "13" : {
+        "Integer" : {
+          "value" : 16
         }
       },
-      "24": {
-        "Integer": {
-          "value": 32
+      "24" : {
+        "Integer" : {
+          "value" : 32
         }
       },
-      "21": {
-        "Float": {
-          "value": 2.0,
-          "kind": {
-            "F64": {}
+      "21" : {
+        "Float" : {
+          "value" : 2.0,
+          "kind" : {
+            "F64" : {
+              
+            }
           }
         }
       },
-      "14": {
-        "Integer": {
-          "value": 16
+      "14" : {
+        "Integer" : {
+          "value" : 16
         }
       },
-      "15": {
-        "Integer": {
-          "value": 17
+      "15" : {
+        "Integer" : {
+          "value" : 17
         }
       },
-      "9": {
-        "Integer": {
-          "value": 1
+      "9" : {
+        "Integer" : {
+          "value" : 1
         }
       },
-      "0": {
-        "Integer": {
-          "value": 3
+      "0" : {
+        "Integer" : {
+          "value" : 3
         }
       },
-      "20": {
-        "Float": {
-          "value": 1.0,
-          "kind": {
-            "F64": {}
+      "20" : {
+        "Float" : {
+          "value" : 1.0,
+          "kind" : {
+            "F64" : {
+              
+            }
           }
         }
       }
     },
-    "stateMachineMap": {},
-    "dictionarySymbolSet": [],
-    "interfaceMap": {}
+    "stateMachineMap" : {
+      
+    },
+    "dictionarySymbolSet" : [
+    ],
+    "interfaceMap" : {
+      
+    }
   }
 }

--- a/tests/parameters/parameters_analysis.json
+++ b/tests/parameters/parameters_analysis.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion": "[ fpp version ]",
+  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
   "analysis": {
     "componentInstanceMap": {},
     "componentMap": {

--- a/tests/parameters/parameters_ast.json
+++ b/tests/parameters/parameters_ast.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion": "[ fpp version ]",
+  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
   "ast": [
     {
       "members": [

--- a/tests/parameters/parameters_ast.json
+++ b/tests/parameters/parameters_ast.json
@@ -1,180 +1,214 @@
 {
-  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
-  "ast": [
+  "fppVersion" : "v3.1.0a10-54-g11243e778",
+  "ast" : [
     {
-      "members": [
+      "members" : [
         [
-          ["An array of 3 F64 values"],
+          [
+            "An array of 3 F64 values"
+          ],
           {
-            "DefArray": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "F64x3",
-                    "size": {
-                      "AstNode": {
-                        "data": {
-                          "ExprLiteralInt": {
-                            "value": "3"
+            "DefArray" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "F64x3",
+                    "size" : {
+                      "AstNode" : {
+                        "data" : {
+                          "ExprLiteralInt" : {
+                            "value" : "3"
                           }
                         },
-                        "id": 0
+                        "id" : 0
                       }
                     },
-                    "eltType": {
-                      "AstNode": {
-                        "data": {
-                          "TypeNameFloat": {
-                            "name": {
-                              "F64": {}
+                    "eltType" : {
+                      "AstNode" : {
+                        "data" : {
+                          "TypeNameFloat" : {
+                            "name" : {
+                              "F64" : {
+                                
+                              }
                             }
                           }
                         },
-                        "id": 1
+                        "id" : 1
                       }
                     },
-                    "default": "None",
-                    "format": "None",
-                    "isDictionaryDef": false
+                    "default" : "None",
+                    "format" : "None",
+                    "isDictionaryDef" : false
                   },
-                  "id": 2
+                  "id" : 2
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          ["A component for illustrating parameter set and save opcodes"],
+          [
+            "A component for illustrating parameter set and save opcodes"
+          ],
           {
-            "DefComponent": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "kind": {
-                      "Passive": {}
+            "DefComponent" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "kind" : {
+                      "Passive" : {
+                        
+                      }
                     },
-                    "name": "ParamOpcodes",
-                    "members": [
+                    "name" : "ParamOpcodes",
+                    "members" : [
                       [
-                        ["Command receive port"],
+                        [
+                          "Command receive port"
+                        ],
                         {
-                          "SpecPortInstance": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "Special": {
-                                    "inputKind": "None",
-                                    "kind": {
-                                      "CommandRecv": {}
+                          "SpecPortInstance" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "Special" : {
+                                    "inputKind" : "None",
+                                    "kind" : {
+                                      "CommandRecv" : {
+                                        
+                                      }
                                     },
-                                    "name": "cmdIn",
-                                    "priority": "None",
-                                    "queueFull": "None"
+                                    "name" : "cmdIn",
+                                    "priority" : "None",
+                                    "queueFull" : "None"
                                   }
                                 },
-                                "id": 3
+                                "id" : 3
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        ["Command registration port"],
+                        [
+                          "Command registration port"
+                        ],
                         {
-                          "SpecPortInstance": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "Special": {
-                                    "inputKind": "None",
-                                    "kind": {
-                                      "CommandReg": {}
+                          "SpecPortInstance" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "Special" : {
+                                    "inputKind" : "None",
+                                    "kind" : {
+                                      "CommandReg" : {
+                                        
+                                      }
                                     },
-                                    "name": "cmdRegOut",
-                                    "priority": "None",
-                                    "queueFull": "None"
+                                    "name" : "cmdRegOut",
+                                    "priority" : "None",
+                                    "queueFull" : "None"
                                   }
                                 },
-                                "id": 4
+                                "id" : 4
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        ["Command response port"],
+                        [
+                          "Command response port"
+                        ],
                         {
-                          "SpecPortInstance": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "Special": {
-                                    "inputKind": "None",
-                                    "kind": {
-                                      "CommandResp": {}
+                          "SpecPortInstance" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "Special" : {
+                                    "inputKind" : "None",
+                                    "kind" : {
+                                      "CommandResp" : {
+                                        
+                                      }
                                     },
-                                    "name": "cmdResponseOut",
-                                    "priority": "None",
-                                    "queueFull": "None"
+                                    "name" : "cmdResponseOut",
+                                    "priority" : "None",
+                                    "queueFull" : "None"
                                   }
                                 },
-                                "id": 5
+                                "id" : 5
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        ["Parameter get port"],
+                        [
+                          "Parameter get port"
+                        ],
                         {
-                          "SpecPortInstance": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "Special": {
-                                    "inputKind": "None",
-                                    "kind": {
-                                      "ParamGet": {}
+                          "SpecPortInstance" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "Special" : {
+                                    "inputKind" : "None",
+                                    "kind" : {
+                                      "ParamGet" : {
+                                        
+                                      }
                                     },
-                                    "name": "prmGetOut",
-                                    "priority": "None",
-                                    "queueFull": "None"
+                                    "name" : "prmGetOut",
+                                    "priority" : "None",
+                                    "queueFull" : "None"
                                   }
                                 },
-                                "id": 6
+                                "id" : 6
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        ["Parameter set port"],
+                        [
+                          "Parameter set port"
+                        ],
                         {
-                          "SpecPortInstance": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "Special": {
-                                    "inputKind": "None",
-                                    "kind": {
-                                      "ParamSet": {}
+                          "SpecPortInstance" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "Special" : {
+                                    "inputKind" : "None",
+                                    "kind" : {
+                                      "ParamSet" : {
+                                        
+                                      }
                                     },
-                                    "name": "prmSetOut",
-                                    "priority": "None",
-                                    "queueFull": "None"
+                                    "name" : "prmSetOut",
+                                    "priority" : "None",
+                                    "queueFull" : "None"
                                   }
                                 },
-                                "id": 7
+                                "id" : 7
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
                         [
@@ -183,46 +217,49 @@
                           "Its implied save opcode is 0x01"
                         ],
                         {
-                          "SpecParam": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "name": "Param1",
-                                  "typeName": {
-                                    "AstNode": {
-                                      "data": {
-                                        "TypeNameInt": {
-                                          "name": {
-                                            "U32": {}
+                          "SpecParam" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "name" : "Param1",
+                                  "typeName" : {
+                                    "AstNode" : {
+                                      "data" : {
+                                        "TypeNameInt" : {
+                                          "name" : {
+                                            "U32" : {
+                                              
+                                            }
                                           }
                                         }
                                       },
-                                      "id": 8
+                                      "id" : 8
                                     }
                                   },
-                                  "default": {
-                                    "Some": {
-                                      "AstNode": {
-                                        "data": {
-                                          "ExprLiteralInt": {
-                                            "value": "1"
+                                  "default" : {
+                                    "Some" : {
+                                      "AstNode" : {
+                                        "data" : {
+                                          "ExprLiteralInt" : {
+                                            "value" : "1"
                                           }
                                         },
-                                        "id": 9
+                                        "id" : 9
                                       }
                                     }
                                   },
-                                  "id": "None",
-                                  "setOpcode": "None",
-                                  "saveOpcode": "None",
-                                  "isExternal": false
+                                  "id" : "None",
+                                  "setOpcode" : "None",
+                                  "saveOpcode" : "None",
+                                  "isExternal" : false
                                 },
-                                "id": 10
+                                "id" : 10
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
                         [
@@ -231,79 +268,82 @@
                           "Its save opcode is 0x11"
                         ],
                         {
-                          "SpecParam": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "name": "Param2",
-                                  "typeName": {
-                                    "AstNode": {
-                                      "data": {
-                                        "TypeNameFloat": {
-                                          "name": {
-                                            "F64": {}
+                          "SpecParam" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "name" : "Param2",
+                                  "typeName" : {
+                                    "AstNode" : {
+                                      "data" : {
+                                        "TypeNameFloat" : {
+                                          "name" : {
+                                            "F64" : {
+                                              
+                                            }
                                           }
                                         }
                                       },
-                                      "id": 11
+                                      "id" : 11
                                     }
                                   },
-                                  "default": {
-                                    "Some": {
-                                      "AstNode": {
-                                        "data": {
-                                          "ExprLiteralFloat": {
-                                            "value": "2.0"
+                                  "default" : {
+                                    "Some" : {
+                                      "AstNode" : {
+                                        "data" : {
+                                          "ExprLiteralFloat" : {
+                                            "value" : "2.0"
                                           }
                                         },
-                                        "id": 12
+                                        "id" : 12
                                       }
                                     }
                                   },
-                                  "id": {
-                                    "Some": {
-                                      "AstNode": {
-                                        "data": {
-                                          "ExprLiteralInt": {
-                                            "value": "0x10"
+                                  "id" : {
+                                    "Some" : {
+                                      "AstNode" : {
+                                        "data" : {
+                                          "ExprLiteralInt" : {
+                                            "value" : "0x10"
                                           }
                                         },
-                                        "id": 13
+                                        "id" : 13
                                       }
                                     }
                                   },
-                                  "setOpcode": {
-                                    "Some": {
-                                      "AstNode": {
-                                        "data": {
-                                          "ExprLiteralInt": {
-                                            "value": "0x10"
+                                  "setOpcode" : {
+                                    "Some" : {
+                                      "AstNode" : {
+                                        "data" : {
+                                          "ExprLiteralInt" : {
+                                            "value" : "0x10"
                                           }
                                         },
-                                        "id": 14
+                                        "id" : 14
                                       }
                                     }
                                   },
-                                  "saveOpcode": {
-                                    "Some": {
-                                      "AstNode": {
-                                        "data": {
-                                          "ExprLiteralInt": {
-                                            "value": "0x11"
+                                  "saveOpcode" : {
+                                    "Some" : {
+                                      "AstNode" : {
+                                        "data" : {
+                                          "ExprLiteralInt" : {
+                                            "value" : "0x11"
                                           }
                                         },
-                                        "id": 15
+                                        "id" : 15
                                       }
                                     }
                                   },
-                                  "isExternal": false
+                                  "isExternal" : false
                                 },
-                                "id": 16
+                                "id" : 16
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
                         [
@@ -312,95 +352,96 @@
                           "Its save opcode is 0x20"
                         ],
                         {
-                          "SpecParam": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "name": "Param3",
-                                  "typeName": {
-                                    "AstNode": {
-                                      "data": {
-                                        "TypeNameQualIdent": {
-                                          "name": {
-                                            "AstNode": {
-                                              "data": {
-                                                "Unqualified": {
-                                                  "name": "F64x3"
+                          "SpecParam" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "name" : "Param3",
+                                  "typeName" : {
+                                    "AstNode" : {
+                                      "data" : {
+                                        "TypeNameQualIdent" : {
+                                          "name" : {
+                                            "AstNode" : {
+                                              "data" : {
+                                                "Unqualified" : {
+                                                  "name" : "F64x3"
                                                 }
                                               },
-                                              "id": 18
+                                              "id" : 18
                                             }
                                           }
                                         }
                                       },
-                                      "id": 19
+                                      "id" : 19
                                     }
                                   },
-                                  "default": {
-                                    "Some": {
-                                      "AstNode": {
-                                        "data": {
-                                          "ExprArray": {
-                                            "elts": [
+                                  "default" : {
+                                    "Some" : {
+                                      "AstNode" : {
+                                        "data" : {
+                                          "ExprArray" : {
+                                            "elts" : [
                                               {
-                                                "AstNode": {
-                                                  "data": {
-                                                    "ExprLiteralFloat": {
-                                                      "value": "1.0"
+                                                "AstNode" : {
+                                                  "data" : {
+                                                    "ExprLiteralFloat" : {
+                                                      "value" : "1.0"
                                                     }
                                                   },
-                                                  "id": 20
+                                                  "id" : 20
                                                 }
                                               },
                                               {
-                                                "AstNode": {
-                                                  "data": {
-                                                    "ExprLiteralFloat": {
-                                                      "value": "2.0"
+                                                "AstNode" : {
+                                                  "data" : {
+                                                    "ExprLiteralFloat" : {
+                                                      "value" : "2.0"
                                                     }
                                                   },
-                                                  "id": 21
+                                                  "id" : 21
                                                 }
                                               },
                                               {
-                                                "AstNode": {
-                                                  "data": {
-                                                    "ExprLiteralFloat": {
-                                                      "value": "3.0"
+                                                "AstNode" : {
+                                                  "data" : {
+                                                    "ExprLiteralFloat" : {
+                                                      "value" : "3.0"
                                                     }
                                                   },
-                                                  "id": 22
+                                                  "id" : 22
                                                 }
                                               }
                                             ]
                                           }
                                         },
-                                        "id": 23
+                                        "id" : 23
                                       }
                                     }
                                   },
-                                  "id": "None",
-                                  "setOpcode": "None",
-                                  "saveOpcode": {
-                                    "Some": {
-                                      "AstNode": {
-                                        "data": {
-                                          "ExprLiteralInt": {
-                                            "value": "0x20"
+                                  "id" : "None",
+                                  "setOpcode" : "None",
+                                  "saveOpcode" : {
+                                    "Some" : {
+                                      "AstNode" : {
+                                        "data" : {
+                                          "ExprLiteralInt" : {
+                                            "value" : "0x20"
                                           }
                                         },
-                                        "id": 24
+                                        "id" : 24
                                       }
                                     }
                                   },
-                                  "isExternal": false
+                                  "isExternal" : false
                                 },
-                                "id": 25
+                                "id" : 25
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
                         [
@@ -409,163 +450,184 @@
                           "Its save opcode is 0x22"
                         ],
                         {
-                          "SpecParam": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "name": "Param4",
-                                  "typeName": {
-                                    "AstNode": {
-                                      "data": {
-                                        "TypeNameInt": {
-                                          "name": {
-                                            "I16": {}
+                          "SpecParam" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "name" : "Param4",
+                                  "typeName" : {
+                                    "AstNode" : {
+                                      "data" : {
+                                        "TypeNameInt" : {
+                                          "name" : {
+                                            "I16" : {
+                                              
+                                            }
                                           }
                                         }
                                       },
-                                      "id": 32
+                                      "id" : 32
                                     }
                                   },
-                                  "default": {
-                                    "Some": {
-                                      "AstNode": {
-                                        "data": {
-                                          "ExprLiteralInt": {
-                                            "value": "42"
+                                  "default" : {
+                                    "Some" : {
+                                      "AstNode" : {
+                                        "data" : {
+                                          "ExprLiteralInt" : {
+                                            "value" : "42"
                                           }
                                         },
-                                        "id": 33
+                                        "id" : 33
                                       }
                                     }
                                   },
-                                  "id": "None",
-                                  "setOpcode": "None",
-                                  "saveOpcode": "None",
-                                  "isExternal": true
+                                  "id" : "None",
+                                  "setOpcode" : "None",
+                                  "saveOpcode" : "None",
+                                  "isExternal" : true
                                 },
-                                "id": 34
+                                "id" : 34
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ]
                     ]
                   },
-                  "id": 35
+                  "id" : 35
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          [],
+          [
+          ],
           {
-            "DefModule": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "Fw",
-                    "members": [
+            "DefModule" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "Fw",
+                    "members" : [
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "DefPort": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "name": "PrmGet",
-                                  "params": [],
-                                  "returnType": "None"
+                          "DefPort" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "name" : "PrmGet",
+                                  "params" : [
+                                  ],
+                                  "returnType" : "None"
                                 },
-                                "id": 36
+                                "id" : 36
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "DefPort": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "name": "PrmSet",
-                                  "params": [],
-                                  "returnType": "None"
+                          "DefPort" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "name" : "PrmSet",
+                                  "params" : [
+                                  ],
+                                  "returnType" : "None"
                                 },
-                                "id": 37
+                                "id" : 37
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "DefPort": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "name": "Cmd",
-                                  "params": [],
-                                  "returnType": "None"
+                          "DefPort" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "name" : "Cmd",
+                                  "params" : [
+                                  ],
+                                  "returnType" : "None"
                                 },
-                                "id": 38
+                                "id" : 38
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "DefPort": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "name": "CmdReg",
-                                  "params": [],
-                                  "returnType": "None"
+                          "DefPort" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "name" : "CmdReg",
+                                  "params" : [
+                                  ],
+                                  "returnType" : "None"
                                 },
-                                "id": 39
+                                "id" : 39
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "DefPort": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "name": "CmdResponse",
-                                  "params": [],
-                                  "returnType": "None"
+                          "DefPort" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "name" : "CmdResponse",
+                                  "params" : [
+                                  ],
+                                  "returnType" : "None"
                                 },
-                                "id": 42
+                                "id" : 42
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ]
                     ]
                   },
-                  "id": 43
+                  "id" : 43
                 }
               }
             }
           },
-          []
+          [
+          ]
         ]
       ]
     }

--- a/tests/parameters/parameters_locations.json
+++ b/tests/parameters/parameters_locations.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion": "[ fpp version ]",
+  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
   "locationMap": {
     "0": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/parameters.fpp",

--- a/tests/parameters/parameters_locations.json
+++ b/tests/parameters/parameters_locations.json
@@ -1,225 +1,225 @@
 {
-  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
-  "locationMap": {
-    "0": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/parameters.fpp",
-      "pos": "2.16",
-      "includingLoc": "None"
+  "fppVersion" : "v3.1.0a10-54-g11243e778",
+  "locationMap" : {
+    "0" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/parameters.fpp",
+      "pos" : "2.16",
+      "includingLoc" : "None"
     },
-    "1": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/parameters.fpp",
-      "pos": "2.19",
-      "includingLoc": "None"
+    "1" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/parameters.fpp",
+      "pos" : "2.19",
+      "includingLoc" : "None"
     },
-    "2": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/parameters.fpp",
-      "pos": "2.1",
-      "includingLoc": "None"
+    "2" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/parameters.fpp",
+      "pos" : "2.1",
+      "includingLoc" : "None"
     },
-    "3": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/parameters.fpp",
-      "pos": "12.3",
-      "includingLoc": "None"
+    "3" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/parameters.fpp",
+      "pos" : "12.3",
+      "includingLoc" : "None"
     },
-    "4": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/parameters.fpp",
-      "pos": "15.3",
-      "includingLoc": "None"
+    "4" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/parameters.fpp",
+      "pos" : "15.3",
+      "includingLoc" : "None"
     },
-    "5": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/parameters.fpp",
-      "pos": "18.3",
-      "includingLoc": "None"
+    "5" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/parameters.fpp",
+      "pos" : "18.3",
+      "includingLoc" : "None"
     },
-    "6": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/parameters.fpp",
-      "pos": "21.3",
-      "includingLoc": "None"
+    "6" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/parameters.fpp",
+      "pos" : "21.3",
+      "includingLoc" : "None"
     },
-    "7": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/parameters.fpp",
-      "pos": "24.3",
-      "includingLoc": "None"
+    "7" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/parameters.fpp",
+      "pos" : "24.3",
+      "includingLoc" : "None"
     },
-    "8": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/parameters.fpp",
-      "pos": "33.17",
-      "includingLoc": "None"
+    "8" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/parameters.fpp",
+      "pos" : "33.17",
+      "includingLoc" : "None"
     },
-    "9": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/parameters.fpp",
-      "pos": "33.29",
-      "includingLoc": "None"
+    "9" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/parameters.fpp",
+      "pos" : "33.29",
+      "includingLoc" : "None"
     },
-    "10": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/parameters.fpp",
-      "pos": "33.3",
-      "includingLoc": "None"
+    "10" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/parameters.fpp",
+      "pos" : "33.3",
+      "includingLoc" : "None"
     },
-    "11": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/parameters.fpp",
-      "pos": "38.17",
-      "includingLoc": "None"
+    "11" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/parameters.fpp",
+      "pos" : "38.17",
+      "includingLoc" : "None"
     },
-    "12": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/parameters.fpp",
-      "pos": "39.13",
-      "includingLoc": "None"
+    "12" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/parameters.fpp",
+      "pos" : "39.13",
+      "includingLoc" : "None"
     },
-    "13": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/parameters.fpp",
-      "pos": "40.8",
-      "includingLoc": "None"
+    "13" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/parameters.fpp",
+      "pos" : "40.8",
+      "includingLoc" : "None"
     },
-    "14": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/parameters.fpp",
-      "pos": "41.16",
-      "includingLoc": "None"
+    "14" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/parameters.fpp",
+      "pos" : "41.16",
+      "includingLoc" : "None"
     },
-    "15": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/parameters.fpp",
-      "pos": "42.17",
-      "includingLoc": "None"
+    "15" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/parameters.fpp",
+      "pos" : "42.17",
+      "includingLoc" : "None"
     },
-    "16": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/parameters.fpp",
-      "pos": "38.3",
-      "includingLoc": "None"
+    "16" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/parameters.fpp",
+      "pos" : "38.3",
+      "includingLoc" : "None"
     },
-    "17": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/parameters.fpp",
-      "pos": "47.17",
-      "includingLoc": "None"
+    "17" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/parameters.fpp",
+      "pos" : "47.17",
+      "includingLoc" : "None"
     },
-    "18": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/parameters.fpp",
-      "pos": "47.17",
-      "includingLoc": "None"
+    "18" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/parameters.fpp",
+      "pos" : "47.17",
+      "includingLoc" : "None"
     },
-    "19": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/parameters.fpp",
-      "pos": "47.17",
-      "includingLoc": "None"
+    "19" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/parameters.fpp",
+      "pos" : "47.17",
+      "includingLoc" : "None"
     },
-    "20": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/parameters.fpp",
-      "pos": "48.15",
-      "includingLoc": "None"
+    "20" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/parameters.fpp",
+      "pos" : "48.15",
+      "includingLoc" : "None"
     },
-    "21": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/parameters.fpp",
-      "pos": "48.20",
-      "includingLoc": "None"
+    "21" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/parameters.fpp",
+      "pos" : "48.20",
+      "includingLoc" : "None"
     },
-    "22": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/parameters.fpp",
-      "pos": "48.25",
-      "includingLoc": "None"
+    "22" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/parameters.fpp",
+      "pos" : "48.25",
+      "includingLoc" : "None"
     },
-    "23": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/parameters.fpp",
-      "pos": "48.13",
-      "includingLoc": "None"
+    "23" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/parameters.fpp",
+      "pos" : "48.13",
+      "includingLoc" : "None"
     },
-    "24": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/parameters.fpp",
-      "pos": "49.17",
-      "includingLoc": "None"
+    "24" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/parameters.fpp",
+      "pos" : "49.17",
+      "includingLoc" : "None"
     },
-    "25": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/parameters.fpp",
-      "pos": "47.3",
-      "includingLoc": "None"
+    "25" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/parameters.fpp",
+      "pos" : "47.3",
+      "includingLoc" : "None"
     },
-    "26": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/parameters.fpp",
-      "pos": "54.26",
-      "includingLoc": "None"
+    "26" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/parameters.fpp",
+      "pos" : "54.26",
+      "includingLoc" : "None"
     },
-    "27": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/parameters.fpp",
-      "pos": "55.13",
-      "includingLoc": "None"
+    "27" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/parameters.fpp",
+      "pos" : "55.13",
+      "includingLoc" : "None"
     },
-    "28": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/parameters.fpp",
-      "pos": "54.3",
-      "includingLoc": "None"
+    "28" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/parameters.fpp",
+      "pos" : "54.3",
+      "includingLoc" : "None"
     },
-    "29": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/parameters.fpp",
-      "pos": "54.26",
-      "includingLoc": "None"
+    "29" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/parameters.fpp",
+      "pos" : "54.26",
+      "includingLoc" : "None"
     },
-    "30": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/parameters.fpp",
-      "pos": "55.13",
-      "includingLoc": "None"
+    "30" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/parameters.fpp",
+      "pos" : "55.13",
+      "includingLoc" : "None"
     },
-    "31": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/parameters.fpp",
-      "pos": "54.3",
-      "includingLoc": "None"
+    "31" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/parameters.fpp",
+      "pos" : "54.3",
+      "includingLoc" : "None"
     },
-    "32": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/parameters.fpp",
-      "pos": "54.26",
-      "includingLoc": "None"
+    "32" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/parameters.fpp",
+      "pos" : "54.26",
+      "includingLoc" : "None"
     },
-    "33": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/parameters.fpp",
-      "pos": "55.13",
-      "includingLoc": "None"
+    "33" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/parameters.fpp",
+      "pos" : "55.13",
+      "includingLoc" : "None"
     },
-    "34": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/parameters.fpp",
-      "pos": "54.3",
-      "includingLoc": "None"
+    "34" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/parameters.fpp",
+      "pos" : "54.3",
+      "includingLoc" : "None"
     },
-    "35": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/parameters.fpp",
-      "pos": "5.1",
-      "includingLoc": "None"
+    "35" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/parameters.fpp",
+      "pos" : "5.1",
+      "includingLoc" : "None"
     },
-    "36": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/parameters.fpp",
-      "pos": "60.3",
-      "includingLoc": "None"
+    "36" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/parameters.fpp",
+      "pos" : "60.3",
+      "includingLoc" : "None"
     },
-    "37": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/parameters.fpp",
-      "pos": "61.3",
-      "includingLoc": "None"
+    "37" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/parameters.fpp",
+      "pos" : "61.3",
+      "includingLoc" : "None"
     },
-    "38": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/parameters.fpp",
-      "pos": "62.3",
-      "includingLoc": "None"
+    "38" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/parameters.fpp",
+      "pos" : "62.3",
+      "includingLoc" : "None"
     },
-    "39": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/parameters.fpp",
-      "pos": "63.3",
-      "includingLoc": "None"
+    "39" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/parameters.fpp",
+      "pos" : "63.3",
+      "includingLoc" : "None"
     },
-    "40": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/parameters.fpp",
-      "pos": "64.3",
-      "includingLoc": "None"
+    "40" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/parameters.fpp",
+      "pos" : "64.3",
+      "includingLoc" : "None"
     },
-    "41": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/parameters.fpp",
-      "pos": "64.3",
-      "includingLoc": "None"
+    "41" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/parameters.fpp",
+      "pos" : "64.3",
+      "includingLoc" : "None"
     },
-    "42": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/parameters.fpp",
-      "pos": "64.3",
-      "includingLoc": "None"
+    "42" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/parameters.fpp",
+      "pos" : "64.3",
+      "includingLoc" : "None"
     },
-    "43": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/parameters.fpp",
-      "pos": "59.1",
-      "includingLoc": "None"
+    "43" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/parameters.fpp",
+      "pos" : "59.1",
+      "includingLoc" : "None"
     }
   }
 }

--- a/tests/passive_component/passive_component_analysis.json
+++ b/tests/passive_component/passive_component_analysis.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion": "[ fpp version ]",
+  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
   "analysis": {
     "componentInstanceMap": {
       "60": {

--- a/tests/passive_component/passive_component_analysis.json
+++ b/tests/passive_component/passive_component_analysis.json
@@ -1,394 +1,463 @@
 {
-  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
-  "analysis": {
-    "componentInstanceMap": {
-      "60": {
-        "aNode": {
-          "astNodeId": 60
+  "fppVersion" : "v3.1.0a10-54-g11243e778",
+  "analysis" : {
+    "componentInstanceMap" : {
+      "60" : {
+        "aNode" : {
+          "astNodeId" : 60
         },
-        "qualifiedName": {
-          "qualifier": ["FSW"],
-          "base": "engineTemp"
+        "qualifiedName" : {
+          "qualifier" : [
+            "FSW"
+          ],
+          "base" : "engineTemp"
         },
-        "component": {
-          "astNodeId": 44
+        "component" : {
+          "astNodeId" : 44
         },
-        "baseId": 256,
-        "maxId": 257,
-        "file": "None",
-        "queueSize": "None",
-        "stackSize": "None",
-        "priority": "None",
-        "cpu": "None",
-        "initSpecifierMap": {}
+        "baseId" : 256,
+        "maxId" : 257,
+        "file" : "None",
+        "queueSize" : "None",
+        "stackSize" : "None",
+        "priority" : "None",
+        "cpu" : "None",
+        "initSpecifierMap" : {
+          
+        }
       }
     },
-    "componentMap": {
-      "44": {
-        "aNode": {
-          "astNodeId": 44
+    "componentMap" : {
+      "44" : {
+        "aNode" : {
+          "astNodeId" : 44
         },
-        "portMap": {
-          "schedIn": {
-            "General": {
-              "aNode": {
-                "astNodeId": 33
+        "portMap" : {
+          "schedIn" : {
+            "General" : {
+              "aNode" : {
+                "astNodeId" : 33
               },
-              "specifier": {
-                "kind": {
-                  "SyncInput": {}
-                },
-                "name": "schedIn",
-                "size": "None",
-                "port": {
-                  "Some": {
-                    "astNodeId": 32
+              "specifier" : {
+                "kind" : {
+                  "SyncInput" : {
+                    
                   }
                 },
-                "priority": "None",
-                "queueFull": "None"
+                "name" : "schedIn",
+                "size" : "None",
+                "port" : {
+                  "Some" : {
+                    "astNodeId" : 32
+                  }
+                },
+                "priority" : "None",
+                "queueFull" : "None"
               },
-              "kind": "SyncInput",
-              "size": 1,
-              "ty": {
-                "DefPort": {
-                  "symbol": {
-                    "Port": {
-                      "nodeId": 64,
-                      "unqualifiedName": "Sched"
+              "kind" : "SyncInput",
+              "size" : 1,
+              "ty" : {
+                "DefPort" : {
+                  "symbol" : {
+                    "Port" : {
+                      "nodeId" : 64,
+                      "unqualifiedName" : "Sched"
                     }
                   }
                 }
               },
-              "importNodeIds": []
+              "importNodeIds" : [
+              ]
             }
           },
-          "tlmOut": {
-            "Special": {
-              "aNode": {
-                "astNodeId": 34
+          "tlmOut" : {
+            "Special" : {
+              "aNode" : {
+                "astNodeId" : 34
               },
-              "specifier": {
-                "inputKind": "None",
-                "kind": {
-                  "Telemetry": {}
+              "specifier" : {
+                "inputKind" : "None",
+                "kind" : {
+                  "Telemetry" : {
+                    
+                  }
                 },
-                "name": "tlmOut",
-                "priority": "None",
-                "queueFull": "None"
+                "name" : "tlmOut",
+                "priority" : "None",
+                "queueFull" : "None"
               },
-              "symbol": {
-                "Port": {
-                  "nodeId": 66,
-                  "unqualifiedName": "Tlm"
+              "symbol" : {
+                "Port" : {
+                  "nodeId" : 66,
+                  "unqualifiedName" : "Tlm"
                 }
               },
-              "priority": "None",
-              "queueFull": "None",
-              "importNodeIds": []
+              "priority" : "None",
+              "queueFull" : "None",
+              "importNodeIds" : [
+              ]
             }
           },
-          "timeGetOut": {
-            "Special": {
-              "aNode": {
-                "astNodeId": 35
+          "timeGetOut" : {
+            "Special" : {
+              "aNode" : {
+                "astNodeId" : 35
               },
-              "specifier": {
-                "inputKind": "None",
-                "kind": {
-                  "TimeGet": {}
+              "specifier" : {
+                "inputKind" : "None",
+                "kind" : {
+                  "TimeGet" : {
+                    
+                  }
                 },
-                "name": "timeGetOut",
-                "priority": "None",
-                "queueFull": "None"
+                "name" : "timeGetOut",
+                "priority" : "None",
+                "queueFull" : "None"
               },
-              "symbol": {
-                "Port": {
-                  "nodeId": 69,
-                  "unqualifiedName": "Time"
+              "symbol" : {
+                "Port" : {
+                  "nodeId" : 69,
+                  "unqualifiedName" : "Time"
                 }
               },
-              "priority": "None",
-              "queueFull": "None",
-              "importNodeIds": []
+              "priority" : "None",
+              "queueFull" : "None",
+              "importNodeIds" : [
+              ]
             }
           }
         },
-        "specialPortMap": {
-          "telemetry": {
-            "aNode": {
-              "astNodeId": 34
+        "specialPortMap" : {
+          "telemetry" : {
+            "aNode" : {
+              "astNodeId" : 34
             },
-            "specifier": {
-              "inputKind": "None",
-              "kind": {
-                "Telemetry": {}
+            "specifier" : {
+              "inputKind" : "None",
+              "kind" : {
+                "Telemetry" : {
+                  
+                }
               },
-              "name": "tlmOut",
-              "priority": "None",
-              "queueFull": "None"
+              "name" : "tlmOut",
+              "priority" : "None",
+              "queueFull" : "None"
             },
-            "symbol": {
-              "Port": {
-                "nodeId": 66,
-                "unqualifiedName": "Tlm"
+            "symbol" : {
+              "Port" : {
+                "nodeId" : 66,
+                "unqualifiedName" : "Tlm"
               }
             },
-            "priority": "None",
-            "queueFull": "None",
-            "importNodeIds": []
+            "priority" : "None",
+            "queueFull" : "None",
+            "importNodeIds" : [
+            ]
           },
-          "time get": {
-            "aNode": {
-              "astNodeId": 35
+          "time get" : {
+            "aNode" : {
+              "astNodeId" : 35
             },
-            "specifier": {
-              "inputKind": "None",
-              "kind": {
-                "TimeGet": {}
+            "specifier" : {
+              "inputKind" : "None",
+              "kind" : {
+                "TimeGet" : {
+                  
+                }
               },
-              "name": "timeGetOut",
-              "priority": "None",
-              "queueFull": "None"
+              "name" : "timeGetOut",
+              "priority" : "None",
+              "queueFull" : "None"
             },
-            "symbol": {
-              "Port": {
-                "nodeId": 69,
-                "unqualifiedName": "Time"
+            "symbol" : {
+              "Port" : {
+                "nodeId" : 69,
+                "unqualifiedName" : "Time"
               }
             },
-            "priority": "None",
-            "queueFull": "None",
-            "importNodeIds": []
+            "priority" : "None",
+            "queueFull" : "None",
+            "importNodeIds" : [
+            ]
           }
         },
-        "commandMap": {},
-        "defaultOpcode": 0,
-        "tlmChannelMap": {
-          "0": {
-            "aNode": {
-              "astNodeId": 37
+        "commandMap" : {
+          
+        },
+        "defaultOpcode" : 0,
+        "tlmChannelMap" : {
+          "0" : {
+            "aNode" : {
+              "astNodeId" : 37
             },
-            "channelType": {
-              "Primitive": {
-                "Float": {
-                  "kind": {
-                    "F32": {}
+            "channelType" : {
+              "Primitive" : {
+                "Float" : {
+                  "kind" : {
+                    "F32" : {
+                      
+                    }
                   }
                 }
               }
             },
-            "update": {
-              "Always": {}
+            "update" : {
+              "Always" : {
+                
+              }
             },
-            "format": "None",
-            "lowLimits": {},
-            "highLimits": {}
+            "format" : "None",
+            "lowLimits" : {
+              
+            },
+            "highLimits" : {
+              
+            }
           },
-          "1": {
-            "aNode": {
-              "astNodeId": 43
+          "1" : {
+            "aNode" : {
+              "astNodeId" : 43
             },
-            "channelType": {
-              "Primitive": {
-                "Float": {
-                  "kind": {
-                    "F32": {}
+            "channelType" : {
+              "Primitive" : {
+                "Float" : {
+                  "kind" : {
+                    "F32" : {
+                      
+                    }
                   }
                 }
               }
             },
-            "update": {
-              "Always": {}
+            "update" : {
+              "Always" : {
+                
+              }
             },
-            "format": "None",
-            "lowLimits": {},
-            "highLimits": {}
+            "format" : "None",
+            "lowLimits" : {
+              
+            },
+            "highLimits" : {
+              
+            }
           }
         },
-        "tlmChannelNameMap": {
-          "ImpulseTemp": {
-            "aNode": {
-              "astNodeId": 37
+        "tlmChannelNameMap" : {
+          "ImpulseTemp" : {
+            "aNode" : {
+              "astNodeId" : 37
             },
-            "channelType": {
-              "Primitive": {
-                "Float": {
-                  "kind": {
-                    "F32": {}
+            "channelType" : {
+              "Primitive" : {
+                "Float" : {
+                  "kind" : {
+                    "F32" : {
+                      
+                    }
                   }
                 }
               }
             },
-            "update": {
-              "Always": {}
+            "update" : {
+              "Always" : {
+                
+              }
             },
-            "format": "None",
-            "lowLimits": {},
-            "highLimits": {}
+            "format" : "None",
+            "lowLimits" : {
+              
+            },
+            "highLimits" : {
+              
+            }
           },
-          "WarpTemp": {
-            "aNode": {
-              "astNodeId": 43
+          "WarpTemp" : {
+            "aNode" : {
+              "astNodeId" : 43
             },
-            "channelType": {
-              "Primitive": {
-                "Float": {
-                  "kind": {
-                    "F32": {}
+            "channelType" : {
+              "Primitive" : {
+                "Float" : {
+                  "kind" : {
+                    "F32" : {
+                      
+                    }
                   }
                 }
               }
             },
-            "update": {
-              "Always": {}
+            "update" : {
+              "Always" : {
+                
+              }
             },
-            "format": "None",
-            "lowLimits": {},
-            "highLimits": {}
+            "format" : "None",
+            "lowLimits" : {
+              
+            },
+            "highLimits" : {
+              
+            }
           }
         },
-        "defaultTlmChannelId": 2,
-        "eventMap": {},
-        "defaultEventId": 0,
-        "paramMap": {},
-        "specPortMatchingList": [],
-        "stateMachineInstanceMap": {},
-        "portMatchingList": [],
-        "defaultParamId": 0,
-        "containerMap": {},
-        "defaultContainerId": 0,
-        "recordMap": {},
-        "defaultRecordId": 0
+        "defaultTlmChannelId" : 2,
+        "eventMap" : {
+          
+        },
+        "defaultEventId" : 0,
+        "paramMap" : {
+          
+        },
+        "specPortMatchingList" : [
+        ],
+        "stateMachineInstanceMap" : {
+          
+        },
+        "portMatchingList" : [
+        ],
+        "defaultParamId" : 0,
+        "containerMap" : {
+          
+        },
+        "defaultContainerId" : 0,
+        "recordMap" : {
+          
+        },
+        "defaultRecordId" : 0
       }
     },
-    "includedFileSet": [],
-    "inputFileSet": [
+    "includedFileSet" : [
+    ],
+    "inputFileSet" : [
       "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp"
     ],
-    "locationSpecifierMap": [],
-    "parentSymbolMap": {
-      "66": {
-        "Module": {
-          "nodeId": 70,
-          "unqualifiedName": "Fw"
+    "locationSpecifierMap" : [
+    ],
+    "parentSymbolMap" : {
+      "66" : {
+        "Module" : {
+          "nodeId" : 70,
+          "unqualifiedName" : "Fw"
         }
       },
-      "44": {
-        "Module": {
-          "nodeId": 45,
-          "unqualifiedName": "Sensors"
+      "44" : {
+        "Module" : {
+          "nodeId" : 45,
+          "unqualifiedName" : "Sensors"
         }
       },
-      "60": {
-        "Module": {
-          "nodeId": 61,
-          "unqualifiedName": "FSW"
+      "60" : {
+        "Module" : {
+          "nodeId" : 61,
+          "unqualifiedName" : "FSW"
         }
       },
-      "69": {
-        "Module": {
-          "nodeId": 70,
-          "unqualifiedName": "Fw"
+      "69" : {
+        "Module" : {
+          "nodeId" : 70,
+          "unqualifiedName" : "Fw"
         }
       },
-      "64": {
-        "Module": {
-          "nodeId": 65,
-          "unqualifiedName": "Svc"
+      "64" : {
+        "Module" : {
+          "nodeId" : 65,
+          "unqualifiedName" : "Svc"
         }
       }
     },
-    "symbolScopeMap": {
-      "45": {
-        "map": {
-          "Component": {
-            "map": {
-              "EngineTemp": {
-                "Component": {
-                  "nodeId": 44,
-                  "unqualifiedName": "EngineTemp"
+    "symbolScopeMap" : {
+      "45" : {
+        "map" : {
+          "Component" : {
+            "map" : {
+              "EngineTemp" : {
+                "Component" : {
+                  "nodeId" : 44,
+                  "unqualifiedName" : "EngineTemp"
                 }
               }
             }
           },
-          "StateMachine": {
-            "map": {
-              "EngineTemp": {
-                "Component": {
-                  "nodeId": 44,
-                  "unqualifiedName": "EngineTemp"
+          "StateMachine" : {
+            "map" : {
+              "EngineTemp" : {
+                "Component" : {
+                  "nodeId" : 44,
+                  "unqualifiedName" : "EngineTemp"
                 }
               }
             }
           },
-          "Type": {
-            "map": {
-              "EngineTemp": {
-                "Component": {
-                  "nodeId": 44,
-                  "unqualifiedName": "EngineTemp"
+          "Type" : {
+            "map" : {
+              "EngineTemp" : {
+                "Component" : {
+                  "nodeId" : 44,
+                  "unqualifiedName" : "EngineTemp"
                 }
               }
             }
           },
-          "Value": {
-            "map": {
-              "EngineTemp": {
-                "Component": {
-                  "nodeId": 44,
-                  "unqualifiedName": "EngineTemp"
+          "Value" : {
+            "map" : {
+              "EngineTemp" : {
+                "Component" : {
+                  "nodeId" : 44,
+                  "unqualifiedName" : "EngineTemp"
                 }
               }
             }
           }
         }
       },
-      "44": {
-        "map": {}
+      "44" : {
+        "map" : {
+          
+        }
       },
-      "61": {
-        "map": {
-          "ComponentInstance": {
-            "map": {
-              "engineTemp": {
-                "ComponentInstance": {
-                  "nodeId": 60,
-                  "unqualifiedName": "engineTemp"
+      "61" : {
+        "map" : {
+          "ComponentInstance" : {
+            "map" : {
+              "engineTemp" : {
+                "ComponentInstance" : {
+                  "nodeId" : 60,
+                  "unqualifiedName" : "engineTemp"
                 }
               }
             }
           }
         }
       },
-      "65": {
-        "map": {
-          "Port": {
-            "map": {
-              "Sched": {
-                "Port": {
-                  "nodeId": 64,
-                  "unqualifiedName": "Sched"
+      "65" : {
+        "map" : {
+          "Port" : {
+            "map" : {
+              "Sched" : {
+                "Port" : {
+                  "nodeId" : 64,
+                  "unqualifiedName" : "Sched"
                 }
               }
             }
           }
         }
       },
-      "70": {
-        "map": {
-          "Port": {
-            "map": {
-              "Tlm": {
-                "Port": {
-                  "nodeId": 66,
-                  "unqualifiedName": "Tlm"
+      "70" : {
+        "map" : {
+          "Port" : {
+            "map" : {
+              "Tlm" : {
+                "Port" : {
+                  "nodeId" : 66,
+                  "unqualifiedName" : "Tlm"
                 }
               },
-              "Time": {
-                "Port": {
-                  "nodeId": 69,
-                  "unqualifiedName": "Time"
+              "Time" : {
+                "Port" : {
+                  "nodeId" : 69,
+                  "unqualifiedName" : "Time"
                 }
               }
             }
@@ -396,79 +465,92 @@
         }
       }
     },
-    "topologyMap": {},
-    "typeMap": {
-      "36": {
-        "Primitive": {
-          "Float": {
-            "kind": {
-              "F32": {}
+    "topologyMap" : {
+      
+    },
+    "typeMap" : {
+      "36" : {
+        "Primitive" : {
+          "Float" : {
+            "kind" : {
+              "F32" : {
+                
+              }
             }
           }
         }
       },
-      "42": {
-        "Primitive": {
-          "Float": {
-            "kind": {
-              "F32": {}
+      "42" : {
+        "Primitive" : {
+          "Float" : {
+            "kind" : {
+              "F32" : {
+                
+              }
             }
           }
         }
       },
-      "59": {
-        "Int": {
-          "Integer": {}
+      "59" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       }
     },
-    "useDefMap": {
-      "34": {
-        "Port": {
-          "nodeId": 66,
-          "unqualifiedName": "Tlm"
+    "useDefMap" : {
+      "34" : {
+        "Port" : {
+          "nodeId" : 66,
+          "unqualifiedName" : "Tlm"
         }
       },
-      "56": {
-        "Module": {
-          "nodeId": 45,
-          "unqualifiedName": "Sensors"
+      "56" : {
+        "Module" : {
+          "nodeId" : 45,
+          "unqualifiedName" : "Sensors"
         }
       },
-      "35": {
-        "Port": {
-          "nodeId": 69,
-          "unqualifiedName": "Time"
+      "35" : {
+        "Port" : {
+          "nodeId" : 69,
+          "unqualifiedName" : "Time"
         }
       },
-      "32": {
-        "Port": {
-          "nodeId": 64,
-          "unqualifiedName": "Sched"
+      "32" : {
+        "Port" : {
+          "nodeId" : 64,
+          "unqualifiedName" : "Sched"
         }
       },
-      "58": {
-        "Component": {
-          "nodeId": 44,
-          "unqualifiedName": "EngineTemp"
+      "58" : {
+        "Component" : {
+          "nodeId" : 44,
+          "unqualifiedName" : "EngineTemp"
         }
       },
-      "30": {
-        "Module": {
-          "nodeId": 65,
-          "unqualifiedName": "Svc"
+      "30" : {
+        "Module" : {
+          "nodeId" : 65,
+          "unqualifiedName" : "Svc"
         }
       }
     },
-    "valueMap": {
-      "59": {
-        "Integer": {
-          "value": 256
+    "valueMap" : {
+      "59" : {
+        "Integer" : {
+          "value" : 256
         }
       }
     },
-    "stateMachineMap": {},
-    "dictionarySymbolSet": [],
-    "interfaceMap": {}
+    "stateMachineMap" : {
+      
+    },
+    "dictionarySymbolSet" : [
+    ],
+    "interfaceMap" : {
+      
+    }
   }
 }

--- a/tests/passive_component/passive_component_ast.json
+++ b/tests/passive_component/passive_component_ast.json
@@ -1,377 +1,432 @@
 {
-  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
-  "ast": [
+  "fppVersion" : "v3.1.0a10-54-g11243e778",
+  "ast" : [
     {
-      "members": [
+      "members" : [
         [
-          [],
+          [
+          ],
           {
-            "DefModule": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "Sensors",
-                    "members": [
+            "DefModule" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "Sensors",
+                    "members" : [
                       [
-                        ["A component for sensing engine temperature"],
+                        [
+                          "A component for sensing engine temperature"
+                        ],
                         {
-                          "DefComponent": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "kind": {
-                                    "Passive": {}
+                          "DefComponent" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "kind" : {
+                                    "Passive" : {
+                                      
+                                    }
                                   },
-                                  "name": "EngineTemp",
-                                  "members": [
+                                  "name" : "EngineTemp",
+                                  "members" : [
                                     [
-                                      ["Schedule input port"],
+                                      [
+                                        "Schedule input port"
+                                      ],
                                       {
-                                        "SpecPortInstance": {
-                                          "node": {
-                                            "AstNode": {
-                                              "data": {
-                                                "General": {
-                                                  "kind": {
-                                                    "SyncInput": {}
+                                        "SpecPortInstance" : {
+                                          "node" : {
+                                            "AstNode" : {
+                                              "data" : {
+                                                "General" : {
+                                                  "kind" : {
+                                                    "SyncInput" : {
+                                                      
+                                                    }
                                                   },
-                                                  "name": "schedIn",
-                                                  "size": "None",
-                                                  "port": {
-                                                    "Some": {
-                                                      "AstNode": {
-                                                        "data": {
-                                                          "Qualified": {
-                                                            "qualifier": {
-                                                              "AstNode": {
-                                                                "data": {
-                                                                  "Unqualified": {
-                                                                    "name": "Svc"
+                                                  "name" : "schedIn",
+                                                  "size" : "None",
+                                                  "port" : {
+                                                    "Some" : {
+                                                      "AstNode" : {
+                                                        "data" : {
+                                                          "Qualified" : {
+                                                            "qualifier" : {
+                                                              "AstNode" : {
+                                                                "data" : {
+                                                                  "Unqualified" : {
+                                                                    "name" : "Svc"
                                                                   }
                                                                 },
-                                                                "id": 30
+                                                                "id" : 30
                                                               }
                                                             },
-                                                            "name": {
-                                                              "AstNode": {
-                                                                "data": "Sched",
-                                                                "id": 31
+                                                            "name" : {
+                                                              "AstNode" : {
+                                                                "data" : "Sched",
+                                                                "id" : 31
                                                               }
                                                             }
                                                           }
                                                         },
-                                                        "id": 32
+                                                        "id" : 32
                                                       }
                                                     }
                                                   },
-                                                  "priority": "None",
-                                                  "queueFull": "None"
+                                                  "priority" : "None",
+                                                  "queueFull" : "None"
                                                 }
                                               },
-                                              "id": 33
+                                              "id" : 33
                                             }
                                           }
                                         }
                                       },
-                                      []
+                                      [
+                                      ]
                                     ],
                                     [
-                                      ["Telemetry port"],
+                                      [
+                                        "Telemetry port"
+                                      ],
                                       {
-                                        "SpecPortInstance": {
-                                          "node": {
-                                            "AstNode": {
-                                              "data": {
-                                                "Special": {
-                                                  "inputKind": "None",
-                                                  "kind": {
-                                                    "Telemetry": {}
+                                        "SpecPortInstance" : {
+                                          "node" : {
+                                            "AstNode" : {
+                                              "data" : {
+                                                "Special" : {
+                                                  "inputKind" : "None",
+                                                  "kind" : {
+                                                    "Telemetry" : {
+                                                      
+                                                    }
                                                   },
-                                                  "name": "tlmOut",
-                                                  "priority": "None",
-                                                  "queueFull": "None"
+                                                  "name" : "tlmOut",
+                                                  "priority" : "None",
+                                                  "queueFull" : "None"
                                                 }
                                               },
-                                              "id": 34
+                                              "id" : 34
                                             }
                                           }
                                         }
                                       },
-                                      []
+                                      [
+                                      ]
                                     ],
                                     [
-                                      ["Time get port"],
+                                      [
+                                        "Time get port"
+                                      ],
                                       {
-                                        "SpecPortInstance": {
-                                          "node": {
-                                            "AstNode": {
-                                              "data": {
-                                                "Special": {
-                                                  "inputKind": "None",
-                                                  "kind": {
-                                                    "TimeGet": {}
+                                        "SpecPortInstance" : {
+                                          "node" : {
+                                            "AstNode" : {
+                                              "data" : {
+                                                "Special" : {
+                                                  "inputKind" : "None",
+                                                  "kind" : {
+                                                    "TimeGet" : {
+                                                      
+                                                    }
                                                   },
-                                                  "name": "timeGetOut",
-                                                  "priority": "None",
-                                                  "queueFull": "None"
+                                                  "name" : "timeGetOut",
+                                                  "priority" : "None",
+                                                  "queueFull" : "None"
                                                 }
                                               },
-                                              "id": 35
+                                              "id" : 35
                                             }
                                           }
                                         }
                                       },
-                                      []
+                                      [
+                                      ]
                                     ],
                                     [
-                                      ["Impulse engine temperature"],
+                                      [
+                                        "Impulse engine temperature"
+                                      ],
                                       {
-                                        "SpecTlmChannel": {
-                                          "node": {
-                                            "AstNode": {
-                                              "data": {
-                                                "name": "ImpulseTemp",
-                                                "typeName": {
-                                                  "AstNode": {
-                                                    "data": {
-                                                      "TypeNameFloat": {
-                                                        "name": {
-                                                          "F32": {}
+                                        "SpecTlmChannel" : {
+                                          "node" : {
+                                            "AstNode" : {
+                                              "data" : {
+                                                "name" : "ImpulseTemp",
+                                                "typeName" : {
+                                                  "AstNode" : {
+                                                    "data" : {
+                                                      "TypeNameFloat" : {
+                                                        "name" : {
+                                                          "F32" : {
+                                                            
+                                                          }
                                                         }
                                                       }
                                                     },
-                                                    "id": 36
+                                                    "id" : 36
                                                   }
                                                 },
-                                                "id": "None",
-                                                "update": "None",
-                                                "format": "None",
-                                                "low": [],
-                                                "high": []
+                                                "id" : "None",
+                                                "update" : "None",
+                                                "format" : "None",
+                                                "low" : [
+                                                ],
+                                                "high" : [
+                                                ]
                                               },
-                                              "id": 37
+                                              "id" : 37
                                             }
                                           }
                                         }
                                       },
-                                      []
+                                      [
+                                      ]
                                     ],
                                     [
-                                      ["Warp core temperature"],
+                                      [
+                                        "Warp core temperature"
+                                      ],
                                       {
-                                        "SpecTlmChannel": {
-                                          "node": {
-                                            "AstNode": {
-                                              "data": {
-                                                "name": "WarpTemp",
-                                                "typeName": {
-                                                  "AstNode": {
-                                                    "data": {
-                                                      "TypeNameFloat": {
-                                                        "name": {
-                                                          "F32": {}
+                                        "SpecTlmChannel" : {
+                                          "node" : {
+                                            "AstNode" : {
+                                              "data" : {
+                                                "name" : "WarpTemp",
+                                                "typeName" : {
+                                                  "AstNode" : {
+                                                    "data" : {
+                                                      "TypeNameFloat" : {
+                                                        "name" : {
+                                                          "F32" : {
+                                                            
+                                                          }
                                                         }
                                                       }
                                                     },
-                                                    "id": 42
+                                                    "id" : 42
                                                   }
                                                 },
-                                                "id": "None",
-                                                "update": "None",
-                                                "format": "None",
-                                                "low": [],
-                                                "high": []
+                                                "id" : "None",
+                                                "update" : "None",
+                                                "format" : "None",
+                                                "low" : [
+                                                ],
+                                                "high" : [
+                                                ]
                                               },
-                                              "id": 43
+                                              "id" : 43
                                             }
                                           }
                                         }
                                       },
-                                      []
+                                      [
+                                      ]
                                     ]
                                   ]
                                 },
-                                "id": 44
+                                "id" : 44
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ]
                     ]
                   },
-                  "id": 45
+                  "id" : 45
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          [],
+          [
+          ],
           {
-            "DefModule": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "FSW",
-                    "members": [
+            "DefModule" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "FSW",
+                    "members" : [
                       [
-                        ["Engine temperature instance"],
+                        [
+                          "Engine temperature instance"
+                        ],
                         {
-                          "DefComponentInstance": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "name": "engineTemp",
-                                  "component": {
-                                    "AstNode": {
-                                      "data": {
-                                        "Qualified": {
-                                          "qualifier": {
-                                            "AstNode": {
-                                              "data": {
-                                                "Unqualified": {
-                                                  "name": "Sensors"
+                          "DefComponentInstance" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "name" : "engineTemp",
+                                  "component" : {
+                                    "AstNode" : {
+                                      "data" : {
+                                        "Qualified" : {
+                                          "qualifier" : {
+                                            "AstNode" : {
+                                              "data" : {
+                                                "Unqualified" : {
+                                                  "name" : "Sensors"
                                                 }
                                               },
-                                              "id": 56
+                                              "id" : 56
                                             }
                                           },
-                                          "name": {
-                                            "AstNode": {
-                                              "data": "EngineTemp",
-                                              "id": 57
+                                          "name" : {
+                                            "AstNode" : {
+                                              "data" : "EngineTemp",
+                                              "id" : 57
                                             }
                                           }
                                         }
                                       },
-                                      "id": 58
+                                      "id" : 58
                                     }
                                   },
-                                  "baseId": {
-                                    "AstNode": {
-                                      "data": {
-                                        "ExprLiteralInt": {
-                                          "value": "0x100"
+                                  "baseId" : {
+                                    "AstNode" : {
+                                      "data" : {
+                                        "ExprLiteralInt" : {
+                                          "value" : "0x100"
                                         }
                                       },
-                                      "id": 59
+                                      "id" : 59
                                     }
                                   },
-                                  "implType": "None",
-                                  "file": "None",
-                                  "queueSize": "None",
-                                  "stackSize": "None",
-                                  "priority": "None",
-                                  "cpu": "None",
-                                  "initSpecs": []
+                                  "implType" : "None",
+                                  "file" : "None",
+                                  "queueSize" : "None",
+                                  "stackSize" : "None",
+                                  "priority" : "None",
+                                  "cpu" : "None",
+                                  "initSpecs" : [
+                                  ]
                                 },
-                                "id": 60
+                                "id" : 60
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ]
                     ]
                   },
-                  "id": 61
+                  "id" : 61
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          [],
+          [
+          ],
           {
-            "DefModule": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "Svc",
-                    "members": [
+            "DefModule" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "Svc",
+                    "members" : [
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "DefPort": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "name": "Sched",
-                                  "params": [],
-                                  "returnType": "None"
+                          "DefPort" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "name" : "Sched",
+                                  "params" : [
+                                  ],
+                                  "returnType" : "None"
                                 },
-                                "id": 64
+                                "id" : 64
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ]
                     ]
                   },
-                  "id": 65
+                  "id" : 65
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          [],
+          [
+          ],
           {
-            "DefModule": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "Fw",
-                    "members": [
+            "DefModule" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "Fw",
+                    "members" : [
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "DefPort": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "name": "Tlm",
-                                  "params": [],
-                                  "returnType": "None"
+                          "DefPort" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "name" : "Tlm",
+                                  "params" : [
+                                  ],
+                                  "returnType" : "None"
                                 },
-                                "id": 66
+                                "id" : 66
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "DefPort": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "name": "Time",
-                                  "params": [],
-                                  "returnType": "None"
+                          "DefPort" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "name" : "Time",
+                                  "params" : [
+                                  ],
+                                  "returnType" : "None"
                                 },
-                                "id": 69
+                                "id" : 69
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ]
                     ]
                   },
-                  "id": 70
+                  "id" : 70
                 }
               }
             }
           },
-          []
+          [
+          ]
         ]
       ]
     }

--- a/tests/passive_component/passive_component_ast.json
+++ b/tests/passive_component/passive_component_ast.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion": "[ fpp version ]",
+  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
   "ast": [
     {
       "members": [

--- a/tests/passive_component/passive_component_locations.json
+++ b/tests/passive_component/passive_component_locations.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion": "[ fpp version ]",
+  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
   "locationMap": {
     "0": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",

--- a/tests/passive_component/passive_component_locations.json
+++ b/tests/passive_component/passive_component_locations.json
@@ -1,360 +1,360 @@
 {
-  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
-  "locationMap": {
-    "0": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
-      "pos": "7.30",
-      "includingLoc": "None"
-    },
-    "1": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
-      "pos": "7.34",
-      "includingLoc": "None"
-    },
-    "2": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
-      "pos": "7.30",
-      "includingLoc": "None"
-    },
-    "3": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
-      "pos": "7.5",
-      "includingLoc": "None"
-    },
-    "4": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
-      "pos": "10.5",
-      "includingLoc": "None"
-    },
-    "5": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
-      "pos": "13.5",
-      "includingLoc": "None"
-    },
-    "6": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
-      "pos": "16.28",
-      "includingLoc": "None"
-    },
-    "7": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
-      "pos": "16.5",
-      "includingLoc": "None"
-    },
-    "8": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
-      "pos": "19.25",
-      "includingLoc": "None"
-    },
-    "9": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
-      "pos": "19.5",
-      "includingLoc": "None"
-    },
-    "10": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
-      "pos": "19.25",
-      "includingLoc": "None"
-    },
-    "11": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
-      "pos": "19.5",
-      "includingLoc": "None"
-    },
-    "12": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
-      "pos": "19.25",
-      "includingLoc": "None"
-    },
-    "13": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
-      "pos": "19.5",
-      "includingLoc": "None"
-    },
-    "14": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
-      "pos": "4.3",
-      "includingLoc": "None"
-    },
-    "15": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
-      "pos": "7.30",
-      "includingLoc": "None"
-    },
-    "16": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
-      "pos": "7.34",
-      "includingLoc": "None"
-    },
-    "17": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
-      "pos": "7.30",
-      "includingLoc": "None"
-    },
-    "18": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
-      "pos": "7.5",
-      "includingLoc": "None"
-    },
-    "19": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
-      "pos": "10.5",
-      "includingLoc": "None"
-    },
-    "20": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
-      "pos": "13.5",
-      "includingLoc": "None"
-    },
-    "21": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
-      "pos": "16.28",
-      "includingLoc": "None"
-    },
-    "22": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
-      "pos": "16.5",
-      "includingLoc": "None"
-    },
-    "23": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
-      "pos": "19.25",
-      "includingLoc": "None"
-    },
-    "24": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
-      "pos": "19.5",
-      "includingLoc": "None"
-    },
-    "25": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
-      "pos": "19.25",
-      "includingLoc": "None"
-    },
-    "26": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
-      "pos": "19.5",
-      "includingLoc": "None"
-    },
-    "27": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
-      "pos": "19.25",
-      "includingLoc": "None"
-    },
-    "28": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
-      "pos": "19.5",
-      "includingLoc": "None"
-    },
-    "29": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
-      "pos": "4.3",
-      "includingLoc": "None"
-    },
-    "30": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
-      "pos": "7.30",
-      "includingLoc": "None"
-    },
-    "31": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
-      "pos": "7.34",
-      "includingLoc": "None"
-    },
-    "32": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
-      "pos": "7.30",
-      "includingLoc": "None"
-    },
-    "33": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
-      "pos": "7.5",
-      "includingLoc": "None"
-    },
-    "34": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
-      "pos": "10.5",
-      "includingLoc": "None"
-    },
-    "35": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
-      "pos": "13.5",
-      "includingLoc": "None"
-    },
-    "36": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
-      "pos": "16.28",
-      "includingLoc": "None"
-    },
-    "37": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
-      "pos": "16.5",
-      "includingLoc": "None"
-    },
-    "38": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
-      "pos": "19.25",
-      "includingLoc": "None"
-    },
-    "39": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
-      "pos": "19.5",
-      "includingLoc": "None"
-    },
-    "40": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
-      "pos": "19.25",
-      "includingLoc": "None"
-    },
-    "41": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
-      "pos": "19.5",
-      "includingLoc": "None"
-    },
-    "42": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
-      "pos": "19.25",
-      "includingLoc": "None"
-    },
-    "43": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
-      "pos": "19.5",
-      "includingLoc": "None"
-    },
-    "44": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
-      "pos": "4.3",
-      "includingLoc": "None"
-    },
-    "45": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
-      "pos": "1.1",
-      "includingLoc": "None"
-    },
-    "46": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
-      "pos": "28.24",
-      "includingLoc": "None"
-    },
-    "47": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
-      "pos": "28.32",
-      "includingLoc": "None"
-    },
-    "48": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
-      "pos": "28.24",
-      "includingLoc": "None"
-    },
-    "49": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
-      "pos": "28.51",
-      "includingLoc": "None"
-    },
-    "50": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
-      "pos": "28.3",
-      "includingLoc": "None"
-    },
-    "51": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
-      "pos": "28.24",
-      "includingLoc": "None"
-    },
-    "52": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
-      "pos": "28.32",
-      "includingLoc": "None"
-    },
-    "53": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
-      "pos": "28.24",
-      "includingLoc": "None"
-    },
-    "54": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
-      "pos": "28.51",
-      "includingLoc": "None"
-    },
-    "55": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
-      "pos": "28.3",
-      "includingLoc": "None"
-    },
-    "56": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
-      "pos": "28.24",
-      "includingLoc": "None"
-    },
-    "57": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
-      "pos": "28.32",
-      "includingLoc": "None"
-    },
-    "58": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
-      "pos": "28.24",
-      "includingLoc": "None"
-    },
-    "59": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
-      "pos": "28.51",
-      "includingLoc": "None"
-    },
-    "60": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
-      "pos": "28.3",
-      "includingLoc": "None"
-    },
-    "61": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
-      "pos": "25.1",
-      "includingLoc": "None"
-    },
-    "62": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
-      "pos": "33.3",
-      "includingLoc": "None"
-    },
-    "63": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
-      "pos": "33.3",
-      "includingLoc": "None"
-    },
-    "64": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
-      "pos": "33.3",
-      "includingLoc": "None"
-    },
-    "65": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
-      "pos": "32.1",
-      "includingLoc": "None"
-    },
-    "66": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
-      "pos": "37.3",
-      "includingLoc": "None"
-    },
-    "67": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
-      "pos": "38.3",
-      "includingLoc": "None"
-    },
-    "68": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
-      "pos": "38.3",
-      "includingLoc": "None"
-    },
-    "69": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
-      "pos": "38.3",
-      "includingLoc": "None"
-    },
-    "70": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
-      "pos": "36.1",
-      "includingLoc": "None"
+  "fppVersion" : "v3.1.0a10-54-g11243e778",
+  "locationMap" : {
+    "0" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
+      "pos" : "7.30",
+      "includingLoc" : "None"
+    },
+    "1" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
+      "pos" : "7.34",
+      "includingLoc" : "None"
+    },
+    "2" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
+      "pos" : "7.30",
+      "includingLoc" : "None"
+    },
+    "3" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
+      "pos" : "7.5",
+      "includingLoc" : "None"
+    },
+    "4" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
+      "pos" : "10.5",
+      "includingLoc" : "None"
+    },
+    "5" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
+      "pos" : "13.5",
+      "includingLoc" : "None"
+    },
+    "6" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
+      "pos" : "16.28",
+      "includingLoc" : "None"
+    },
+    "7" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
+      "pos" : "16.5",
+      "includingLoc" : "None"
+    },
+    "8" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
+      "pos" : "19.25",
+      "includingLoc" : "None"
+    },
+    "9" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
+      "pos" : "19.5",
+      "includingLoc" : "None"
+    },
+    "10" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
+      "pos" : "19.25",
+      "includingLoc" : "None"
+    },
+    "11" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
+      "pos" : "19.5",
+      "includingLoc" : "None"
+    },
+    "12" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
+      "pos" : "19.25",
+      "includingLoc" : "None"
+    },
+    "13" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
+      "pos" : "19.5",
+      "includingLoc" : "None"
+    },
+    "14" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
+      "pos" : "4.3",
+      "includingLoc" : "None"
+    },
+    "15" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
+      "pos" : "7.30",
+      "includingLoc" : "None"
+    },
+    "16" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
+      "pos" : "7.34",
+      "includingLoc" : "None"
+    },
+    "17" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
+      "pos" : "7.30",
+      "includingLoc" : "None"
+    },
+    "18" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
+      "pos" : "7.5",
+      "includingLoc" : "None"
+    },
+    "19" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
+      "pos" : "10.5",
+      "includingLoc" : "None"
+    },
+    "20" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
+      "pos" : "13.5",
+      "includingLoc" : "None"
+    },
+    "21" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
+      "pos" : "16.28",
+      "includingLoc" : "None"
+    },
+    "22" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
+      "pos" : "16.5",
+      "includingLoc" : "None"
+    },
+    "23" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
+      "pos" : "19.25",
+      "includingLoc" : "None"
+    },
+    "24" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
+      "pos" : "19.5",
+      "includingLoc" : "None"
+    },
+    "25" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
+      "pos" : "19.25",
+      "includingLoc" : "None"
+    },
+    "26" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
+      "pos" : "19.5",
+      "includingLoc" : "None"
+    },
+    "27" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
+      "pos" : "19.25",
+      "includingLoc" : "None"
+    },
+    "28" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
+      "pos" : "19.5",
+      "includingLoc" : "None"
+    },
+    "29" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
+      "pos" : "4.3",
+      "includingLoc" : "None"
+    },
+    "30" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
+      "pos" : "7.30",
+      "includingLoc" : "None"
+    },
+    "31" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
+      "pos" : "7.34",
+      "includingLoc" : "None"
+    },
+    "32" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
+      "pos" : "7.30",
+      "includingLoc" : "None"
+    },
+    "33" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
+      "pos" : "7.5",
+      "includingLoc" : "None"
+    },
+    "34" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
+      "pos" : "10.5",
+      "includingLoc" : "None"
+    },
+    "35" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
+      "pos" : "13.5",
+      "includingLoc" : "None"
+    },
+    "36" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
+      "pos" : "16.28",
+      "includingLoc" : "None"
+    },
+    "37" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
+      "pos" : "16.5",
+      "includingLoc" : "None"
+    },
+    "38" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
+      "pos" : "19.25",
+      "includingLoc" : "None"
+    },
+    "39" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
+      "pos" : "19.5",
+      "includingLoc" : "None"
+    },
+    "40" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
+      "pos" : "19.25",
+      "includingLoc" : "None"
+    },
+    "41" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
+      "pos" : "19.5",
+      "includingLoc" : "None"
+    },
+    "42" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
+      "pos" : "19.25",
+      "includingLoc" : "None"
+    },
+    "43" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
+      "pos" : "19.5",
+      "includingLoc" : "None"
+    },
+    "44" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
+      "pos" : "4.3",
+      "includingLoc" : "None"
+    },
+    "45" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
+      "pos" : "1.1",
+      "includingLoc" : "None"
+    },
+    "46" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
+      "pos" : "28.24",
+      "includingLoc" : "None"
+    },
+    "47" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
+      "pos" : "28.32",
+      "includingLoc" : "None"
+    },
+    "48" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
+      "pos" : "28.24",
+      "includingLoc" : "None"
+    },
+    "49" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
+      "pos" : "28.51",
+      "includingLoc" : "None"
+    },
+    "50" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
+      "pos" : "28.3",
+      "includingLoc" : "None"
+    },
+    "51" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
+      "pos" : "28.24",
+      "includingLoc" : "None"
+    },
+    "52" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
+      "pos" : "28.32",
+      "includingLoc" : "None"
+    },
+    "53" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
+      "pos" : "28.24",
+      "includingLoc" : "None"
+    },
+    "54" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
+      "pos" : "28.51",
+      "includingLoc" : "None"
+    },
+    "55" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
+      "pos" : "28.3",
+      "includingLoc" : "None"
+    },
+    "56" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
+      "pos" : "28.24",
+      "includingLoc" : "None"
+    },
+    "57" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
+      "pos" : "28.32",
+      "includingLoc" : "None"
+    },
+    "58" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
+      "pos" : "28.24",
+      "includingLoc" : "None"
+    },
+    "59" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
+      "pos" : "28.51",
+      "includingLoc" : "None"
+    },
+    "60" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
+      "pos" : "28.3",
+      "includingLoc" : "None"
+    },
+    "61" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
+      "pos" : "25.1",
+      "includingLoc" : "None"
+    },
+    "62" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
+      "pos" : "33.3",
+      "includingLoc" : "None"
+    },
+    "63" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
+      "pos" : "33.3",
+      "includingLoc" : "None"
+    },
+    "64" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
+      "pos" : "33.3",
+      "includingLoc" : "None"
+    },
+    "65" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
+      "pos" : "32.1",
+      "includingLoc" : "None"
+    },
+    "66" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
+      "pos" : "37.3",
+      "includingLoc" : "None"
+    },
+    "67" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
+      "pos" : "38.3",
+      "includingLoc" : "None"
+    },
+    "68" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
+      "pos" : "38.3",
+      "includingLoc" : "None"
+    },
+    "69" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
+      "pos" : "38.3",
+      "includingLoc" : "None"
+    },
+    "70" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",
+      "pos" : "36.1",
+      "includingLoc" : "None"
     }
   }
 }

--- a/tests/patterned_connections/patterned_connections.fpp
+++ b/tests/patterned_connections/patterned_connections.fpp
@@ -2,8 +2,6 @@ passive component Time {
 
   sync input port timeGetPort: Fw.Time
 
-  time get port timeGetOut
-
 }
 
 passive component Command {
@@ -21,8 +19,6 @@ passive component Command {
 passive component Event {
 
   sync input port eventLog: Fw.Log
-
-  time get port timeGetOut
 
 }
 
@@ -54,18 +50,6 @@ passive component TextEvent {
 
 }
 
-passive component C {
-
-  command reg port cmdRegOut
-
-  command recv port cmdIn
-
-  command resp port cmdResponseOut
-
-}
-
-instance c: C base id 0x100
-
 instance c1: Time base id 0x100
 
 instance c2: Command base id 0x200
@@ -81,8 +65,6 @@ instance c6: Telemetry base id 0x600
 instance c7: TextEvent base id 0x700
 
 topology T {
-
-  instance c
 
   instance c1
 
@@ -100,9 +82,7 @@ topology T {
 
   time connections instance c1
 
-  command connections instance c2 {
-    c
-  }
+  command connections instance c2
 
   event connections instance c3
 

--- a/tests/patterned_connections/patterned_connections_analysis.json
+++ b/tests/patterned_connections/patterned_connections_analysis.json
@@ -1,6858 +1,2863 @@
 {
-  "fppVersion": "v3.1.0a10",
-  "analysis": {
-    "componentInstanceMap": {
-      "110": {
-        "aNode": {
-          "astNodeId": 110
+  "fppVersion" : "v3.1.0a10-54-g11243e778",
+  "analysis" : {
+    "componentInstanceMap" : {
+      "134" : {
+        "aNode" : {
+          "astNodeId" : 134
         },
-        "qualifiedName": {
-          "qualifier": [],
-          "base": "c"
+        "qualifiedName" : {
+          "qualifier" : [
+          ],
+          "base" : "c6"
         },
-        "component": {
-          "astNodeId": 106
+        "component" : {
+          "astNodeId" : 97
         },
-        "baseId": 256,
-        "maxId": 255,
-        "file": "None",
-        "queueSize": "None",
-        "stackSize": "None",
-        "priority": "None",
-        "cpu": "None",
-        "initSpecifierMap": {}
+        "baseId" : 1536,
+        "maxId" : 1535,
+        "file" : "None",
+        "queueSize" : "None",
+        "stackSize" : "None",
+        "priority" : "None",
+        "cpu" : "None",
+        "initSpecifierMap" : {
+          
+        }
       },
-      "134": {
-        "aNode": {
-          "astNodeId": 134
+      "138" : {
+        "aNode" : {
+          "astNodeId" : 138
         },
-        "qualifiedName": {
-          "qualifier": [],
-          "base": "c6"
+        "qualifiedName" : {
+          "qualifier" : [
+          ],
+          "base" : "c7"
         },
-        "component": {
-          "astNodeId": 87
+        "component" : {
+          "astNodeId" : 110
         },
-        "baseId": 1536,
-        "maxId": 1535,
-        "file": "None",
-        "queueSize": "None",
-        "stackSize": "None",
-        "priority": "None",
-        "cpu": "None",
-        "initSpecifierMap": {}
+        "baseId" : 1792,
+        "maxId" : 1791,
+        "file" : "None",
+        "queueSize" : "None",
+        "stackSize" : "None",
+        "priority" : "None",
+        "cpu" : "None",
+        "initSpecifierMap" : {
+          
+        }
       },
-      "138": {
-        "aNode": {
-          "astNodeId": 138
+      "126" : {
+        "aNode" : {
+          "astNodeId" : 126
         },
-        "qualifiedName": {
-          "qualifier": [],
-          "base": "c7"
+        "qualifiedName" : {
+          "qualifier" : [
+          ],
+          "base" : "c4"
         },
-        "component": {
-          "astNodeId": 100
+        "component" : {
+          "astNodeId" : 67
         },
-        "baseId": 1792,
-        "maxId": 1791,
-        "file": "None",
-        "queueSize": "None",
-        "stackSize": "None",
-        "priority": "None",
-        "cpu": "None",
-        "initSpecifierMap": {}
+        "baseId" : 1024,
+        "maxId" : 1023,
+        "file" : "None",
+        "queueSize" : "None",
+        "stackSize" : "None",
+        "priority" : "None",
+        "cpu" : "None",
+        "initSpecifierMap" : {
+          
+        }
       },
-      "126": {
-        "aNode": {
-          "astNodeId": 126
+      "122" : {
+        "aNode" : {
+          "astNodeId" : 122
         },
-        "qualifiedName": {
-          "qualifier": [],
-          "base": "c4"
+        "qualifiedName" : {
+          "qualifier" : [
+          ],
+          "base" : "c3"
         },
-        "component": {
-          "astNodeId": 57
+        "component" : {
+          "astNodeId" : 50
         },
-        "baseId": 1024,
-        "maxId": 1023,
-        "file": "None",
-        "queueSize": "None",
-        "stackSize": "None",
-        "priority": "None",
-        "cpu": "None",
-        "initSpecifierMap": {}
+        "baseId" : 768,
+        "maxId" : 767,
+        "file" : "None",
+        "queueSize" : "None",
+        "stackSize" : "None",
+        "priority" : "None",
+        "cpu" : "None",
+        "initSpecifierMap" : {
+          
+        }
       },
-      "122": {
-        "aNode": {
-          "astNodeId": 122
+      "118" : {
+        "aNode" : {
+          "astNodeId" : 118
         },
-        "qualifiedName": {
-          "qualifier": [],
-          "base": "c3"
+        "qualifiedName" : {
+          "qualifier" : [
+          ],
+          "base" : "c2"
         },
-        "component": {
-          "astNodeId": 40
+        "component" : {
+          "astNodeId" : 37
         },
-        "baseId": 768,
-        "maxId": 767,
-        "file": "None",
-        "queueSize": "None",
-        "stackSize": "None",
-        "priority": "None",
-        "cpu": "None",
-        "initSpecifierMap": {}
+        "baseId" : 512,
+        "maxId" : 511,
+        "file" : "None",
+        "queueSize" : "None",
+        "stackSize" : "None",
+        "priority" : "None",
+        "cpu" : "None",
+        "initSpecifierMap" : {
+          
+        }
       },
-      "118": {
-        "aNode": {
-          "astNodeId": 118
+      "130" : {
+        "aNode" : {
+          "astNodeId" : 130
         },
-        "qualifiedName": {
-          "qualifier": [],
-          "base": "c2"
+        "qualifiedName" : {
+          "qualifier" : [
+          ],
+          "base" : "c5"
         },
-        "component": {
-          "astNodeId": 32
+        "component" : {
+          "astNodeId" : 84
         },
-        "baseId": 512,
-        "maxId": 511,
-        "file": "None",
-        "queueSize": "None",
-        "stackSize": "None",
-        "priority": "None",
-        "cpu": "None",
-        "initSpecifierMap": {}
+        "baseId" : 1280,
+        "maxId" : 1279,
+        "file" : "None",
+        "queueSize" : "None",
+        "stackSize" : "None",
+        "priority" : "None",
+        "cpu" : "None",
+        "initSpecifierMap" : {
+          
+        }
       },
-      "130": {
-        "aNode": {
-          "astNodeId": 130
+      "114" : {
+        "aNode" : {
+          "astNodeId" : 114
         },
-        "qualifiedName": {
-          "qualifier": [],
-          "base": "c5"
+        "qualifiedName" : {
+          "qualifier" : [
+          ],
+          "base" : "c1"
         },
-        "component": {
-          "astNodeId": 74
+        "component" : {
+          "astNodeId" : 12
         },
-        "baseId": 1280,
-        "maxId": 1279,
-        "file": "None",
-        "queueSize": "None",
-        "stackSize": "None",
-        "priority": "None",
-        "cpu": "None",
-        "initSpecifierMap": {}
-      },
-      "114": {
-        "aNode": {
-          "astNodeId": 114
-        },
-        "qualifiedName": {
-          "qualifier": [],
-          "base": "c1"
-        },
-        "component": {
-          "astNodeId": 7
-        },
-        "baseId": 256,
-        "maxId": 255,
-        "file": "None",
-        "queueSize": "None",
-        "stackSize": "None",
-        "priority": "None",
-        "cpu": "None",
-        "initSpecifierMap": {}
+        "baseId" : 256,
+        "maxId" : 255,
+        "file" : "None",
+        "queueSize" : "None",
+        "stackSize" : "None",
+        "priority" : "None",
+        "cpu" : "None",
+        "initSpecifierMap" : {
+          
+        }
       }
     },
-    "componentMap": {
-      "100": {
-        "aNode": {
-          "astNodeId": 100
+    "componentMap" : {
+      "67" : {
+        "aNode" : {
+          "astNodeId" : 67
         },
-        "portMap": {
-          "textEventLog": {
-            "General": {
-              "aNode": {
-                "astNodeId": 99
+        "portMap" : {
+          "PingSend" : {
+            "General" : {
+              "aNode" : {
+                "astNodeId" : 54
               },
-              "specifier": {
-                "kind": {
-                  "SyncInput": {}
-                },
-                "name": "textEventLog",
-                "size": "None",
-                "port": {
-                  "Some": {
-                    "astNodeId": 98
+              "specifier" : {
+                "kind" : {
+                  "Output" : {
+                    
                   }
                 },
-                "priority": "None",
-                "queueFull": "None"
+                "name" : "PingSend",
+                "size" : "None",
+                "port" : {
+                  "Some" : {
+                    "astNodeId" : 53
+                  }
+                },
+                "priority" : "None",
+                "queueFull" : "None"
               },
-              "kind": "SyncInput",
-              "size": 1,
-              "ty": {
-                "DefPort": {
-                  "symbol": {
-                    "Port": {
-                      "nodeId": 197,
-                      "unqualifiedName": "LogText"
+              "kind" : "Output",
+              "size" : 1,
+              "ty" : {
+                "DefPort" : {
+                  "symbol" : {
+                    "Port" : {
+                      "nodeId" : 301,
+                      "unqualifiedName" : "Ping"
                     }
                   }
                 }
               },
-              "importNodeIds": []
+              "importNodeIds" : [
+              ]
+            }
+          },
+          "PingReturn" : {
+            "General" : {
+              "aNode" : {
+                "astNodeId" : 66
+              },
+              "specifier" : {
+                "kind" : {
+                  "SyncInput" : {
+                    
+                  }
+                },
+                "name" : "PingReturn",
+                "size" : "None",
+                "port" : {
+                  "Some" : {
+                    "astNodeId" : 65
+                  }
+                },
+                "priority" : "None",
+                "queueFull" : "None"
+              },
+              "kind" : "SyncInput",
+              "size" : 1,
+              "ty" : {
+                "DefPort" : {
+                  "symbol" : {
+                    "Port" : {
+                      "nodeId" : 301,
+                      "unqualifiedName" : "Ping"
+                    }
+                  }
+                }
+              },
+              "importNodeIds" : [
+              ]
             }
           }
         },
-        "specialPortMap": {},
-        "commandMap": {},
-        "defaultOpcode": 0,
-        "tlmChannelMap": {},
-        "tlmChannelNameMap": {},
-        "defaultTlmChannelId": 0,
-        "eventMap": {},
-        "defaultEventId": 0,
-        "paramMap": {},
-        "specPortMatchingList": [],
-        "stateMachineInstanceMap": {},
-        "portMatchingList": [],
-        "defaultParamId": 0,
-        "containerMap": {},
-        "defaultContainerId": 0,
-        "recordMap": {},
-        "defaultRecordId": 0
+        "specialPortMap" : {
+          
+        },
+        "commandMap" : {
+          
+        },
+        "defaultOpcode" : 0,
+        "tlmChannelMap" : {
+          
+        },
+        "tlmChannelNameMap" : {
+          
+        },
+        "defaultTlmChannelId" : 0,
+        "eventMap" : {
+          
+        },
+        "defaultEventId" : 0,
+        "paramMap" : {
+          
+        },
+        "specPortMatchingList" : [
+        ],
+        "stateMachineInstanceMap" : {
+          
+        },
+        "portMatchingList" : [
+        ],
+        "defaultParamId" : 0,
+        "containerMap" : {
+          
+        },
+        "defaultContainerId" : 0,
+        "recordMap" : {
+          
+        },
+        "defaultRecordId" : 0
       },
-      "40": {
-        "aNode": {
-          "astNodeId": 40
+      "12" : {
+        "aNode" : {
+          "astNodeId" : 12
         },
-        "portMap": {
-          "eventLog": {
-            "General": {
-              "aNode": {
-                "astNodeId": 36
+        "portMap" : {
+          "timeGetPort" : {
+            "General" : {
+              "aNode" : {
+                "astNodeId" : 11
               },
-              "specifier": {
-                "kind": {
-                  "SyncInput": {}
-                },
-                "name": "eventLog",
-                "size": "None",
-                "port": {
-                  "Some": {
-                    "astNodeId": 35
+              "specifier" : {
+                "kind" : {
+                  "SyncInput" : {
+                    
                   }
                 },
-                "priority": "None",
-                "queueFull": "None"
+                "name" : "timeGetPort",
+                "size" : "None",
+                "port" : {
+                  "Some" : {
+                    "astNodeId" : 10
+                  }
+                },
+                "priority" : "None",
+                "queueFull" : "None"
               },
-              "kind": "SyncInput",
-              "size": 1,
-              "ty": {
-                "DefPort": {
-                  "symbol": {
-                    "Port": {
-                      "nodeId": 196,
-                      "unqualifiedName": "Log"
+              "kind" : "SyncInput",
+              "size" : 1,
+              "ty" : {
+                "DefPort" : {
+                  "symbol" : {
+                    "Port" : {
+                      "nodeId" : 293,
+                      "unqualifiedName" : "Time"
                     }
                   }
                 }
               },
-              "importNodeIds": []
-            }
-          },
-          "timeGetOut": {
-            "Special": {
-              "aNode": {
-                "astNodeId": 39
-              },
-              "specifier": {
-                "inputKind": "None",
-                "kind": {
-                  "TimeGet": {}
-                },
-                "name": "timeGetOut",
-                "priority": "None",
-                "queueFull": "None"
-              },
-              "symbol": {
-                "Port": {
-                  "nodeId": 200,
-                  "unqualifiedName": "Time"
-                }
-              },
-              "priority": "None",
-              "queueFull": "None",
-              "importNodeIds": []
+              "importNodeIds" : [
+              ]
             }
           }
         },
-        "specialPortMap": {
-          "time get": {
-            "aNode": {
-              "astNodeId": 39
-            },
-            "specifier": {
-              "inputKind": "None",
-              "kind": {
-                "TimeGet": {}
-              },
-              "name": "timeGetOut",
-              "priority": "None",
-              "queueFull": "None"
-            },
-            "symbol": {
-              "Port": {
-                "nodeId": 200,
-                "unqualifiedName": "Time"
-              }
-            },
-            "priority": "None",
-            "queueFull": "None",
-            "importNodeIds": []
-          }
+        "specialPortMap" : {
+          
         },
-        "commandMap": {},
-        "defaultOpcode": 0,
-        "tlmChannelMap": {},
-        "tlmChannelNameMap": {},
-        "defaultTlmChannelId": 0,
-        "eventMap": {},
-        "defaultEventId": 0,
-        "paramMap": {},
-        "specPortMatchingList": [],
-        "stateMachineInstanceMap": {},
-        "portMatchingList": [],
-        "defaultParamId": 0,
-        "containerMap": {},
-        "defaultContainerId": 0,
-        "recordMap": {},
-        "defaultRecordId": 0
+        "commandMap" : {
+          
+        },
+        "defaultOpcode" : 0,
+        "tlmChannelMap" : {
+          
+        },
+        "tlmChannelNameMap" : {
+          
+        },
+        "defaultTlmChannelId" : 0,
+        "eventMap" : {
+          
+        },
+        "defaultEventId" : 0,
+        "paramMap" : {
+          
+        },
+        "specPortMatchingList" : [
+        ],
+        "stateMachineInstanceMap" : {
+          
+        },
+        "portMatchingList" : [
+        ],
+        "defaultParamId" : 0,
+        "containerMap" : {
+          
+        },
+        "defaultContainerId" : 0,
+        "recordMap" : {
+          
+        },
+        "defaultRecordId" : 0
       },
-      "87": {
-        "aNode": {
-          "astNodeId": 87
+      "84" : {
+        "aNode" : {
+          "astNodeId" : 84
         },
-        "portMap": {
-          "tlm": {
-            "General": {
-              "aNode": {
-                "astNodeId": 86
+        "portMap" : {
+          "paramGet" : {
+            "General" : {
+              "aNode" : {
+                "astNodeId" : 71
               },
-              "specifier": {
-                "kind": {
-                  "SyncInput": {}
-                },
-                "name": "tlm",
-                "size": "None",
-                "port": {
-                  "Some": {
-                    "astNodeId": 85
+              "specifier" : {
+                "kind" : {
+                  "SyncInput" : {
+                    
                   }
                 },
-                "priority": "None",
-                "queueFull": "None"
+                "name" : "paramGet",
+                "size" : "None",
+                "port" : {
+                  "Some" : {
+                    "astNodeId" : 70
+                  }
+                },
+                "priority" : "None",
+                "queueFull" : "None"
               },
-              "kind": "SyncInput",
-              "size": 1,
-              "ty": {
-                "DefPort": {
-                  "symbol": {
-                    "Port": {
-                      "nodeId": 201,
-                      "unqualifiedName": "Tlm"
+              "kind" : "SyncInput",
+              "size" : 1,
+              "ty" : {
+                "DefPort" : {
+                  "symbol" : {
+                    "Port" : {
+                      "nodeId" : 291,
+                      "unqualifiedName" : "PrmGet"
                     }
                   }
                 }
               },
-              "importNodeIds": []
+              "importNodeIds" : [
+              ]
+            }
+          },
+          "paramSet" : {
+            "General" : {
+              "aNode" : {
+                "astNodeId" : 83
+              },
+              "specifier" : {
+                "kind" : {
+                  "SyncInput" : {
+                    
+                  }
+                },
+                "name" : "paramSet",
+                "size" : "None",
+                "port" : {
+                  "Some" : {
+                    "astNodeId" : 82
+                  }
+                },
+                "priority" : "None",
+                "queueFull" : "None"
+              },
+              "kind" : "SyncInput",
+              "size" : 1,
+              "ty" : {
+                "DefPort" : {
+                  "symbol" : {
+                    "Port" : {
+                      "nodeId" : 292,
+                      "unqualifiedName" : "PrmSet"
+                    }
+                  }
+                }
+              },
+              "importNodeIds" : [
+              ]
             }
           }
         },
-        "specialPortMap": {},
-        "commandMap": {},
-        "defaultOpcode": 0,
-        "tlmChannelMap": {},
-        "tlmChannelNameMap": {},
-        "defaultTlmChannelId": 0,
-        "eventMap": {},
-        "defaultEventId": 0,
-        "paramMap": {},
-        "specPortMatchingList": [],
-        "stateMachineInstanceMap": {},
-        "portMatchingList": [],
-        "defaultParamId": 0,
-        "containerMap": {},
-        "defaultContainerId": 0,
-        "recordMap": {},
-        "defaultRecordId": 0
+        "specialPortMap" : {
+          
+        },
+        "commandMap" : {
+          
+        },
+        "defaultOpcode" : 0,
+        "tlmChannelMap" : {
+          
+        },
+        "tlmChannelNameMap" : {
+          
+        },
+        "defaultTlmChannelId" : 0,
+        "eventMap" : {
+          
+        },
+        "defaultEventId" : 0,
+        "paramMap" : {
+          
+        },
+        "specPortMatchingList" : [
+        ],
+        "stateMachineInstanceMap" : {
+          
+        },
+        "portMatchingList" : [
+        ],
+        "defaultParamId" : 0,
+        "containerMap" : {
+          
+        },
+        "defaultContainerId" : 0,
+        "recordMap" : {
+          
+        },
+        "defaultRecordId" : 0
       },
-      "106": {
-        "aNode": {
-          "astNodeId": 106
+      "110" : {
+        "aNode" : {
+          "astNodeId" : 110
         },
-        "portMap": {
-          "cmdRegOut": {
-            "Special": {
-              "aNode": {
-                "astNodeId": 101
+        "portMap" : {
+          "textEventLog" : {
+            "General" : {
+              "aNode" : {
+                "astNodeId" : 109
               },
-              "specifier": {
-                "inputKind": "None",
-                "kind": {
-                  "CommandReg": {}
+              "specifier" : {
+                "kind" : {
+                  "SyncInput" : {
+                    
+                  }
                 },
-                "name": "cmdRegOut",
-                "priority": "None",
-                "queueFull": "None"
+                "name" : "textEventLog",
+                "size" : "None",
+                "port" : {
+                  "Some" : {
+                    "astNodeId" : 108
+                  }
+                },
+                "priority" : "None",
+                "queueFull" : "None"
               },
-              "symbol": {
-                "Port": {
-                  "nodeId": 194,
-                  "unqualifiedName": "CmdReg"
+              "kind" : "SyncInput",
+              "size" : 1,
+              "ty" : {
+                "DefPort" : {
+                  "symbol" : {
+                    "Port" : {
+                      "nodeId" : 290,
+                      "unqualifiedName" : "LogText"
+                    }
+                  }
                 }
               },
-              "priority": "None",
-              "queueFull": "None",
-              "importNodeIds": []
-            }
-          },
-          "cmdIn": {
-            "Special": {
-              "aNode": {
-                "astNodeId": 102
-              },
-              "specifier": {
-                "inputKind": "None",
-                "kind": {
-                  "CommandRecv": {}
-                },
-                "name": "cmdIn",
-                "priority": "None",
-                "queueFull": "None"
-              },
-              "symbol": {
-                "Port": {
-                  "nodeId": 193,
-                  "unqualifiedName": "Cmd"
-                }
-              },
-              "priority": "None",
-              "queueFull": "None",
-              "importNodeIds": []
-            }
-          },
-          "cmdResponseOut": {
-            "Special": {
-              "aNode": {
-                "astNodeId": 105
-              },
-              "specifier": {
-                "inputKind": "None",
-                "kind": {
-                  "CommandResp": {}
-                },
-                "name": "cmdResponseOut",
-                "priority": "None",
-                "queueFull": "None"
-              },
-              "symbol": {
-                "Port": {
-                  "nodeId": 195,
-                  "unqualifiedName": "CmdResponse"
-                }
-              },
-              "priority": "None",
-              "queueFull": "None",
-              "importNodeIds": []
+              "importNodeIds" : [
+              ]
             }
           }
         },
-        "specialPortMap": {
-          "command reg": {
-            "aNode": {
-              "astNodeId": 101
-            },
-            "specifier": {
-              "inputKind": "None",
-              "kind": {
-                "CommandReg": {}
-              },
-              "name": "cmdRegOut",
-              "priority": "None",
-              "queueFull": "None"
-            },
-            "symbol": {
-              "Port": {
-                "nodeId": 194,
-                "unqualifiedName": "CmdReg"
-              }
-            },
-            "priority": "None",
-            "queueFull": "None",
-            "importNodeIds": []
-          },
-          "command recv": {
-            "aNode": {
-              "astNodeId": 102
-            },
-            "specifier": {
-              "inputKind": "None",
-              "kind": {
-                "CommandRecv": {}
-              },
-              "name": "cmdIn",
-              "priority": "None",
-              "queueFull": "None"
-            },
-            "symbol": {
-              "Port": {
-                "nodeId": 193,
-                "unqualifiedName": "Cmd"
-              }
-            },
-            "priority": "None",
-            "queueFull": "None",
-            "importNodeIds": []
-          },
-          "command resp": {
-            "aNode": {
-              "astNodeId": 105
-            },
-            "specifier": {
-              "inputKind": "None",
-              "kind": {
-                "CommandResp": {}
-              },
-              "name": "cmdResponseOut",
-              "priority": "None",
-              "queueFull": "None"
-            },
-            "symbol": {
-              "Port": {
-                "nodeId": 195,
-                "unqualifiedName": "CmdResponse"
-              }
-            },
-            "priority": "None",
-            "queueFull": "None",
-            "importNodeIds": []
-          }
+        "specialPortMap" : {
+          
         },
-        "commandMap": {},
-        "defaultOpcode": 0,
-        "tlmChannelMap": {},
-        "tlmChannelNameMap": {},
-        "defaultTlmChannelId": 0,
-        "eventMap": {},
-        "defaultEventId": 0,
-        "paramMap": {},
-        "specPortMatchingList": [],
-        "stateMachineInstanceMap": {},
-        "portMatchingList": [],
-        "defaultParamId": 0,
-        "containerMap": {},
-        "defaultContainerId": 0,
-        "recordMap": {},
-        "defaultRecordId": 0
+        "commandMap" : {
+          
+        },
+        "defaultOpcode" : 0,
+        "tlmChannelMap" : {
+          
+        },
+        "tlmChannelNameMap" : {
+          
+        },
+        "defaultTlmChannelId" : 0,
+        "eventMap" : {
+          
+        },
+        "defaultEventId" : 0,
+        "paramMap" : {
+          
+        },
+        "specPortMatchingList" : [
+        ],
+        "stateMachineInstanceMap" : {
+          
+        },
+        "portMatchingList" : [
+        ],
+        "defaultParamId" : 0,
+        "containerMap" : {
+          
+        },
+        "defaultContainerId" : 0,
+        "recordMap" : {
+          
+        },
+        "defaultRecordId" : 0
       },
-      "7": {
-        "aNode": {
-          "astNodeId": 7
+      "97" : {
+        "aNode" : {
+          "astNodeId" : 97
         },
-        "portMap": {
-          "timeGetPort": {
-            "General": {
-              "aNode": {
-                "astNodeId": 3
+        "portMap" : {
+          "tlm" : {
+            "General" : {
+              "aNode" : {
+                "astNodeId" : 96
               },
-              "specifier": {
-                "kind": {
-                  "SyncInput": {}
-                },
-                "name": "timeGetPort",
-                "size": "None",
-                "port": {
-                  "Some": {
-                    "astNodeId": 2
+              "specifier" : {
+                "kind" : {
+                  "SyncInput" : {
+                    
                   }
                 },
-                "priority": "None",
-                "queueFull": "None"
+                "name" : "tlm",
+                "size" : "None",
+                "port" : {
+                  "Some" : {
+                    "astNodeId" : 95
+                  }
+                },
+                "priority" : "None",
+                "queueFull" : "None"
               },
-              "kind": "SyncInput",
-              "size": 1,
-              "ty": {
-                "DefPort": {
-                  "symbol": {
-                    "Port": {
-                      "nodeId": 200,
-                      "unqualifiedName": "Time"
+              "kind" : "SyncInput",
+              "size" : 1,
+              "ty" : {
+                "DefPort" : {
+                  "symbol" : {
+                    "Port" : {
+                      "nodeId" : 294,
+                      "unqualifiedName" : "Tlm"
                     }
                   }
                 }
               },
-              "importNodeIds": []
-            }
-          },
-          "timeGetOut": {
-            "Special": {
-              "aNode": {
-                "astNodeId": 6
-              },
-              "specifier": {
-                "inputKind": "None",
-                "kind": {
-                  "TimeGet": {}
-                },
-                "name": "timeGetOut",
-                "priority": "None",
-                "queueFull": "None"
-              },
-              "symbol": {
-                "Port": {
-                  "nodeId": 200,
-                  "unqualifiedName": "Time"
-                }
-              },
-              "priority": "None",
-              "queueFull": "None",
-              "importNodeIds": []
+              "importNodeIds" : [
+              ]
             }
           }
         },
-        "specialPortMap": {
-          "time get": {
-            "aNode": {
-              "astNodeId": 6
-            },
-            "specifier": {
-              "inputKind": "None",
-              "kind": {
-                "TimeGet": {}
-              },
-              "name": "timeGetOut",
-              "priority": "None",
-              "queueFull": "None"
-            },
-            "symbol": {
-              "Port": {
-                "nodeId": 200,
-                "unqualifiedName": "Time"
-              }
-            },
-            "priority": "None",
-            "queueFull": "None",
-            "importNodeIds": []
-          }
+        "specialPortMap" : {
+          
         },
-        "commandMap": {},
-        "defaultOpcode": 0,
-        "tlmChannelMap": {},
-        "tlmChannelNameMap": {},
-        "defaultTlmChannelId": 0,
-        "eventMap": {},
-        "defaultEventId": 0,
-        "paramMap": {},
-        "specPortMatchingList": [],
-        "stateMachineInstanceMap": {},
-        "portMatchingList": [],
-        "defaultParamId": 0,
-        "containerMap": {},
-        "defaultContainerId": 0,
-        "recordMap": {},
-        "defaultRecordId": 0
+        "commandMap" : {
+          
+        },
+        "defaultOpcode" : 0,
+        "tlmChannelMap" : {
+          
+        },
+        "tlmChannelNameMap" : {
+          
+        },
+        "defaultTlmChannelId" : 0,
+        "eventMap" : {
+          
+        },
+        "defaultEventId" : 0,
+        "paramMap" : {
+          
+        },
+        "specPortMatchingList" : [
+        ],
+        "stateMachineInstanceMap" : {
+          
+        },
+        "portMatchingList" : [
+        ],
+        "defaultParamId" : 0,
+        "containerMap" : {
+          
+        },
+        "defaultContainerId" : 0,
+        "recordMap" : {
+          
+        },
+        "defaultRecordId" : 0
       },
-      "74": {
-        "aNode": {
-          "astNodeId": 74
+      "50" : {
+        "aNode" : {
+          "astNodeId" : 50
         },
-        "portMap": {
-          "paramGet": {
-            "General": {
-              "aNode": {
-                "astNodeId": 61
+        "portMap" : {
+          "eventLog" : {
+            "General" : {
+              "aNode" : {
+                "astNodeId" : 49
               },
-              "specifier": {
-                "kind": {
-                  "SyncInput": {}
-                },
-                "name": "paramGet",
-                "size": "None",
-                "port": {
-                  "Some": {
-                    "astNodeId": 60
+              "specifier" : {
+                "kind" : {
+                  "SyncInput" : {
+                    
                   }
                 },
-                "priority": "None",
-                "queueFull": "None"
+                "name" : "eventLog",
+                "size" : "None",
+                "port" : {
+                  "Some" : {
+                    "astNodeId" : 48
+                  }
+                },
+                "priority" : "None",
+                "queueFull" : "None"
               },
-              "kind": "SyncInput",
-              "size": 1,
-              "ty": {
-                "DefPort": {
-                  "symbol": {
-                    "Port": {
-                      "nodeId": 198,
-                      "unqualifiedName": "PrmGet"
+              "kind" : "SyncInput",
+              "size" : 1,
+              "ty" : {
+                "DefPort" : {
+                  "symbol" : {
+                    "Port" : {
+                      "nodeId" : 289,
+                      "unqualifiedName" : "Log"
                     }
                   }
                 }
               },
-              "importNodeIds": []
-            }
-          },
-          "paramSet": {
-            "General": {
-              "aNode": {
-                "astNodeId": 73
-              },
-              "specifier": {
-                "kind": {
-                  "SyncInput": {}
-                },
-                "name": "paramSet",
-                "size": "None",
-                "port": {
-                  "Some": {
-                    "astNodeId": 72
-                  }
-                },
-                "priority": "None",
-                "queueFull": "None"
-              },
-              "kind": "SyncInput",
-              "size": 1,
-              "ty": {
-                "DefPort": {
-                  "symbol": {
-                    "Port": {
-                      "nodeId": 199,
-                      "unqualifiedName": "PrmSet"
-                    }
-                  }
-                }
-              },
-              "importNodeIds": []
+              "importNodeIds" : [
+              ]
             }
           }
         },
-        "specialPortMap": {},
-        "commandMap": {},
-        "defaultOpcode": 0,
-        "tlmChannelMap": {},
-        "tlmChannelNameMap": {},
-        "defaultTlmChannelId": 0,
-        "eventMap": {},
-        "defaultEventId": 0,
-        "paramMap": {},
-        "specPortMatchingList": [],
-        "stateMachineInstanceMap": {},
-        "portMatchingList": [],
-        "defaultParamId": 0,
-        "containerMap": {},
-        "defaultContainerId": 0,
-        "recordMap": {},
-        "defaultRecordId": 0
+        "specialPortMap" : {
+          
+        },
+        "commandMap" : {
+          
+        },
+        "defaultOpcode" : 0,
+        "tlmChannelMap" : {
+          
+        },
+        "tlmChannelNameMap" : {
+          
+        },
+        "defaultTlmChannelId" : 0,
+        "eventMap" : {
+          
+        },
+        "defaultEventId" : 0,
+        "paramMap" : {
+          
+        },
+        "specPortMatchingList" : [
+        ],
+        "stateMachineInstanceMap" : {
+          
+        },
+        "portMatchingList" : [
+        ],
+        "defaultParamId" : 0,
+        "containerMap" : {
+          
+        },
+        "defaultContainerId" : 0,
+        "recordMap" : {
+          
+        },
+        "defaultRecordId" : 0
       },
-      "57": {
-        "aNode": {
-          "astNodeId": 57
+      "37" : {
+        "aNode" : {
+          "astNodeId" : 37
         },
-        "portMap": {
-          "PingSend": {
-            "General": {
-              "aNode": {
-                "astNodeId": 44
+        "portMap" : {
+          "cmdIn" : {
+            "General" : {
+              "aNode" : {
+                "astNodeId" : 16
               },
-              "specifier": {
-                "kind": {
-                  "Output": {}
-                },
-                "name": "PingSend",
-                "size": "None",
-                "port": {
-                  "Some": {
-                    "astNodeId": 43
+              "specifier" : {
+                "kind" : {
+                  "SyncInput" : {
+                    
                   }
                 },
-                "priority": "None",
-                "queueFull": "None"
+                "name" : "cmdIn",
+                "size" : "None",
+                "port" : {
+                  "Some" : {
+                    "astNodeId" : 15
+                  }
+                },
+                "priority" : "None",
+                "queueFull" : "None"
               },
-              "kind": "Output",
-              "size": 1,
-              "ty": {
-                "DefPort": {
-                  "symbol": {
-                    "Port": {
-                      "nodeId": 208,
-                      "unqualifiedName": "Ping"
+              "kind" : "SyncInput",
+              "size" : 1,
+              "ty" : {
+                "DefPort" : {
+                  "symbol" : {
+                    "Port" : {
+                      "nodeId" : 286,
+                      "unqualifiedName" : "Cmd"
                     }
                   }
                 }
               },
-              "importNodeIds": []
+              "importNodeIds" : [
+              ]
             }
           },
-          "PingReturn": {
-            "General": {
-              "aNode": {
-                "astNodeId": 56
+          "cmdRegOut" : {
+            "General" : {
+              "aNode" : {
+                "astNodeId" : 20
               },
-              "specifier": {
-                "kind": {
-                  "SyncInput": {}
-                },
-                "name": "PingReturn",
-                "size": "None",
-                "port": {
-                  "Some": {
-                    "astNodeId": 55
+              "specifier" : {
+                "kind" : {
+                  "SyncInput" : {
+                    
                   }
                 },
-                "priority": "None",
-                "queueFull": "None"
+                "name" : "cmdRegOut",
+                "size" : "None",
+                "port" : {
+                  "Some" : {
+                    "astNodeId" : 19
+                  }
+                },
+                "priority" : "None",
+                "queueFull" : "None"
               },
-              "kind": "SyncInput",
-              "size": 1,
-              "ty": {
-                "DefPort": {
-                  "symbol": {
-                    "Port": {
-                      "nodeId": 208,
-                      "unqualifiedName": "Ping"
+              "kind" : "SyncInput",
+              "size" : 1,
+              "ty" : {
+                "DefPort" : {
+                  "symbol" : {
+                    "Port" : {
+                      "nodeId" : 287,
+                      "unqualifiedName" : "CmdReg"
                     }
                   }
                 }
               },
-              "importNodeIds": []
+              "importNodeIds" : [
+              ]
+            }
+          },
+          "cmdResponseOut" : {
+            "General" : {
+              "aNode" : {
+                "astNodeId" : 24
+              },
+              "specifier" : {
+                "kind" : {
+                  "SyncInput" : {
+                    
+                  }
+                },
+                "name" : "cmdResponseOut",
+                "size" : "None",
+                "port" : {
+                  "Some" : {
+                    "astNodeId" : 23
+                  }
+                },
+                "priority" : "None",
+                "queueFull" : "None"
+              },
+              "kind" : "SyncInput",
+              "size" : 1,
+              "ty" : {
+                "DefPort" : {
+                  "symbol" : {
+                    "Port" : {
+                      "nodeId" : 288,
+                      "unqualifiedName" : "CmdResponse"
+                    }
+                  }
+                }
+              },
+              "importNodeIds" : [
+              ]
+            }
+          },
+          "cmdSend" : {
+            "General" : {
+              "aNode" : {
+                "astNodeId" : 36
+              },
+              "specifier" : {
+                "kind" : {
+                  "Output" : {
+                    
+                  }
+                },
+                "name" : "cmdSend",
+                "size" : "None",
+                "port" : {
+                  "Some" : {
+                    "astNodeId" : 35
+                  }
+                },
+                "priority" : "None",
+                "queueFull" : "None"
+              },
+              "kind" : "Output",
+              "size" : 1,
+              "ty" : {
+                "DefPort" : {
+                  "symbol" : {
+                    "Port" : {
+                      "nodeId" : 286,
+                      "unqualifiedName" : "Cmd"
+                    }
+                  }
+                }
+              },
+              "importNodeIds" : [
+              ]
             }
           }
         },
-        "specialPortMap": {},
-        "commandMap": {},
-        "defaultOpcode": 0,
-        "tlmChannelMap": {},
-        "tlmChannelNameMap": {},
-        "defaultTlmChannelId": 0,
-        "eventMap": {},
-        "defaultEventId": 0,
-        "paramMap": {},
-        "specPortMatchingList": [],
-        "stateMachineInstanceMap": {},
-        "portMatchingList": [],
-        "defaultParamId": 0,
-        "containerMap": {},
-        "defaultContainerId": 0,
-        "recordMap": {},
-        "defaultRecordId": 0
-      },
-      "32": {
-        "aNode": {
-          "astNodeId": 32
+        "specialPortMap" : {
+          
         },
-        "portMap": {
-          "cmdIn": {
-            "General": {
-              "aNode": {
-                "astNodeId": 11
-              },
-              "specifier": {
-                "kind": {
-                  "SyncInput": {}
-                },
-                "name": "cmdIn",
-                "size": "None",
-                "port": {
-                  "Some": {
-                    "astNodeId": 10
-                  }
-                },
-                "priority": "None",
-                "queueFull": "None"
-              },
-              "kind": "SyncInput",
-              "size": 1,
-              "ty": {
-                "DefPort": {
-                  "symbol": {
-                    "Port": {
-                      "nodeId": 193,
-                      "unqualifiedName": "Cmd"
-                    }
-                  }
-                }
-              },
-              "importNodeIds": []
-            }
-          },
-          "cmdRegOut": {
-            "General": {
-              "aNode": {
-                "astNodeId": 15
-              },
-              "specifier": {
-                "kind": {
-                  "SyncInput": {}
-                },
-                "name": "cmdRegOut",
-                "size": "None",
-                "port": {
-                  "Some": {
-                    "astNodeId": 14
-                  }
-                },
-                "priority": "None",
-                "queueFull": "None"
-              },
-              "kind": "SyncInput",
-              "size": 1,
-              "ty": {
-                "DefPort": {
-                  "symbol": {
-                    "Port": {
-                      "nodeId": 194,
-                      "unqualifiedName": "CmdReg"
-                    }
-                  }
-                }
-              },
-              "importNodeIds": []
-            }
-          },
-          "cmdResponseOut": {
-            "General": {
-              "aNode": {
-                "astNodeId": 19
-              },
-              "specifier": {
-                "kind": {
-                  "SyncInput": {}
-                },
-                "name": "cmdResponseOut",
-                "size": "None",
-                "port": {
-                  "Some": {
-                    "astNodeId": 18
-                  }
-                },
-                "priority": "None",
-                "queueFull": "None"
-              },
-              "kind": "SyncInput",
-              "size": 1,
-              "ty": {
-                "DefPort": {
-                  "symbol": {
-                    "Port": {
-                      "nodeId": 195,
-                      "unqualifiedName": "CmdResponse"
-                    }
-                  }
-                }
-              },
-              "importNodeIds": []
-            }
-          },
-          "cmdSend": {
-            "General": {
-              "aNode": {
-                "astNodeId": 31
-              },
-              "specifier": {
-                "kind": {
-                  "Output": {}
-                },
-                "name": "cmdSend",
-                "size": "None",
-                "port": {
-                  "Some": {
-                    "astNodeId": 30
-                  }
-                },
-                "priority": "None",
-                "queueFull": "None"
-              },
-              "kind": "Output",
-              "size": 1,
-              "ty": {
-                "DefPort": {
-                  "symbol": {
-                    "Port": {
-                      "nodeId": 193,
-                      "unqualifiedName": "Cmd"
-                    }
-                  }
-                }
-              },
-              "importNodeIds": []
-            }
-          }
+        "commandMap" : {
+          
         },
-        "specialPortMap": {},
-        "commandMap": {},
-        "defaultOpcode": 0,
-        "tlmChannelMap": {},
-        "tlmChannelNameMap": {},
-        "defaultTlmChannelId": 0,
-        "eventMap": {},
-        "defaultEventId": 0,
-        "paramMap": {},
-        "specPortMatchingList": [],
-        "stateMachineInstanceMap": {},
-        "portMatchingList": [],
-        "defaultParamId": 0,
-        "containerMap": {},
-        "defaultContainerId": 0,
-        "recordMap": {},
-        "defaultRecordId": 0
+        "defaultOpcode" : 0,
+        "tlmChannelMap" : {
+          
+        },
+        "tlmChannelNameMap" : {
+          
+        },
+        "defaultTlmChannelId" : 0,
+        "eventMap" : {
+          
+        },
+        "defaultEventId" : 0,
+        "paramMap" : {
+          
+        },
+        "specPortMatchingList" : [
+        ],
+        "stateMachineInstanceMap" : {
+          
+        },
+        "portMatchingList" : [
+        ],
+        "defaultParamId" : 0,
+        "containerMap" : {
+          
+        },
+        "defaultContainerId" : 0,
+        "recordMap" : {
+          
+        },
+        "defaultRecordId" : 0
       }
     },
-    "includedFileSet": [],
-    "inputFileSet": [
+    "includedFileSet" : [
+    ],
+    "inputFileSet" : [
       "[ local path prefix ]/compiler/tools/fpp-to-json/test/fprime/defs.fpp",
       "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp"
     ],
-    "locationSpecifierMap": [],
-    "parentSymbolMap": {
-      "193": {
-        "Module": {
-          "nodeId": 205,
-          "unqualifiedName": "Fw"
+    "locationSpecifierMap" : [
+    ],
+    "parentSymbolMap" : {
+      "287" : {
+        "Module" : {
+          "nodeId" : 298,
+          "unqualifiedName" : "Fw"
         }
       },
-      "199": {
-        "Module": {
-          "nodeId": 205,
-          "unqualifiedName": "Fw"
+      "291" : {
+        "Module" : {
+          "nodeId" : 298,
+          "unqualifiedName" : "Fw"
         }
       },
-      "196": {
-        "Module": {
-          "nodeId": 205,
-          "unqualifiedName": "Fw"
+      "292" : {
+        "Module" : {
+          "nodeId" : 298,
+          "unqualifiedName" : "Fw"
         }
       },
-      "208": {
-        "Module": {
-          "nodeId": 209,
-          "unqualifiedName": "Svc"
+      "297" : {
+        "Module" : {
+          "nodeId" : 298,
+          "unqualifiedName" : "Fw"
         }
       },
-      "195": {
-        "Module": {
-          "nodeId": 205,
-          "unqualifiedName": "Fw"
+      "290" : {
+        "Module" : {
+          "nodeId" : 298,
+          "unqualifiedName" : "Fw"
         }
       },
-      "198": {
-        "Module": {
-          "nodeId": 205,
-          "unqualifiedName": "Fw"
+      "293" : {
+        "Module" : {
+          "nodeId" : 298,
+          "unqualifiedName" : "Fw"
         }
       },
-      "194": {
-        "Module": {
-          "nodeId": 205,
-          "unqualifiedName": "Fw"
+      "294" : {
+        "Module" : {
+          "nodeId" : 298,
+          "unqualifiedName" : "Fw"
         }
       },
-      "204": {
-        "Module": {
-          "nodeId": 205,
-          "unqualifiedName": "Fw"
+      "288" : {
+        "Module" : {
+          "nodeId" : 298,
+          "unqualifiedName" : "Fw"
         }
       },
-      "200": {
-        "Module": {
-          "nodeId": 205,
-          "unqualifiedName": "Fw"
+      "301" : {
+        "Module" : {
+          "nodeId" : 302,
+          "unqualifiedName" : "Svc"
         }
       },
-      "201": {
-        "Module": {
-          "nodeId": 205,
-          "unqualifiedName": "Fw"
+      "286" : {
+        "Module" : {
+          "nodeId" : 298,
+          "unqualifiedName" : "Fw"
         }
       },
-      "197": {
-        "Module": {
-          "nodeId": 205,
-          "unqualifiedName": "Fw"
+      "289" : {
+        "Module" : {
+          "nodeId" : 298,
+          "unqualifiedName" : "Fw"
         }
       }
     },
-    "symbolScopeMap": {
-      "205": {
-        "map": {
-          "Port": {
-            "map": {
-              "CmdReg": {
-                "Port": {
-                  "nodeId": 194,
-                  "unqualifiedName": "CmdReg"
+    "symbolScopeMap" : {
+      "12" : {
+        "map" : {
+          
+        }
+      },
+      "84" : {
+        "map" : {
+          
+        }
+      },
+      "110" : {
+        "map" : {
+          
+        }
+      },
+      "298" : {
+        "map" : {
+          "Port" : {
+            "map" : {
+              "CmdReg" : {
+                "Port" : {
+                  "nodeId" : 287,
+                  "unqualifiedName" : "CmdReg"
                 }
               },
-              "Tlm": {
-                "Port": {
-                  "nodeId": 201,
-                  "unqualifiedName": "Tlm"
+              "Tlm" : {
+                "Port" : {
+                  "nodeId" : 294,
+                  "unqualifiedName" : "Tlm"
                 }
               },
-              "PrmGet": {
-                "Port": {
-                  "nodeId": 198,
-                  "unqualifiedName": "PrmGet"
+              "PrmGet" : {
+                "Port" : {
+                  "nodeId" : 291,
+                  "unqualifiedName" : "PrmGet"
                 }
               },
-              "LogText": {
-                "Port": {
-                  "nodeId": 197,
-                  "unqualifiedName": "LogText"
+              "LogText" : {
+                "Port" : {
+                  "nodeId" : 290,
+                  "unqualifiedName" : "LogText"
                 }
               },
-              "Cmd": {
-                "Port": {
-                  "nodeId": 193,
-                  "unqualifiedName": "Cmd"
+              "Cmd" : {
+                "Port" : {
+                  "nodeId" : 286,
+                  "unqualifiedName" : "Cmd"
                 }
               },
-              "Log": {
-                "Port": {
-                  "nodeId": 196,
-                  "unqualifiedName": "Log"
+              "Log" : {
+                "Port" : {
+                  "nodeId" : 289,
+                  "unqualifiedName" : "Log"
                 }
               },
-              "CmdResponse": {
-                "Port": {
-                  "nodeId": 195,
-                  "unqualifiedName": "CmdResponse"
+              "CmdResponse" : {
+                "Port" : {
+                  "nodeId" : 288,
+                  "unqualifiedName" : "CmdResponse"
                 }
               },
-              "Time": {
-                "Port": {
-                  "nodeId": 200,
-                  "unqualifiedName": "Time"
+              "Time" : {
+                "Port" : {
+                  "nodeId" : 293,
+                  "unqualifiedName" : "Time"
                 }
               },
-              "PrmSet": {
-                "Port": {
-                  "nodeId": 199,
-                  "unqualifiedName": "PrmSet"
+              "PrmSet" : {
+                "Port" : {
+                  "nodeId" : 292,
+                  "unqualifiedName" : "PrmSet"
                 }
               },
-              "TlmGet": {
-                "Port": {
-                  "nodeId": 204,
-                  "unqualifiedName": "TlmGet"
+              "TlmGet" : {
+                "Port" : {
+                  "nodeId" : 297,
+                  "unqualifiedName" : "TlmGet"
                 }
               }
             }
           }
         }
       },
-      "100": {
-        "map": {}
+      "97" : {
+        "map" : {
+          
+        }
       },
-      "40": {
-        "map": {}
+      "67" : {
+        "map" : {
+          
+        }
       },
-      "209": {
-        "map": {
-          "Port": {
-            "map": {
-              "Ping": {
-                "Port": {
-                  "nodeId": 208,
-                  "unqualifiedName": "Ping"
+      "302" : {
+        "map" : {
+          "Port" : {
+            "map" : {
+              "Ping" : {
+                "Port" : {
+                  "nodeId" : 301,
+                  "unqualifiedName" : "Ping"
                 }
               }
             }
           }
         }
       },
-      "87": {
-        "map": {}
+      "50" : {
+        "map" : {
+          
+        }
       },
-      "106": {
-        "map": {}
-      },
-      "7": {
-        "map": {}
-      },
-      "74": {
-        "map": {}
-      },
-      "57": {
-        "map": {}
-      },
-      "32": {
-        "map": {}
+      "37" : {
+        "map" : {
+          
+        }
       }
     },
-    "topologyMap": {
-      "192": {
-        "aNode": {
-          "astNodeId": 192
+    "topologyMap" : {
+      "285" : {
+        "aNode" : {
+          "astNodeId" : 285
         },
-        "directImportMap": {},
-        "transitiveImportSet": [],
-        "instanceMap": [
+        "directImportMap" : {
+          
+        },
+        "transitiveImportSet" : [
+        ],
+        "instanceMap" : [
           [
             {
-              "aNode": {
-                "astNodeId": 114
+              "aNode" : {
+                "astNodeId" : 130
               },
-              "qualifiedName": {
-                "qualifier": [],
-                "base": "c1"
+              "qualifiedName" : {
+                "qualifier" : [
+                ],
+                "base" : "c5"
               },
-              "component": {
-                "astNodeId": 7
+              "component" : {
+                "astNodeId" : 84
               },
-              "baseId": 256,
-              "maxId": 255,
-              "file": "None",
-              "queueSize": "None",
-              "stackSize": "None",
-              "priority": "None",
-              "cpu": "None",
-              "initSpecifierMap": {}
+              "baseId" : 1280,
+              "maxId" : 1279,
+              "file" : "None",
+              "queueSize" : "None",
+              "stackSize" : "None",
+              "priority" : "None",
+              "cpu" : "None",
+              "initSpecifierMap" : {
+                
+              }
             },
             [
               {
-                "Public": {}
+                "Public" : {
+                  
+                }
               },
               {
-                "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-                "pos": "55.5",
-                "includingLoc": "None"
+                "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+                "pos" : "47.5",
+                "includingLoc" : "None"
               }
             ]
           ],
           [
             {
-              "aNode": {
-                "astNodeId": 130
+              "aNode" : {
+                "astNodeId" : 138
               },
-              "qualifiedName": {
-                "qualifier": [],
-                "base": "c5"
+              "qualifiedName" : {
+                "qualifier" : [
+                ],
+                "base" : "c7"
               },
-              "component": {
-                "astNodeId": 74
+              "component" : {
+                "astNodeId" : 110
               },
-              "baseId": 1280,
-              "maxId": 1279,
-              "file": "None",
-              "queueSize": "None",
-              "stackSize": "None",
-              "priority": "None",
-              "cpu": "None",
-              "initSpecifierMap": {}
+              "baseId" : 1792,
+              "maxId" : 1791,
+              "file" : "None",
+              "queueSize" : "None",
+              "stackSize" : "None",
+              "priority" : "None",
+              "cpu" : "None",
+              "initSpecifierMap" : {
+                
+              }
             },
             [
               {
-                "Public": {}
+                "Public" : {
+                  
+                }
               },
               {
-                "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-                "pos": "59.5",
-                "includingLoc": "None"
+                "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+                "pos" : "49.5",
+                "includingLoc" : "None"
               }
             ]
           ],
           [
             {
-              "aNode": {
-                "astNodeId": 126
+              "aNode" : {
+                "astNodeId" : 134
               },
-              "qualifiedName": {
-                "qualifier": [],
-                "base": "c4"
+              "qualifiedName" : {
+                "qualifier" : [
+                ],
+                "base" : "c6"
               },
-              "component": {
-                "astNodeId": 57
+              "component" : {
+                "astNodeId" : 97
               },
-              "baseId": 1024,
-              "maxId": 1023,
-              "file": "None",
-              "queueSize": "None",
-              "stackSize": "None",
-              "priority": "None",
-              "cpu": "None",
-              "initSpecifierMap": {}
+              "baseId" : 1536,
+              "maxId" : 1535,
+              "file" : "None",
+              "queueSize" : "None",
+              "stackSize" : "None",
+              "priority" : "None",
+              "cpu" : "None",
+              "initSpecifierMap" : {
+                
+              }
             },
             [
               {
-                "Public": {}
+                "Public" : {
+                  
+                }
               },
               {
-                "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-                "pos": "58.5",
-                "includingLoc": "None"
+                "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+                "pos" : "48.5",
+                "includingLoc" : "None"
               }
             ]
           ],
           [
             {
-              "aNode": {
-                "astNodeId": 134
+              "aNode" : {
+                "astNodeId" : 126
               },
-              "qualifiedName": {
-                "qualifier": [],
-                "base": "c6"
+              "qualifiedName" : {
+                "qualifier" : [
+                ],
+                "base" : "c4"
               },
-              "component": {
-                "astNodeId": 87
+              "component" : {
+                "astNodeId" : 67
               },
-              "baseId": 1536,
-              "maxId": 1535,
-              "file": "None",
-              "queueSize": "None",
-              "stackSize": "None",
-              "priority": "None",
-              "cpu": "None",
-              "initSpecifierMap": {}
+              "baseId" : 1024,
+              "maxId" : 1023,
+              "file" : "None",
+              "queueSize" : "None",
+              "stackSize" : "None",
+              "priority" : "None",
+              "cpu" : "None",
+              "initSpecifierMap" : {
+                
+              }
             },
             [
               {
-                "Public": {}
+                "Public" : {
+                  
+                }
               },
               {
-                "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-                "pos": "60.5",
-                "includingLoc": "None"
+                "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+                "pos" : "46.5",
+                "includingLoc" : "None"
               }
             ]
           ],
           [
             {
-              "aNode": {
-                "astNodeId": 138
+              "aNode" : {
+                "astNodeId" : 114
               },
-              "qualifiedName": {
-                "qualifier": [],
-                "base": "c7"
+              "qualifiedName" : {
+                "qualifier" : [
+                ],
+                "base" : "c1"
               },
-              "component": {
-                "astNodeId": 100
+              "component" : {
+                "astNodeId" : 12
               },
-              "baseId": 1792,
-              "maxId": 1791,
-              "file": "None",
-              "queueSize": "None",
-              "stackSize": "None",
-              "priority": "None",
-              "cpu": "None",
-              "initSpecifierMap": {}
+              "baseId" : 256,
+              "maxId" : 255,
+              "file" : "None",
+              "queueSize" : "None",
+              "stackSize" : "None",
+              "priority" : "None",
+              "cpu" : "None",
+              "initSpecifierMap" : {
+                
+              }
             },
             [
               {
-                "Public": {}
+                "Public" : {
+                  
+                }
               },
               {
-                "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-                "pos": "61.5",
-                "includingLoc": "None"
+                "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+                "pos" : "43.5",
+                "includingLoc" : "None"
               }
             ]
           ],
           [
             {
-              "aNode": {
-                "astNodeId": 118
+              "aNode" : {
+                "astNodeId" : 118
               },
-              "qualifiedName": {
-                "qualifier": [],
-                "base": "c2"
+              "qualifiedName" : {
+                "qualifier" : [
+                ],
+                "base" : "c2"
               },
-              "component": {
-                "astNodeId": 32
+              "component" : {
+                "astNodeId" : 37
               },
-              "baseId": 512,
-              "maxId": 511,
-              "file": "None",
-              "queueSize": "None",
-              "stackSize": "None",
-              "priority": "None",
-              "cpu": "None",
-              "initSpecifierMap": {}
+              "baseId" : 512,
+              "maxId" : 511,
+              "file" : "None",
+              "queueSize" : "None",
+              "stackSize" : "None",
+              "priority" : "None",
+              "cpu" : "None",
+              "initSpecifierMap" : {
+                
+              }
             },
             [
               {
-                "Public": {}
+                "Public" : {
+                  
+                }
               },
               {
-                "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-                "pos": "56.5",
-                "includingLoc": "None"
+                "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+                "pos" : "44.5",
+                "includingLoc" : "None"
               }
             ]
           ],
           [
             {
-              "aNode": {
-                "astNodeId": 110
+              "aNode" : {
+                "astNodeId" : 122
               },
-              "qualifiedName": {
-                "qualifier": [],
-                "base": "c"
+              "qualifiedName" : {
+                "qualifier" : [
+                ],
+                "base" : "c3"
               },
-              "component": {
-                "astNodeId": 106
+              "component" : {
+                "astNodeId" : 50
               },
-              "baseId": 256,
-              "maxId": 255,
-              "file": "None",
-              "queueSize": "None",
-              "stackSize": "None",
-              "priority": "None",
-              "cpu": "None",
-              "initSpecifierMap": {}
-            },
-            [
-              {
-                "Public": {}
-              },
-              {
-                "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-                "pos": "54.5",
-                "includingLoc": "None"
+              "baseId" : 768,
+              "maxId" : 767,
+              "file" : "None",
+              "queueSize" : "None",
+              "stackSize" : "None",
+              "priority" : "None",
+              "cpu" : "None",
+              "initSpecifierMap" : {
+                
               }
-            ]
-          ],
-          [
-            {
-              "aNode": {
-                "astNodeId": 122
-              },
-              "qualifiedName": {
-                "qualifier": [],
-                "base": "c3"
-              },
-              "component": {
-                "astNodeId": 40
-              },
-              "baseId": 768,
-              "maxId": 767,
-              "file": "None",
-              "queueSize": "None",
-              "stackSize": "None",
-              "priority": "None",
-              "cpu": "None",
-              "initSpecifierMap": {}
             },
             [
               {
-                "Public": {}
+                "Public" : {
+                  
+                }
               },
               {
-                "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-                "pos": "57.5",
-                "includingLoc": "None"
+                "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+                "pos" : "45.5",
+                "includingLoc" : "None"
               }
             ]
           ]
         ],
-        "patternMap": {
-          "Event": {
-            "aNode": {
-              "astNodeId": 173
+        "patternMap" : {
+          "Event" : {
+            "aNode" : {
+              "astNodeId" : 266
             },
-            "ast": {
-              "kind": {
-                "Event": {}
-              },
-              "source": {
-                "astNodeId": 172
-              },
-              "targets": []
-            },
-            "source": [
-              {
-                "aNode": {
-                  "astNodeId": 122
-                },
-                "qualifiedName": {
-                  "qualifier": [],
-                  "base": "c3"
-                },
-                "component": {
-                  "astNodeId": 40
-                },
-                "baseId": 768,
-                "maxId": 767,
-                "file": "None",
-                "queueSize": "None",
-                "stackSize": "None",
-                "priority": "None",
-                "cpu": "None",
-                "initSpecifierMap": {}
-              },
-              {
-                "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-                "pos": "65.32",
-                "includingLoc": "None"
-              }
-            ],
-            "targets": []
-          },
-          "Command": {
-            "aNode": {
-              "astNodeId": 170
-            },
-            "ast": {
-              "kind": {
-                "Command": {}
-              },
-              "source": {
-                "astNodeId": 167
-              },
-              "targets": [
-                {
-                  "astNodeId": 169
+            "ast" : {
+              "kind" : {
+                "Event" : {
+                  
                 }
+              },
+              "source" : {
+                "astNodeId" : 265
+              },
+              "targets" : [
               ]
             },
-            "source": [
+            "source" : [
               {
-                "aNode": {
-                  "astNodeId": 118
+                "aNode" : {
+                  "astNodeId" : 122
                 },
-                "qualifiedName": {
-                  "qualifier": [],
-                  "base": "c2"
+                "qualifiedName" : {
+                  "qualifier" : [
+                  ],
+                  "base" : "c3"
                 },
-                "component": {
-                  "astNodeId": 32
+                "component" : {
+                  "astNodeId" : 50
                 },
-                "baseId": 512,
-                "maxId": 511,
-                "file": "None",
-                "queueSize": "None",
-                "stackSize": "None",
-                "priority": "None",
-                "cpu": "None",
-                "initSpecifierMap": {}
+                "baseId" : 768,
+                "maxId" : 767,
+                "file" : "None",
+                "queueSize" : "None",
+                "stackSize" : "None",
+                "priority" : "None",
+                "cpu" : "None",
+                "initSpecifierMap" : {
+                  
+                }
               },
               {
-                "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-                "pos": "64.34",
-                "includingLoc": "None"
+                "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+                "pos" : "53.32",
+                "includingLoc" : "None"
               }
             ],
-            "targets": [
-              [
-                {
-                  "aNode": {
-                    "astNodeId": 110
-                  },
-                  "qualifiedName": {
-                    "qualifier": [],
-                    "base": "c"
-                  },
-                  "component": {
-                    "astNodeId": 106
-                  },
-                  "baseId": 256,
-                  "maxId": 255,
-                  "file": "None",
-                  "queueSize": "None",
-                  "stackSize": "None",
-                  "priority": "None",
-                  "cpu": "None",
-                  "initSpecifierMap": {}
-                },
-                {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-                  "pos": "64.39",
-                  "includingLoc": "None"
-                }
-              ]
+            "targets" : [
             ]
           },
-          "Param": {
-            "aNode": {
-              "astNodeId": 179
+          "Command" : {
+            "aNode" : {
+              "astNodeId" : 263
             },
-            "ast": {
-              "kind": {
-                "Param": {}
+            "ast" : {
+              "kind" : {
+                "Command" : {
+                  
+                }
               },
-              "source": {
-                "astNodeId": 178
+              "source" : {
+                "astNodeId" : 262
               },
-              "targets": []
+              "targets" : [
+              ]
             },
-            "source": [
+            "source" : [
               {
-                "aNode": {
-                  "astNodeId": 130
+                "aNode" : {
+                  "astNodeId" : 118
                 },
-                "qualifiedName": {
-                  "qualifier": [],
-                  "base": "c5"
+                "qualifiedName" : {
+                  "qualifier" : [
+                  ],
+                  "base" : "c2"
                 },
-                "component": {
-                  "astNodeId": 74
+                "component" : {
+                  "astNodeId" : 37
                 },
-                "baseId": 1280,
-                "maxId": 1279,
-                "file": "None",
-                "queueSize": "None",
-                "stackSize": "None",
-                "priority": "None",
-                "cpu": "None",
-                "initSpecifierMap": {}
+                "baseId" : 512,
+                "maxId" : 511,
+                "file" : "None",
+                "queueSize" : "None",
+                "stackSize" : "None",
+                "priority" : "None",
+                "cpu" : "None",
+                "initSpecifierMap" : {
+                  
+                }
               },
               {
-                "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-                "pos": "67.32",
-                "includingLoc": "None"
+                "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+                "pos" : "52.34",
+                "includingLoc" : "None"
               }
             ],
-            "targets": []
+            "targets" : [
+            ]
           },
-          "Telemetry": {
-            "aNode": {
-              "astNodeId": 182
+          "Param" : {
+            "aNode" : {
+              "astNodeId" : 272
             },
-            "ast": {
-              "kind": {
-                "Telemetry": {}
+            "ast" : {
+              "kind" : {
+                "Param" : {
+                  
+                }
               },
-              "source": {
-                "astNodeId": 181
+              "source" : {
+                "astNodeId" : 271
               },
-              "targets": []
+              "targets" : [
+              ]
             },
-            "source": [
+            "source" : [
               {
-                "aNode": {
-                  "astNodeId": 134
+                "aNode" : {
+                  "astNodeId" : 130
                 },
-                "qualifiedName": {
-                  "qualifier": [],
-                  "base": "c6"
+                "qualifiedName" : {
+                  "qualifier" : [
+                  ],
+                  "base" : "c5"
                 },
-                "component": {
-                  "astNodeId": 87
+                "component" : {
+                  "astNodeId" : 84
                 },
-                "baseId": 1536,
-                "maxId": 1535,
-                "file": "None",
-                "queueSize": "None",
-                "stackSize": "None",
-                "priority": "None",
-                "cpu": "None",
-                "initSpecifierMap": {}
+                "baseId" : 1280,
+                "maxId" : 1279,
+                "file" : "None",
+                "queueSize" : "None",
+                "stackSize" : "None",
+                "priority" : "None",
+                "cpu" : "None",
+                "initSpecifierMap" : {
+                  
+                }
               },
               {
-                "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-                "pos": "68.36",
-                "includingLoc": "None"
+                "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+                "pos" : "55.32",
+                "includingLoc" : "None"
               }
             ],
-            "targets": []
+            "targets" : [
+            ]
           },
-          "Time": {
-            "aNode": {
-              "astNodeId": 165
+          "Telemetry" : {
+            "aNode" : {
+              "astNodeId" : 275
             },
-            "ast": {
-              "kind": {
-                "Time": {}
+            "ast" : {
+              "kind" : {
+                "Telemetry" : {
+                  
+                }
               },
-              "source": {
-                "astNodeId": 164
+              "source" : {
+                "astNodeId" : 274
               },
-              "targets": []
+              "targets" : [
+              ]
             },
-            "source": [
+            "source" : [
               {
-                "aNode": {
-                  "astNodeId": 114
+                "aNode" : {
+                  "astNodeId" : 134
                 },
-                "qualifiedName": {
-                  "qualifier": [],
-                  "base": "c1"
+                "qualifiedName" : {
+                  "qualifier" : [
+                  ],
+                  "base" : "c6"
                 },
-                "component": {
-                  "astNodeId": 7
+                "component" : {
+                  "astNodeId" : 97
                 },
-                "baseId": 256,
-                "maxId": 255,
-                "file": "None",
-                "queueSize": "None",
-                "stackSize": "None",
-                "priority": "None",
-                "cpu": "None",
-                "initSpecifierMap": {}
+                "baseId" : 1536,
+                "maxId" : 1535,
+                "file" : "None",
+                "queueSize" : "None",
+                "stackSize" : "None",
+                "priority" : "None",
+                "cpu" : "None",
+                "initSpecifierMap" : {
+                  
+                }
               },
               {
-                "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-                "pos": "63.31",
-                "includingLoc": "None"
+                "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+                "pos" : "56.36",
+                "includingLoc" : "None"
               }
             ],
-            "targets": []
+            "targets" : [
+            ]
           },
-          "TextEvent": {
-            "aNode": {
-              "astNodeId": 191
+          "Time" : {
+            "aNode" : {
+              "astNodeId" : 260
             },
-            "ast": {
-              "kind": {
-                "TextEvent": {}
+            "ast" : {
+              "kind" : {
+                "Time" : {
+                  
+                }
               },
-              "source": {
-                "astNodeId": 190
+              "source" : {
+                "astNodeId" : 259
               },
-              "targets": []
+              "targets" : [
+              ]
             },
-            "source": [
+            "source" : [
               {
-                "aNode": {
-                  "astNodeId": 138
+                "aNode" : {
+                  "astNodeId" : 114
                 },
-                "qualifiedName": {
-                  "qualifier": [],
-                  "base": "c7"
+                "qualifiedName" : {
+                  "qualifier" : [
+                  ],
+                  "base" : "c1"
                 },
-                "component": {
-                  "astNodeId": 100
+                "component" : {
+                  "astNodeId" : 12
                 },
-                "baseId": 1792,
-                "maxId": 1791,
-                "file": "None",
-                "queueSize": "None",
-                "stackSize": "None",
-                "priority": "None",
-                "cpu": "None",
-                "initSpecifierMap": {}
+                "baseId" : 256,
+                "maxId" : 255,
+                "file" : "None",
+                "queueSize" : "None",
+                "stackSize" : "None",
+                "priority" : "None",
+                "cpu" : "None",
+                "initSpecifierMap" : {
+                  
+                }
               },
               {
-                "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-                "pos": "69.37",
-                "includingLoc": "None"
+                "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+                "pos" : "51.31",
+                "includingLoc" : "None"
               }
             ],
-            "targets": []
+            "targets" : [
+            ]
           },
-          "Health": {
-            "aNode": {
-              "astNodeId": 176
+          "TextEvent" : {
+            "aNode" : {
+              "astNodeId" : 284
             },
-            "ast": {
-              "kind": {
-                "Health": {}
+            "ast" : {
+              "kind" : {
+                "TextEvent" : {
+                  
+                }
               },
-              "source": {
-                "astNodeId": 175
+              "source" : {
+                "astNodeId" : 283
               },
-              "targets": []
+              "targets" : [
+              ]
             },
-            "source": [
+            "source" : [
               {
-                "aNode": {
-                  "astNodeId": 126
+                "aNode" : {
+                  "astNodeId" : 138
                 },
-                "qualifiedName": {
-                  "qualifier": [],
-                  "base": "c4"
+                "qualifiedName" : {
+                  "qualifier" : [
+                  ],
+                  "base" : "c7"
                 },
-                "component": {
-                  "astNodeId": 57
+                "component" : {
+                  "astNodeId" : 110
                 },
-                "baseId": 1024,
-                "maxId": 1023,
-                "file": "None",
-                "queueSize": "None",
-                "stackSize": "None",
-                "priority": "None",
-                "cpu": "None",
-                "initSpecifierMap": {}
+                "baseId" : 1792,
+                "maxId" : 1791,
+                "file" : "None",
+                "queueSize" : "None",
+                "stackSize" : "None",
+                "priority" : "None",
+                "cpu" : "None",
+                "initSpecifierMap" : {
+                  
+                }
               },
               {
-                "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-                "pos": "66.33",
-                "includingLoc": "None"
+                "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+                "pos" : "57.37",
+                "includingLoc" : "None"
               }
             ],
-            "targets": []
+            "targets" : [
+            ]
+          },
+          "Health" : {
+            "aNode" : {
+              "astNodeId" : 269
+            },
+            "ast" : {
+              "kind" : {
+                "Health" : {
+                  
+                }
+              },
+              "source" : {
+                "astNodeId" : 268
+              },
+              "targets" : [
+              ]
+            },
+            "source" : [
+              {
+                "aNode" : {
+                  "astNodeId" : 126
+                },
+                "qualifiedName" : {
+                  "qualifier" : [
+                  ],
+                  "base" : "c4"
+                },
+                "component" : {
+                  "astNodeId" : 67
+                },
+                "baseId" : 1024,
+                "maxId" : 1023,
+                "file" : "None",
+                "queueSize" : "None",
+                "stackSize" : "None",
+                "priority" : "None",
+                "cpu" : "None",
+                "initSpecifierMap" : {
+                  
+                }
+              },
+              {
+                "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+                "pos" : "54.33",
+                "includingLoc" : "None"
+              }
+            ],
+            "targets" : [
+            ]
           }
         },
-        "connectionMap": {
-          "CommandRegistration": [
-            {
-              "from": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-                  "pos": "64.5",
-                  "includingLoc": "None"
-                },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 110
-                    },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c"
-                    },
-                    "component": {
-                      "astNodeId": 106
-                    },
-                    "baseId": 256,
-                    "maxId": 255,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
-                  },
-                  "portInstance": {
-                    "Special": {
-                      "aNode": {
-                        "astNodeId": 101
-                      },
-                      "specifier": {
-                        "inputKind": "None",
-                        "kind": {
-                          "CommandReg": {}
-                        },
-                        "name": "cmdRegOut",
-                        "priority": "None",
-                        "queueFull": "None"
-                      },
-                      "symbol": {
-                        "Port": {
-                          "nodeId": 194,
-                          "unqualifiedName": "CmdReg"
-                        }
-                      },
-                      "priority": "None",
-                      "queueFull": "None",
-                      "importNodeIds": []
-                    }
-                  }
-                },
-                "portNumber": "None"
-              },
-              "to": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-                  "pos": "64.5",
-                  "includingLoc": "None"
-                },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 118
-                    },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c2"
-                    },
-                    "component": {
-                      "astNodeId": 32
-                    },
-                    "baseId": 512,
-                    "maxId": 511,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
-                  },
-                  "portInstance": {
-                    "General": {
-                      "aNode": {
-                        "astNodeId": 15
-                      },
-                      "specifier": {
-                        "kind": {
-                          "SyncInput": {}
-                        },
-                        "name": "cmdRegOut",
-                        "size": "None",
-                        "port": {
-                          "Some": {
-                            "astNodeId": 14
-                          }
-                        },
-                        "priority": "None",
-                        "queueFull": "None"
-                      },
-                      "kind": "SyncInput",
-                      "size": 1,
-                      "ty": {
-                        "DefPort": {
-                          "symbol": {
-                            "Port": {
-                              "nodeId": 194,
-                              "unqualifiedName": "CmdReg"
-                            }
-                          }
-                        }
-                      },
-                      "importNodeIds": []
-                    }
-                  }
-                },
-                "portNumber": "None"
-              },
-              "isUnmatched": false
-            }
-          ],
-          "Command": [
-            {
-              "from": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-                  "pos": "64.5",
-                  "includingLoc": "None"
-                },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 118
-                    },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c2"
-                    },
-                    "component": {
-                      "astNodeId": 32
-                    },
-                    "baseId": 512,
-                    "maxId": 511,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
-                  },
-                  "portInstance": {
-                    "General": {
-                      "aNode": {
-                        "astNodeId": 31
-                      },
-                      "specifier": {
-                        "kind": {
-                          "Output": {}
-                        },
-                        "name": "cmdSend",
-                        "size": "None",
-                        "port": {
-                          "Some": {
-                            "astNodeId": 30
-                          }
-                        },
-                        "priority": "None",
-                        "queueFull": "None"
-                      },
-                      "kind": "Output",
-                      "size": 1,
-                      "ty": {
-                        "DefPort": {
-                          "symbol": {
-                            "Port": {
-                              "nodeId": 193,
-                              "unqualifiedName": "Cmd"
-                            }
-                          }
-                        }
-                      },
-                      "importNodeIds": []
-                    }
-                  }
-                },
-                "portNumber": "None"
-              },
-              "to": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-                  "pos": "64.5",
-                  "includingLoc": "None"
-                },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 110
-                    },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c"
-                    },
-                    "component": {
-                      "astNodeId": 106
-                    },
-                    "baseId": 256,
-                    "maxId": 255,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
-                  },
-                  "portInstance": {
-                    "Special": {
-                      "aNode": {
-                        "astNodeId": 102
-                      },
-                      "specifier": {
-                        "inputKind": "None",
-                        "kind": {
-                          "CommandRecv": {}
-                        },
-                        "name": "cmdIn",
-                        "priority": "None",
-                        "queueFull": "None"
-                      },
-                      "symbol": {
-                        "Port": {
-                          "nodeId": 193,
-                          "unqualifiedName": "Cmd"
-                        }
-                      },
-                      "priority": "None",
-                      "queueFull": "None",
-                      "importNodeIds": []
-                    }
-                  }
-                },
-                "portNumber": "None"
-              },
-              "isUnmatched": false
-            }
-          ],
-          "CommandResponse": [
-            {
-              "from": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-                  "pos": "64.5",
-                  "includingLoc": "None"
-                },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 110
-                    },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c"
-                    },
-                    "component": {
-                      "astNodeId": 106
-                    },
-                    "baseId": 256,
-                    "maxId": 255,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
-                  },
-                  "portInstance": {
-                    "Special": {
-                      "aNode": {
-                        "astNodeId": 105
-                      },
-                      "specifier": {
-                        "inputKind": "None",
-                        "kind": {
-                          "CommandResp": {}
-                        },
-                        "name": "cmdResponseOut",
-                        "priority": "None",
-                        "queueFull": "None"
-                      },
-                      "symbol": {
-                        "Port": {
-                          "nodeId": 195,
-                          "unqualifiedName": "CmdResponse"
-                        }
-                      },
-                      "priority": "None",
-                      "queueFull": "None",
-                      "importNodeIds": []
-                    }
-                  }
-                },
-                "portNumber": "None"
-              },
-              "to": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-                  "pos": "64.5",
-                  "includingLoc": "None"
-                },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 118
-                    },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c2"
-                    },
-                    "component": {
-                      "astNodeId": 32
-                    },
-                    "baseId": 512,
-                    "maxId": 511,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
-                  },
-                  "portInstance": {
-                    "General": {
-                      "aNode": {
-                        "astNodeId": 19
-                      },
-                      "specifier": {
-                        "kind": {
-                          "SyncInput": {}
-                        },
-                        "name": "cmdResponseOut",
-                        "size": "None",
-                        "port": {
-                          "Some": {
-                            "astNodeId": 18
-                          }
-                        },
-                        "priority": "None",
-                        "queueFull": "None"
-                      },
-                      "kind": "SyncInput",
-                      "size": 1,
-                      "ty": {
-                        "DefPort": {
-                          "symbol": {
-                            "Port": {
-                              "nodeId": 195,
-                              "unqualifiedName": "CmdResponse"
-                            }
-                          }
-                        }
-                      },
-                      "importNodeIds": []
-                    }
-                  }
-                },
-                "portNumber": "None"
-              },
-              "isUnmatched": false
-            }
-          ],
-          "Time": [
-            {
-              "from": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-                  "pos": "63.5",
-                  "includingLoc": "None"
-                },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 114
-                    },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c1"
-                    },
-                    "component": {
-                      "astNodeId": 7
-                    },
-                    "baseId": 256,
-                    "maxId": 255,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
-                  },
-                  "portInstance": {
-                    "Special": {
-                      "aNode": {
-                        "astNodeId": 6
-                      },
-                      "specifier": {
-                        "inputKind": "None",
-                        "kind": {
-                          "TimeGet": {}
-                        },
-                        "name": "timeGetOut",
-                        "priority": "None",
-                        "queueFull": "None"
-                      },
-                      "symbol": {
-                        "Port": {
-                          "nodeId": 200,
-                          "unqualifiedName": "Time"
-                        }
-                      },
-                      "priority": "None",
-                      "queueFull": "None",
-                      "importNodeIds": []
-                    }
-                  }
-                },
-                "portNumber": "None"
-              },
-              "to": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-                  "pos": "63.5",
-                  "includingLoc": "None"
-                },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 114
-                    },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c1"
-                    },
-                    "component": {
-                      "astNodeId": 7
-                    },
-                    "baseId": 256,
-                    "maxId": 255,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
-                  },
-                  "portInstance": {
-                    "General": {
-                      "aNode": {
-                        "astNodeId": 3
-                      },
-                      "specifier": {
-                        "kind": {
-                          "SyncInput": {}
-                        },
-                        "name": "timeGetPort",
-                        "size": "None",
-                        "port": {
-                          "Some": {
-                            "astNodeId": 2
-                          }
-                        },
-                        "priority": "None",
-                        "queueFull": "None"
-                      },
-                      "kind": "SyncInput",
-                      "size": 1,
-                      "ty": {
-                        "DefPort": {
-                          "symbol": {
-                            "Port": {
-                              "nodeId": 200,
-                              "unqualifiedName": "Time"
-                            }
-                          }
-                        }
-                      },
-                      "importNodeIds": []
-                    }
-                  }
-                },
-                "portNumber": "None"
-              },
-              "isUnmatched": false
-            },
-            {
-              "from": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-                  "pos": "63.5",
-                  "includingLoc": "None"
-                },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 122
-                    },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c3"
-                    },
-                    "component": {
-                      "astNodeId": 40
-                    },
-                    "baseId": 768,
-                    "maxId": 767,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
-                  },
-                  "portInstance": {
-                    "Special": {
-                      "aNode": {
-                        "astNodeId": 39
-                      },
-                      "specifier": {
-                        "inputKind": "None",
-                        "kind": {
-                          "TimeGet": {}
-                        },
-                        "name": "timeGetOut",
-                        "priority": "None",
-                        "queueFull": "None"
-                      },
-                      "symbol": {
-                        "Port": {
-                          "nodeId": 200,
-                          "unqualifiedName": "Time"
-                        }
-                      },
-                      "priority": "None",
-                      "queueFull": "None",
-                      "importNodeIds": []
-                    }
-                  }
-                },
-                "portNumber": "None"
-              },
-              "to": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-                  "pos": "63.5",
-                  "includingLoc": "None"
-                },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 114
-                    },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c1"
-                    },
-                    "component": {
-                      "astNodeId": 7
-                    },
-                    "baseId": 256,
-                    "maxId": 255,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
-                  },
-                  "portInstance": {
-                    "General": {
-                      "aNode": {
-                        "astNodeId": 3
-                      },
-                      "specifier": {
-                        "kind": {
-                          "SyncInput": {}
-                        },
-                        "name": "timeGetPort",
-                        "size": "None",
-                        "port": {
-                          "Some": {
-                            "astNodeId": 2
-                          }
-                        },
-                        "priority": "None",
-                        "queueFull": "None"
-                      },
-                      "kind": "SyncInput",
-                      "size": 1,
-                      "ty": {
-                        "DefPort": {
-                          "symbol": {
-                            "Port": {
-                              "nodeId": 200,
-                              "unqualifiedName": "Time"
-                            }
-                          }
-                        }
-                      },
-                      "importNodeIds": []
-                    }
-                  }
-                },
-                "portNumber": "None"
-              },
-              "isUnmatched": false
-            }
-          ]
+        "connectionMap" : {
+          
         },
-        "localConnectionMap": {
-          "CommandRegistration": [
-            {
-              "from": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-                  "pos": "64.5",
-                  "includingLoc": "None"
-                },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 110
-                    },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c"
-                    },
-                    "component": {
-                      "astNodeId": 106
-                    },
-                    "baseId": 256,
-                    "maxId": 255,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
-                  },
-                  "portInstance": {
-                    "Special": {
-                      "aNode": {
-                        "astNodeId": 101
-                      },
-                      "specifier": {
-                        "inputKind": "None",
-                        "kind": {
-                          "CommandReg": {}
-                        },
-                        "name": "cmdRegOut",
-                        "priority": "None",
-                        "queueFull": "None"
-                      },
-                      "symbol": {
-                        "Port": {
-                          "nodeId": 194,
-                          "unqualifiedName": "CmdReg"
-                        }
-                      },
-                      "priority": "None",
-                      "queueFull": "None",
-                      "importNodeIds": []
-                    }
-                  }
-                },
-                "portNumber": "None"
-              },
-              "to": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-                  "pos": "64.5",
-                  "includingLoc": "None"
-                },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 118
-                    },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c2"
-                    },
-                    "component": {
-                      "astNodeId": 32
-                    },
-                    "baseId": 512,
-                    "maxId": 511,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
-                  },
-                  "portInstance": {
-                    "General": {
-                      "aNode": {
-                        "astNodeId": 15
-                      },
-                      "specifier": {
-                        "kind": {
-                          "SyncInput": {}
-                        },
-                        "name": "cmdRegOut",
-                        "size": "None",
-                        "port": {
-                          "Some": {
-                            "astNodeId": 14
-                          }
-                        },
-                        "priority": "None",
-                        "queueFull": "None"
-                      },
-                      "kind": "SyncInput",
-                      "size": 1,
-                      "ty": {
-                        "DefPort": {
-                          "symbol": {
-                            "Port": {
-                              "nodeId": 194,
-                              "unqualifiedName": "CmdReg"
-                            }
-                          }
-                        }
-                      },
-                      "importNodeIds": []
-                    }
-                  }
-                },
-                "portNumber": "None"
-              },
-              "isUnmatched": false
-            }
-          ],
-          "Command": [
-            {
-              "from": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-                  "pos": "64.5",
-                  "includingLoc": "None"
-                },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 118
-                    },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c2"
-                    },
-                    "component": {
-                      "astNodeId": 32
-                    },
-                    "baseId": 512,
-                    "maxId": 511,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
-                  },
-                  "portInstance": {
-                    "General": {
-                      "aNode": {
-                        "astNodeId": 31
-                      },
-                      "specifier": {
-                        "kind": {
-                          "Output": {}
-                        },
-                        "name": "cmdSend",
-                        "size": "None",
-                        "port": {
-                          "Some": {
-                            "astNodeId": 30
-                          }
-                        },
-                        "priority": "None",
-                        "queueFull": "None"
-                      },
-                      "kind": "Output",
-                      "size": 1,
-                      "ty": {
-                        "DefPort": {
-                          "symbol": {
-                            "Port": {
-                              "nodeId": 193,
-                              "unqualifiedName": "Cmd"
-                            }
-                          }
-                        }
-                      },
-                      "importNodeIds": []
-                    }
-                  }
-                },
-                "portNumber": "None"
-              },
-              "to": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-                  "pos": "64.5",
-                  "includingLoc": "None"
-                },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 110
-                    },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c"
-                    },
-                    "component": {
-                      "astNodeId": 106
-                    },
-                    "baseId": 256,
-                    "maxId": 255,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
-                  },
-                  "portInstance": {
-                    "Special": {
-                      "aNode": {
-                        "astNodeId": 102
-                      },
-                      "specifier": {
-                        "inputKind": "None",
-                        "kind": {
-                          "CommandRecv": {}
-                        },
-                        "name": "cmdIn",
-                        "priority": "None",
-                        "queueFull": "None"
-                      },
-                      "symbol": {
-                        "Port": {
-                          "nodeId": 193,
-                          "unqualifiedName": "Cmd"
-                        }
-                      },
-                      "priority": "None",
-                      "queueFull": "None",
-                      "importNodeIds": []
-                    }
-                  }
-                },
-                "portNumber": "None"
-              },
-              "isUnmatched": false
-            }
-          ],
-          "CommandResponse": [
-            {
-              "from": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-                  "pos": "64.5",
-                  "includingLoc": "None"
-                },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 110
-                    },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c"
-                    },
-                    "component": {
-                      "astNodeId": 106
-                    },
-                    "baseId": 256,
-                    "maxId": 255,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
-                  },
-                  "portInstance": {
-                    "Special": {
-                      "aNode": {
-                        "astNodeId": 105
-                      },
-                      "specifier": {
-                        "inputKind": "None",
-                        "kind": {
-                          "CommandResp": {}
-                        },
-                        "name": "cmdResponseOut",
-                        "priority": "None",
-                        "queueFull": "None"
-                      },
-                      "symbol": {
-                        "Port": {
-                          "nodeId": 195,
-                          "unqualifiedName": "CmdResponse"
-                        }
-                      },
-                      "priority": "None",
-                      "queueFull": "None",
-                      "importNodeIds": []
-                    }
-                  }
-                },
-                "portNumber": "None"
-              },
-              "to": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-                  "pos": "64.5",
-                  "includingLoc": "None"
-                },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 118
-                    },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c2"
-                    },
-                    "component": {
-                      "astNodeId": 32
-                    },
-                    "baseId": 512,
-                    "maxId": 511,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
-                  },
-                  "portInstance": {
-                    "General": {
-                      "aNode": {
-                        "astNodeId": 19
-                      },
-                      "specifier": {
-                        "kind": {
-                          "SyncInput": {}
-                        },
-                        "name": "cmdResponseOut",
-                        "size": "None",
-                        "port": {
-                          "Some": {
-                            "astNodeId": 18
-                          }
-                        },
-                        "priority": "None",
-                        "queueFull": "None"
-                      },
-                      "kind": "SyncInput",
-                      "size": 1,
-                      "ty": {
-                        "DefPort": {
-                          "symbol": {
-                            "Port": {
-                              "nodeId": 195,
-                              "unqualifiedName": "CmdResponse"
-                            }
-                          }
-                        }
-                      },
-                      "importNodeIds": []
-                    }
-                  }
-                },
-                "portNumber": "None"
-              },
-              "isUnmatched": false
-            }
-          ],
-          "Time": [
-            {
-              "from": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-                  "pos": "63.5",
-                  "includingLoc": "None"
-                },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 114
-                    },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c1"
-                    },
-                    "component": {
-                      "astNodeId": 7
-                    },
-                    "baseId": 256,
-                    "maxId": 255,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
-                  },
-                  "portInstance": {
-                    "Special": {
-                      "aNode": {
-                        "astNodeId": 6
-                      },
-                      "specifier": {
-                        "inputKind": "None",
-                        "kind": {
-                          "TimeGet": {}
-                        },
-                        "name": "timeGetOut",
-                        "priority": "None",
-                        "queueFull": "None"
-                      },
-                      "symbol": {
-                        "Port": {
-                          "nodeId": 200,
-                          "unqualifiedName": "Time"
-                        }
-                      },
-                      "priority": "None",
-                      "queueFull": "None",
-                      "importNodeIds": []
-                    }
-                  }
-                },
-                "portNumber": "None"
-              },
-              "to": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-                  "pos": "63.5",
-                  "includingLoc": "None"
-                },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 114
-                    },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c1"
-                    },
-                    "component": {
-                      "astNodeId": 7
-                    },
-                    "baseId": 256,
-                    "maxId": 255,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
-                  },
-                  "portInstance": {
-                    "General": {
-                      "aNode": {
-                        "astNodeId": 3
-                      },
-                      "specifier": {
-                        "kind": {
-                          "SyncInput": {}
-                        },
-                        "name": "timeGetPort",
-                        "size": "None",
-                        "port": {
-                          "Some": {
-                            "astNodeId": 2
-                          }
-                        },
-                        "priority": "None",
-                        "queueFull": "None"
-                      },
-                      "kind": "SyncInput",
-                      "size": 1,
-                      "ty": {
-                        "DefPort": {
-                          "symbol": {
-                            "Port": {
-                              "nodeId": 200,
-                              "unqualifiedName": "Time"
-                            }
-                          }
-                        }
-                      },
-                      "importNodeIds": []
-                    }
-                  }
-                },
-                "portNumber": "None"
-              },
-              "isUnmatched": false
-            },
-            {
-              "from": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-                  "pos": "63.5",
-                  "includingLoc": "None"
-                },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 122
-                    },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c3"
-                    },
-                    "component": {
-                      "astNodeId": 40
-                    },
-                    "baseId": 768,
-                    "maxId": 767,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
-                  },
-                  "portInstance": {
-                    "Special": {
-                      "aNode": {
-                        "astNodeId": 39
-                      },
-                      "specifier": {
-                        "inputKind": "None",
-                        "kind": {
-                          "TimeGet": {}
-                        },
-                        "name": "timeGetOut",
-                        "priority": "None",
-                        "queueFull": "None"
-                      },
-                      "symbol": {
-                        "Port": {
-                          "nodeId": 200,
-                          "unqualifiedName": "Time"
-                        }
-                      },
-                      "priority": "None",
-                      "queueFull": "None",
-                      "importNodeIds": []
-                    }
-                  }
-                },
-                "portNumber": "None"
-              },
-              "to": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-                  "pos": "63.5",
-                  "includingLoc": "None"
-                },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 114
-                    },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c1"
-                    },
-                    "component": {
-                      "astNodeId": 7
-                    },
-                    "baseId": 256,
-                    "maxId": 255,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
-                  },
-                  "portInstance": {
-                    "General": {
-                      "aNode": {
-                        "astNodeId": 3
-                      },
-                      "specifier": {
-                        "kind": {
-                          "SyncInput": {}
-                        },
-                        "name": "timeGetPort",
-                        "size": "None",
-                        "port": {
-                          "Some": {
-                            "astNodeId": 2
-                          }
-                        },
-                        "priority": "None",
-                        "queueFull": "None"
-                      },
-                      "kind": "SyncInput",
-                      "size": 1,
-                      "ty": {
-                        "DefPort": {
-                          "symbol": {
-                            "Port": {
-                              "nodeId": 200,
-                              "unqualifiedName": "Time"
-                            }
-                          }
-                        }
-                      },
-                      "importNodeIds": []
-                    }
-                  }
-                },
-                "portNumber": "None"
-              },
-              "isUnmatched": false
-            }
-          ]
+        "localConnectionMap" : {
+          
         },
-        "outputConnectionMap": [
-          [
-            {
-              "componentInstance": {
-                "aNode": {
-                  "astNodeId": 122
-                },
-                "qualifiedName": {
-                  "qualifier": [],
-                  "base": "c3"
-                },
-                "component": {
-                  "astNodeId": 40
-                },
-                "baseId": 768,
-                "maxId": 767,
-                "file": "None",
-                "queueSize": "None",
-                "stackSize": "None",
-                "priority": "None",
-                "cpu": "None",
-                "initSpecifierMap": {}
-              },
-              "portInstance": {
-                "Special": {
-                  "aNode": {
-                    "astNodeId": 39
-                  },
-                  "specifier": {
-                    "inputKind": "None",
-                    "kind": {
-                      "TimeGet": {}
-                    },
-                    "name": "timeGetOut",
-                    "priority": "None",
-                    "queueFull": "None"
-                  },
-                  "symbol": {
-                    "Port": {
-                      "nodeId": 200,
-                      "unqualifiedName": "Time"
-                    }
-                  },
-                  "priority": "None",
-                  "queueFull": "None",
-                  "importNodeIds": []
-                }
-              }
-            },
-            [
-              {
-                "from": {
-                  "loc": {
-                    "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-                    "pos": "63.5",
-                    "includingLoc": "None"
-                  },
-                  "port": {
-                    "componentInstance": {
-                      "aNode": {
-                        "astNodeId": 122
-                      },
-                      "qualifiedName": {
-                        "qualifier": [],
-                        "base": "c3"
-                      },
-                      "component": {
-                        "astNodeId": 40
-                      },
-                      "baseId": 768,
-                      "maxId": 767,
-                      "file": "None",
-                      "queueSize": "None",
-                      "stackSize": "None",
-                      "priority": "None",
-                      "cpu": "None",
-                      "initSpecifierMap": {}
-                    },
-                    "portInstance": {
-                      "Special": {
-                        "aNode": {
-                          "astNodeId": 39
-                        },
-                        "specifier": {
-                          "inputKind": "None",
-                          "kind": {
-                            "TimeGet": {}
-                          },
-                          "name": "timeGetOut",
-                          "priority": "None",
-                          "queueFull": "None"
-                        },
-                        "symbol": {
-                          "Port": {
-                            "nodeId": 200,
-                            "unqualifiedName": "Time"
-                          }
-                        },
-                        "priority": "None",
-                        "queueFull": "None",
-                        "importNodeIds": []
-                      }
-                    }
-                  },
-                  "portNumber": "None"
-                },
-                "to": {
-                  "loc": {
-                    "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-                    "pos": "63.5",
-                    "includingLoc": "None"
-                  },
-                  "port": {
-                    "componentInstance": {
-                      "aNode": {
-                        "astNodeId": 114
-                      },
-                      "qualifiedName": {
-                        "qualifier": [],
-                        "base": "c1"
-                      },
-                      "component": {
-                        "astNodeId": 7
-                      },
-                      "baseId": 256,
-                      "maxId": 255,
-                      "file": "None",
-                      "queueSize": "None",
-                      "stackSize": "None",
-                      "priority": "None",
-                      "cpu": "None",
-                      "initSpecifierMap": {}
-                    },
-                    "portInstance": {
-                      "General": {
-                        "aNode": {
-                          "astNodeId": 3
-                        },
-                        "specifier": {
-                          "kind": {
-                            "SyncInput": {}
-                          },
-                          "name": "timeGetPort",
-                          "size": "None",
-                          "port": {
-                            "Some": {
-                              "astNodeId": 2
-                            }
-                          },
-                          "priority": "None",
-                          "queueFull": "None"
-                        },
-                        "kind": "SyncInput",
-                        "size": 1,
-                        "ty": {
-                          "DefPort": {
-                            "symbol": {
-                              "Port": {
-                                "nodeId": 200,
-                                "unqualifiedName": "Time"
-                              }
-                            }
-                          }
-                        },
-                        "importNodeIds": []
-                      }
-                    }
-                  },
-                  "portNumber": "None"
-                },
-                "isUnmatched": false
-              }
-            ]
-          ],
-          [
-            {
-              "componentInstance": {
-                "aNode": {
-                  "astNodeId": 118
-                },
-                "qualifiedName": {
-                  "qualifier": [],
-                  "base": "c2"
-                },
-                "component": {
-                  "astNodeId": 32
-                },
-                "baseId": 512,
-                "maxId": 511,
-                "file": "None",
-                "queueSize": "None",
-                "stackSize": "None",
-                "priority": "None",
-                "cpu": "None",
-                "initSpecifierMap": {}
-              },
-              "portInstance": {
-                "General": {
-                  "aNode": {
-                    "astNodeId": 31
-                  },
-                  "specifier": {
-                    "kind": {
-                      "Output": {}
-                    },
-                    "name": "cmdSend",
-                    "size": "None",
-                    "port": {
-                      "Some": {
-                        "astNodeId": 30
-                      }
-                    },
-                    "priority": "None",
-                    "queueFull": "None"
-                  },
-                  "kind": "Output",
-                  "size": 1,
-                  "ty": {
-                    "DefPort": {
-                      "symbol": {
-                        "Port": {
-                          "nodeId": 193,
-                          "unqualifiedName": "Cmd"
-                        }
-                      }
-                    }
-                  },
-                  "importNodeIds": []
-                }
-              }
-            },
-            [
-              {
-                "from": {
-                  "loc": {
-                    "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-                    "pos": "64.5",
-                    "includingLoc": "None"
-                  },
-                  "port": {
-                    "componentInstance": {
-                      "aNode": {
-                        "astNodeId": 118
-                      },
-                      "qualifiedName": {
-                        "qualifier": [],
-                        "base": "c2"
-                      },
-                      "component": {
-                        "astNodeId": 32
-                      },
-                      "baseId": 512,
-                      "maxId": 511,
-                      "file": "None",
-                      "queueSize": "None",
-                      "stackSize": "None",
-                      "priority": "None",
-                      "cpu": "None",
-                      "initSpecifierMap": {}
-                    },
-                    "portInstance": {
-                      "General": {
-                        "aNode": {
-                          "astNodeId": 31
-                        },
-                        "specifier": {
-                          "kind": {
-                            "Output": {}
-                          },
-                          "name": "cmdSend",
-                          "size": "None",
-                          "port": {
-                            "Some": {
-                              "astNodeId": 30
-                            }
-                          },
-                          "priority": "None",
-                          "queueFull": "None"
-                        },
-                        "kind": "Output",
-                        "size": 1,
-                        "ty": {
-                          "DefPort": {
-                            "symbol": {
-                              "Port": {
-                                "nodeId": 193,
-                                "unqualifiedName": "Cmd"
-                              }
-                            }
-                          }
-                        },
-                        "importNodeIds": []
-                      }
-                    }
-                  },
-                  "portNumber": "None"
-                },
-                "to": {
-                  "loc": {
-                    "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-                    "pos": "64.5",
-                    "includingLoc": "None"
-                  },
-                  "port": {
-                    "componentInstance": {
-                      "aNode": {
-                        "astNodeId": 110
-                      },
-                      "qualifiedName": {
-                        "qualifier": [],
-                        "base": "c"
-                      },
-                      "component": {
-                        "astNodeId": 106
-                      },
-                      "baseId": 256,
-                      "maxId": 255,
-                      "file": "None",
-                      "queueSize": "None",
-                      "stackSize": "None",
-                      "priority": "None",
-                      "cpu": "None",
-                      "initSpecifierMap": {}
-                    },
-                    "portInstance": {
-                      "Special": {
-                        "aNode": {
-                          "astNodeId": 102
-                        },
-                        "specifier": {
-                          "inputKind": "None",
-                          "kind": {
-                            "CommandRecv": {}
-                          },
-                          "name": "cmdIn",
-                          "priority": "None",
-                          "queueFull": "None"
-                        },
-                        "symbol": {
-                          "Port": {
-                            "nodeId": 193,
-                            "unqualifiedName": "Cmd"
-                          }
-                        },
-                        "priority": "None",
-                        "queueFull": "None",
-                        "importNodeIds": []
-                      }
-                    }
-                  },
-                  "portNumber": "None"
-                },
-                "isUnmatched": false
-              }
-            ]
-          ],
-          [
-            {
-              "componentInstance": {
-                "aNode": {
-                  "astNodeId": 114
-                },
-                "qualifiedName": {
-                  "qualifier": [],
-                  "base": "c1"
-                },
-                "component": {
-                  "astNodeId": 7
-                },
-                "baseId": 256,
-                "maxId": 255,
-                "file": "None",
-                "queueSize": "None",
-                "stackSize": "None",
-                "priority": "None",
-                "cpu": "None",
-                "initSpecifierMap": {}
-              },
-              "portInstance": {
-                "Special": {
-                  "aNode": {
-                    "astNodeId": 6
-                  },
-                  "specifier": {
-                    "inputKind": "None",
-                    "kind": {
-                      "TimeGet": {}
-                    },
-                    "name": "timeGetOut",
-                    "priority": "None",
-                    "queueFull": "None"
-                  },
-                  "symbol": {
-                    "Port": {
-                      "nodeId": 200,
-                      "unqualifiedName": "Time"
-                    }
-                  },
-                  "priority": "None",
-                  "queueFull": "None",
-                  "importNodeIds": []
-                }
-              }
-            },
-            [
-              {
-                "from": {
-                  "loc": {
-                    "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-                    "pos": "63.5",
-                    "includingLoc": "None"
-                  },
-                  "port": {
-                    "componentInstance": {
-                      "aNode": {
-                        "astNodeId": 114
-                      },
-                      "qualifiedName": {
-                        "qualifier": [],
-                        "base": "c1"
-                      },
-                      "component": {
-                        "astNodeId": 7
-                      },
-                      "baseId": 256,
-                      "maxId": 255,
-                      "file": "None",
-                      "queueSize": "None",
-                      "stackSize": "None",
-                      "priority": "None",
-                      "cpu": "None",
-                      "initSpecifierMap": {}
-                    },
-                    "portInstance": {
-                      "Special": {
-                        "aNode": {
-                          "astNodeId": 6
-                        },
-                        "specifier": {
-                          "inputKind": "None",
-                          "kind": {
-                            "TimeGet": {}
-                          },
-                          "name": "timeGetOut",
-                          "priority": "None",
-                          "queueFull": "None"
-                        },
-                        "symbol": {
-                          "Port": {
-                            "nodeId": 200,
-                            "unqualifiedName": "Time"
-                          }
-                        },
-                        "priority": "None",
-                        "queueFull": "None",
-                        "importNodeIds": []
-                      }
-                    }
-                  },
-                  "portNumber": "None"
-                },
-                "to": {
-                  "loc": {
-                    "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-                    "pos": "63.5",
-                    "includingLoc": "None"
-                  },
-                  "port": {
-                    "componentInstance": {
-                      "aNode": {
-                        "astNodeId": 114
-                      },
-                      "qualifiedName": {
-                        "qualifier": [],
-                        "base": "c1"
-                      },
-                      "component": {
-                        "astNodeId": 7
-                      },
-                      "baseId": 256,
-                      "maxId": 255,
-                      "file": "None",
-                      "queueSize": "None",
-                      "stackSize": "None",
-                      "priority": "None",
-                      "cpu": "None",
-                      "initSpecifierMap": {}
-                    },
-                    "portInstance": {
-                      "General": {
-                        "aNode": {
-                          "astNodeId": 3
-                        },
-                        "specifier": {
-                          "kind": {
-                            "SyncInput": {}
-                          },
-                          "name": "timeGetPort",
-                          "size": "None",
-                          "port": {
-                            "Some": {
-                              "astNodeId": 2
-                            }
-                          },
-                          "priority": "None",
-                          "queueFull": "None"
-                        },
-                        "kind": "SyncInput",
-                        "size": 1,
-                        "ty": {
-                          "DefPort": {
-                            "symbol": {
-                              "Port": {
-                                "nodeId": 200,
-                                "unqualifiedName": "Time"
-                              }
-                            }
-                          }
-                        },
-                        "importNodeIds": []
-                      }
-                    }
-                  },
-                  "portNumber": "None"
-                },
-                "isUnmatched": false
-              }
-            ]
-          ],
-          [
-            {
-              "componentInstance": {
-                "aNode": {
-                  "astNodeId": 110
-                },
-                "qualifiedName": {
-                  "qualifier": [],
-                  "base": "c"
-                },
-                "component": {
-                  "astNodeId": 106
-                },
-                "baseId": 256,
-                "maxId": 255,
-                "file": "None",
-                "queueSize": "None",
-                "stackSize": "None",
-                "priority": "None",
-                "cpu": "None",
-                "initSpecifierMap": {}
-              },
-              "portInstance": {
-                "Special": {
-                  "aNode": {
-                    "astNodeId": 101
-                  },
-                  "specifier": {
-                    "inputKind": "None",
-                    "kind": {
-                      "CommandReg": {}
-                    },
-                    "name": "cmdRegOut",
-                    "priority": "None",
-                    "queueFull": "None"
-                  },
-                  "symbol": {
-                    "Port": {
-                      "nodeId": 194,
-                      "unqualifiedName": "CmdReg"
-                    }
-                  },
-                  "priority": "None",
-                  "queueFull": "None",
-                  "importNodeIds": []
-                }
-              }
-            },
-            [
-              {
-                "from": {
-                  "loc": {
-                    "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-                    "pos": "64.5",
-                    "includingLoc": "None"
-                  },
-                  "port": {
-                    "componentInstance": {
-                      "aNode": {
-                        "astNodeId": 110
-                      },
-                      "qualifiedName": {
-                        "qualifier": [],
-                        "base": "c"
-                      },
-                      "component": {
-                        "astNodeId": 106
-                      },
-                      "baseId": 256,
-                      "maxId": 255,
-                      "file": "None",
-                      "queueSize": "None",
-                      "stackSize": "None",
-                      "priority": "None",
-                      "cpu": "None",
-                      "initSpecifierMap": {}
-                    },
-                    "portInstance": {
-                      "Special": {
-                        "aNode": {
-                          "astNodeId": 101
-                        },
-                        "specifier": {
-                          "inputKind": "None",
-                          "kind": {
-                            "CommandReg": {}
-                          },
-                          "name": "cmdRegOut",
-                          "priority": "None",
-                          "queueFull": "None"
-                        },
-                        "symbol": {
-                          "Port": {
-                            "nodeId": 194,
-                            "unqualifiedName": "CmdReg"
-                          }
-                        },
-                        "priority": "None",
-                        "queueFull": "None",
-                        "importNodeIds": []
-                      }
-                    }
-                  },
-                  "portNumber": "None"
-                },
-                "to": {
-                  "loc": {
-                    "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-                    "pos": "64.5",
-                    "includingLoc": "None"
-                  },
-                  "port": {
-                    "componentInstance": {
-                      "aNode": {
-                        "astNodeId": 118
-                      },
-                      "qualifiedName": {
-                        "qualifier": [],
-                        "base": "c2"
-                      },
-                      "component": {
-                        "astNodeId": 32
-                      },
-                      "baseId": 512,
-                      "maxId": 511,
-                      "file": "None",
-                      "queueSize": "None",
-                      "stackSize": "None",
-                      "priority": "None",
-                      "cpu": "None",
-                      "initSpecifierMap": {}
-                    },
-                    "portInstance": {
-                      "General": {
-                        "aNode": {
-                          "astNodeId": 15
-                        },
-                        "specifier": {
-                          "kind": {
-                            "SyncInput": {}
-                          },
-                          "name": "cmdRegOut",
-                          "size": "None",
-                          "port": {
-                            "Some": {
-                              "astNodeId": 14
-                            }
-                          },
-                          "priority": "None",
-                          "queueFull": "None"
-                        },
-                        "kind": "SyncInput",
-                        "size": 1,
-                        "ty": {
-                          "DefPort": {
-                            "symbol": {
-                              "Port": {
-                                "nodeId": 194,
-                                "unqualifiedName": "CmdReg"
-                              }
-                            }
-                          }
-                        },
-                        "importNodeIds": []
-                      }
-                    }
-                  },
-                  "portNumber": "None"
-                },
-                "isUnmatched": false
-              }
-            ]
-          ],
-          [
-            {
-              "componentInstance": {
-                "aNode": {
-                  "astNodeId": 110
-                },
-                "qualifiedName": {
-                  "qualifier": [],
-                  "base": "c"
-                },
-                "component": {
-                  "astNodeId": 106
-                },
-                "baseId": 256,
-                "maxId": 255,
-                "file": "None",
-                "queueSize": "None",
-                "stackSize": "None",
-                "priority": "None",
-                "cpu": "None",
-                "initSpecifierMap": {}
-              },
-              "portInstance": {
-                "Special": {
-                  "aNode": {
-                    "astNodeId": 105
-                  },
-                  "specifier": {
-                    "inputKind": "None",
-                    "kind": {
-                      "CommandResp": {}
-                    },
-                    "name": "cmdResponseOut",
-                    "priority": "None",
-                    "queueFull": "None"
-                  },
-                  "symbol": {
-                    "Port": {
-                      "nodeId": 195,
-                      "unqualifiedName": "CmdResponse"
-                    }
-                  },
-                  "priority": "None",
-                  "queueFull": "None",
-                  "importNodeIds": []
-                }
-              }
-            },
-            [
-              {
-                "from": {
-                  "loc": {
-                    "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-                    "pos": "64.5",
-                    "includingLoc": "None"
-                  },
-                  "port": {
-                    "componentInstance": {
-                      "aNode": {
-                        "astNodeId": 110
-                      },
-                      "qualifiedName": {
-                        "qualifier": [],
-                        "base": "c"
-                      },
-                      "component": {
-                        "astNodeId": 106
-                      },
-                      "baseId": 256,
-                      "maxId": 255,
-                      "file": "None",
-                      "queueSize": "None",
-                      "stackSize": "None",
-                      "priority": "None",
-                      "cpu": "None",
-                      "initSpecifierMap": {}
-                    },
-                    "portInstance": {
-                      "Special": {
-                        "aNode": {
-                          "astNodeId": 105
-                        },
-                        "specifier": {
-                          "inputKind": "None",
-                          "kind": {
-                            "CommandResp": {}
-                          },
-                          "name": "cmdResponseOut",
-                          "priority": "None",
-                          "queueFull": "None"
-                        },
-                        "symbol": {
-                          "Port": {
-                            "nodeId": 195,
-                            "unqualifiedName": "CmdResponse"
-                          }
-                        },
-                        "priority": "None",
-                        "queueFull": "None",
-                        "importNodeIds": []
-                      }
-                    }
-                  },
-                  "portNumber": "None"
-                },
-                "to": {
-                  "loc": {
-                    "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-                    "pos": "64.5",
-                    "includingLoc": "None"
-                  },
-                  "port": {
-                    "componentInstance": {
-                      "aNode": {
-                        "astNodeId": 118
-                      },
-                      "qualifiedName": {
-                        "qualifier": [],
-                        "base": "c2"
-                      },
-                      "component": {
-                        "astNodeId": 32
-                      },
-                      "baseId": 512,
-                      "maxId": 511,
-                      "file": "None",
-                      "queueSize": "None",
-                      "stackSize": "None",
-                      "priority": "None",
-                      "cpu": "None",
-                      "initSpecifierMap": {}
-                    },
-                    "portInstance": {
-                      "General": {
-                        "aNode": {
-                          "astNodeId": 19
-                        },
-                        "specifier": {
-                          "kind": {
-                            "SyncInput": {}
-                          },
-                          "name": "cmdResponseOut",
-                          "size": "None",
-                          "port": {
-                            "Some": {
-                              "astNodeId": 18
-                            }
-                          },
-                          "priority": "None",
-                          "queueFull": "None"
-                        },
-                        "kind": "SyncInput",
-                        "size": 1,
-                        "ty": {
-                          "DefPort": {
-                            "symbol": {
-                              "Port": {
-                                "nodeId": 195,
-                                "unqualifiedName": "CmdResponse"
-                              }
-                            }
-                          }
-                        },
-                        "importNodeIds": []
-                      }
-                    }
-                  },
-                  "portNumber": "None"
-                },
-                "isUnmatched": false
-              }
-            ]
-          ]
+        "outputConnectionMap" : [
         ],
-        "inputConnectionMap": [
-          [
-            {
-              "componentInstance": {
-                "aNode": {
-                  "astNodeId": 118
-                },
-                "qualifiedName": {
-                  "qualifier": [],
-                  "base": "c2"
-                },
-                "component": {
-                  "astNodeId": 32
-                },
-                "baseId": 512,
-                "maxId": 511,
-                "file": "None",
-                "queueSize": "None",
-                "stackSize": "None",
-                "priority": "None",
-                "cpu": "None",
-                "initSpecifierMap": {}
-              },
-              "portInstance": {
-                "General": {
-                  "aNode": {
-                    "astNodeId": 15
-                  },
-                  "specifier": {
-                    "kind": {
-                      "SyncInput": {}
-                    },
-                    "name": "cmdRegOut",
-                    "size": "None",
-                    "port": {
-                      "Some": {
-                        "astNodeId": 14
-                      }
-                    },
-                    "priority": "None",
-                    "queueFull": "None"
-                  },
-                  "kind": "SyncInput",
-                  "size": 1,
-                  "ty": {
-                    "DefPort": {
-                      "symbol": {
-                        "Port": {
-                          "nodeId": 194,
-                          "unqualifiedName": "CmdReg"
-                        }
-                      }
-                    }
-                  },
-                  "importNodeIds": []
-                }
-              }
-            },
-            [
-              {
-                "from": {
-                  "loc": {
-                    "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-                    "pos": "64.5",
-                    "includingLoc": "None"
-                  },
-                  "port": {
-                    "componentInstance": {
-                      "aNode": {
-                        "astNodeId": 110
-                      },
-                      "qualifiedName": {
-                        "qualifier": [],
-                        "base": "c"
-                      },
-                      "component": {
-                        "astNodeId": 106
-                      },
-                      "baseId": 256,
-                      "maxId": 255,
-                      "file": "None",
-                      "queueSize": "None",
-                      "stackSize": "None",
-                      "priority": "None",
-                      "cpu": "None",
-                      "initSpecifierMap": {}
-                    },
-                    "portInstance": {
-                      "Special": {
-                        "aNode": {
-                          "astNodeId": 101
-                        },
-                        "specifier": {
-                          "inputKind": "None",
-                          "kind": {
-                            "CommandReg": {}
-                          },
-                          "name": "cmdRegOut",
-                          "priority": "None",
-                          "queueFull": "None"
-                        },
-                        "symbol": {
-                          "Port": {
-                            "nodeId": 194,
-                            "unqualifiedName": "CmdReg"
-                          }
-                        },
-                        "priority": "None",
-                        "queueFull": "None",
-                        "importNodeIds": []
-                      }
-                    }
-                  },
-                  "portNumber": "None"
-                },
-                "to": {
-                  "loc": {
-                    "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-                    "pos": "64.5",
-                    "includingLoc": "None"
-                  },
-                  "port": {
-                    "componentInstance": {
-                      "aNode": {
-                        "astNodeId": 118
-                      },
-                      "qualifiedName": {
-                        "qualifier": [],
-                        "base": "c2"
-                      },
-                      "component": {
-                        "astNodeId": 32
-                      },
-                      "baseId": 512,
-                      "maxId": 511,
-                      "file": "None",
-                      "queueSize": "None",
-                      "stackSize": "None",
-                      "priority": "None",
-                      "cpu": "None",
-                      "initSpecifierMap": {}
-                    },
-                    "portInstance": {
-                      "General": {
-                        "aNode": {
-                          "astNodeId": 15
-                        },
-                        "specifier": {
-                          "kind": {
-                            "SyncInput": {}
-                          },
-                          "name": "cmdRegOut",
-                          "size": "None",
-                          "port": {
-                            "Some": {
-                              "astNodeId": 14
-                            }
-                          },
-                          "priority": "None",
-                          "queueFull": "None"
-                        },
-                        "kind": "SyncInput",
-                        "size": 1,
-                        "ty": {
-                          "DefPort": {
-                            "symbol": {
-                              "Port": {
-                                "nodeId": 194,
-                                "unqualifiedName": "CmdReg"
-                              }
-                            }
-                          }
-                        },
-                        "importNodeIds": []
-                      }
-                    }
-                  },
-                  "portNumber": "None"
-                },
-                "isUnmatched": false
-              }
-            ]
-          ],
-          [
-            {
-              "componentInstance": {
-                "aNode": {
-                  "astNodeId": 110
-                },
-                "qualifiedName": {
-                  "qualifier": [],
-                  "base": "c"
-                },
-                "component": {
-                  "astNodeId": 106
-                },
-                "baseId": 256,
-                "maxId": 255,
-                "file": "None",
-                "queueSize": "None",
-                "stackSize": "None",
-                "priority": "None",
-                "cpu": "None",
-                "initSpecifierMap": {}
-              },
-              "portInstance": {
-                "Special": {
-                  "aNode": {
-                    "astNodeId": 102
-                  },
-                  "specifier": {
-                    "inputKind": "None",
-                    "kind": {
-                      "CommandRecv": {}
-                    },
-                    "name": "cmdIn",
-                    "priority": "None",
-                    "queueFull": "None"
-                  },
-                  "symbol": {
-                    "Port": {
-                      "nodeId": 193,
-                      "unqualifiedName": "Cmd"
-                    }
-                  },
-                  "priority": "None",
-                  "queueFull": "None",
-                  "importNodeIds": []
-                }
-              }
-            },
-            [
-              {
-                "from": {
-                  "loc": {
-                    "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-                    "pos": "64.5",
-                    "includingLoc": "None"
-                  },
-                  "port": {
-                    "componentInstance": {
-                      "aNode": {
-                        "astNodeId": 118
-                      },
-                      "qualifiedName": {
-                        "qualifier": [],
-                        "base": "c2"
-                      },
-                      "component": {
-                        "astNodeId": 32
-                      },
-                      "baseId": 512,
-                      "maxId": 511,
-                      "file": "None",
-                      "queueSize": "None",
-                      "stackSize": "None",
-                      "priority": "None",
-                      "cpu": "None",
-                      "initSpecifierMap": {}
-                    },
-                    "portInstance": {
-                      "General": {
-                        "aNode": {
-                          "astNodeId": 31
-                        },
-                        "specifier": {
-                          "kind": {
-                            "Output": {}
-                          },
-                          "name": "cmdSend",
-                          "size": "None",
-                          "port": {
-                            "Some": {
-                              "astNodeId": 30
-                            }
-                          },
-                          "priority": "None",
-                          "queueFull": "None"
-                        },
-                        "kind": "Output",
-                        "size": 1,
-                        "ty": {
-                          "DefPort": {
-                            "symbol": {
-                              "Port": {
-                                "nodeId": 193,
-                                "unqualifiedName": "Cmd"
-                              }
-                            }
-                          }
-                        },
-                        "importNodeIds": []
-                      }
-                    }
-                  },
-                  "portNumber": "None"
-                },
-                "to": {
-                  "loc": {
-                    "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-                    "pos": "64.5",
-                    "includingLoc": "None"
-                  },
-                  "port": {
-                    "componentInstance": {
-                      "aNode": {
-                        "astNodeId": 110
-                      },
-                      "qualifiedName": {
-                        "qualifier": [],
-                        "base": "c"
-                      },
-                      "component": {
-                        "astNodeId": 106
-                      },
-                      "baseId": 256,
-                      "maxId": 255,
-                      "file": "None",
-                      "queueSize": "None",
-                      "stackSize": "None",
-                      "priority": "None",
-                      "cpu": "None",
-                      "initSpecifierMap": {}
-                    },
-                    "portInstance": {
-                      "Special": {
-                        "aNode": {
-                          "astNodeId": 102
-                        },
-                        "specifier": {
-                          "inputKind": "None",
-                          "kind": {
-                            "CommandRecv": {}
-                          },
-                          "name": "cmdIn",
-                          "priority": "None",
-                          "queueFull": "None"
-                        },
-                        "symbol": {
-                          "Port": {
-                            "nodeId": 193,
-                            "unqualifiedName": "Cmd"
-                          }
-                        },
-                        "priority": "None",
-                        "queueFull": "None",
-                        "importNodeIds": []
-                      }
-                    }
-                  },
-                  "portNumber": "None"
-                },
-                "isUnmatched": false
-              }
-            ]
-          ],
-          [
-            {
-              "componentInstance": {
-                "aNode": {
-                  "astNodeId": 118
-                },
-                "qualifiedName": {
-                  "qualifier": [],
-                  "base": "c2"
-                },
-                "component": {
-                  "astNodeId": 32
-                },
-                "baseId": 512,
-                "maxId": 511,
-                "file": "None",
-                "queueSize": "None",
-                "stackSize": "None",
-                "priority": "None",
-                "cpu": "None",
-                "initSpecifierMap": {}
-              },
-              "portInstance": {
-                "General": {
-                  "aNode": {
-                    "astNodeId": 19
-                  },
-                  "specifier": {
-                    "kind": {
-                      "SyncInput": {}
-                    },
-                    "name": "cmdResponseOut",
-                    "size": "None",
-                    "port": {
-                      "Some": {
-                        "astNodeId": 18
-                      }
-                    },
-                    "priority": "None",
-                    "queueFull": "None"
-                  },
-                  "kind": "SyncInput",
-                  "size": 1,
-                  "ty": {
-                    "DefPort": {
-                      "symbol": {
-                        "Port": {
-                          "nodeId": 195,
-                          "unqualifiedName": "CmdResponse"
-                        }
-                      }
-                    }
-                  },
-                  "importNodeIds": []
-                }
-              }
-            },
-            [
-              {
-                "from": {
-                  "loc": {
-                    "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-                    "pos": "64.5",
-                    "includingLoc": "None"
-                  },
-                  "port": {
-                    "componentInstance": {
-                      "aNode": {
-                        "astNodeId": 110
-                      },
-                      "qualifiedName": {
-                        "qualifier": [],
-                        "base": "c"
-                      },
-                      "component": {
-                        "astNodeId": 106
-                      },
-                      "baseId": 256,
-                      "maxId": 255,
-                      "file": "None",
-                      "queueSize": "None",
-                      "stackSize": "None",
-                      "priority": "None",
-                      "cpu": "None",
-                      "initSpecifierMap": {}
-                    },
-                    "portInstance": {
-                      "Special": {
-                        "aNode": {
-                          "astNodeId": 105
-                        },
-                        "specifier": {
-                          "inputKind": "None",
-                          "kind": {
-                            "CommandResp": {}
-                          },
-                          "name": "cmdResponseOut",
-                          "priority": "None",
-                          "queueFull": "None"
-                        },
-                        "symbol": {
-                          "Port": {
-                            "nodeId": 195,
-                            "unqualifiedName": "CmdResponse"
-                          }
-                        },
-                        "priority": "None",
-                        "queueFull": "None",
-                        "importNodeIds": []
-                      }
-                    }
-                  },
-                  "portNumber": "None"
-                },
-                "to": {
-                  "loc": {
-                    "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-                    "pos": "64.5",
-                    "includingLoc": "None"
-                  },
-                  "port": {
-                    "componentInstance": {
-                      "aNode": {
-                        "astNodeId": 118
-                      },
-                      "qualifiedName": {
-                        "qualifier": [],
-                        "base": "c2"
-                      },
-                      "component": {
-                        "astNodeId": 32
-                      },
-                      "baseId": 512,
-                      "maxId": 511,
-                      "file": "None",
-                      "queueSize": "None",
-                      "stackSize": "None",
-                      "priority": "None",
-                      "cpu": "None",
-                      "initSpecifierMap": {}
-                    },
-                    "portInstance": {
-                      "General": {
-                        "aNode": {
-                          "astNodeId": 19
-                        },
-                        "specifier": {
-                          "kind": {
-                            "SyncInput": {}
-                          },
-                          "name": "cmdResponseOut",
-                          "size": "None",
-                          "port": {
-                            "Some": {
-                              "astNodeId": 18
-                            }
-                          },
-                          "priority": "None",
-                          "queueFull": "None"
-                        },
-                        "kind": "SyncInput",
-                        "size": 1,
-                        "ty": {
-                          "DefPort": {
-                            "symbol": {
-                              "Port": {
-                                "nodeId": 195,
-                                "unqualifiedName": "CmdResponse"
-                              }
-                            }
-                          }
-                        },
-                        "importNodeIds": []
-                      }
-                    }
-                  },
-                  "portNumber": "None"
-                },
-                "isUnmatched": false
-              }
-            ]
-          ],
-          [
-            {
-              "componentInstance": {
-                "aNode": {
-                  "astNodeId": 114
-                },
-                "qualifiedName": {
-                  "qualifier": [],
-                  "base": "c1"
-                },
-                "component": {
-                  "astNodeId": 7
-                },
-                "baseId": 256,
-                "maxId": 255,
-                "file": "None",
-                "queueSize": "None",
-                "stackSize": "None",
-                "priority": "None",
-                "cpu": "None",
-                "initSpecifierMap": {}
-              },
-              "portInstance": {
-                "General": {
-                  "aNode": {
-                    "astNodeId": 3
-                  },
-                  "specifier": {
-                    "kind": {
-                      "SyncInput": {}
-                    },
-                    "name": "timeGetPort",
-                    "size": "None",
-                    "port": {
-                      "Some": {
-                        "astNodeId": 2
-                      }
-                    },
-                    "priority": "None",
-                    "queueFull": "None"
-                  },
-                  "kind": "SyncInput",
-                  "size": 1,
-                  "ty": {
-                    "DefPort": {
-                      "symbol": {
-                        "Port": {
-                          "nodeId": 200,
-                          "unqualifiedName": "Time"
-                        }
-                      }
-                    }
-                  },
-                  "importNodeIds": []
-                }
-              }
-            },
-            [
-              {
-                "from": {
-                  "loc": {
-                    "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-                    "pos": "63.5",
-                    "includingLoc": "None"
-                  },
-                  "port": {
-                    "componentInstance": {
-                      "aNode": {
-                        "astNodeId": 122
-                      },
-                      "qualifiedName": {
-                        "qualifier": [],
-                        "base": "c3"
-                      },
-                      "component": {
-                        "astNodeId": 40
-                      },
-                      "baseId": 768,
-                      "maxId": 767,
-                      "file": "None",
-                      "queueSize": "None",
-                      "stackSize": "None",
-                      "priority": "None",
-                      "cpu": "None",
-                      "initSpecifierMap": {}
-                    },
-                    "portInstance": {
-                      "Special": {
-                        "aNode": {
-                          "astNodeId": 39
-                        },
-                        "specifier": {
-                          "inputKind": "None",
-                          "kind": {
-                            "TimeGet": {}
-                          },
-                          "name": "timeGetOut",
-                          "priority": "None",
-                          "queueFull": "None"
-                        },
-                        "symbol": {
-                          "Port": {
-                            "nodeId": 200,
-                            "unqualifiedName": "Time"
-                          }
-                        },
-                        "priority": "None",
-                        "queueFull": "None",
-                        "importNodeIds": []
-                      }
-                    }
-                  },
-                  "portNumber": "None"
-                },
-                "to": {
-                  "loc": {
-                    "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-                    "pos": "63.5",
-                    "includingLoc": "None"
-                  },
-                  "port": {
-                    "componentInstance": {
-                      "aNode": {
-                        "astNodeId": 114
-                      },
-                      "qualifiedName": {
-                        "qualifier": [],
-                        "base": "c1"
-                      },
-                      "component": {
-                        "astNodeId": 7
-                      },
-                      "baseId": 256,
-                      "maxId": 255,
-                      "file": "None",
-                      "queueSize": "None",
-                      "stackSize": "None",
-                      "priority": "None",
-                      "cpu": "None",
-                      "initSpecifierMap": {}
-                    },
-                    "portInstance": {
-                      "General": {
-                        "aNode": {
-                          "astNodeId": 3
-                        },
-                        "specifier": {
-                          "kind": {
-                            "SyncInput": {}
-                          },
-                          "name": "timeGetPort",
-                          "size": "None",
-                          "port": {
-                            "Some": {
-                              "astNodeId": 2
-                            }
-                          },
-                          "priority": "None",
-                          "queueFull": "None"
-                        },
-                        "kind": "SyncInput",
-                        "size": 1,
-                        "ty": {
-                          "DefPort": {
-                            "symbol": {
-                              "Port": {
-                                "nodeId": 200,
-                                "unqualifiedName": "Time"
-                              }
-                            }
-                          }
-                        },
-                        "importNodeIds": []
-                      }
-                    }
-                  },
-                  "portNumber": "None"
-                },
-                "isUnmatched": false
-              },
-              {
-                "from": {
-                  "loc": {
-                    "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-                    "pos": "63.5",
-                    "includingLoc": "None"
-                  },
-                  "port": {
-                    "componentInstance": {
-                      "aNode": {
-                        "astNodeId": 114
-                      },
-                      "qualifiedName": {
-                        "qualifier": [],
-                        "base": "c1"
-                      },
-                      "component": {
-                        "astNodeId": 7
-                      },
-                      "baseId": 256,
-                      "maxId": 255,
-                      "file": "None",
-                      "queueSize": "None",
-                      "stackSize": "None",
-                      "priority": "None",
-                      "cpu": "None",
-                      "initSpecifierMap": {}
-                    },
-                    "portInstance": {
-                      "Special": {
-                        "aNode": {
-                          "astNodeId": 6
-                        },
-                        "specifier": {
-                          "inputKind": "None",
-                          "kind": {
-                            "TimeGet": {}
-                          },
-                          "name": "timeGetOut",
-                          "priority": "None",
-                          "queueFull": "None"
-                        },
-                        "symbol": {
-                          "Port": {
-                            "nodeId": 200,
-                            "unqualifiedName": "Time"
-                          }
-                        },
-                        "priority": "None",
-                        "queueFull": "None",
-                        "importNodeIds": []
-                      }
-                    }
-                  },
-                  "portNumber": "None"
-                },
-                "to": {
-                  "loc": {
-                    "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-                    "pos": "63.5",
-                    "includingLoc": "None"
-                  },
-                  "port": {
-                    "componentInstance": {
-                      "aNode": {
-                        "astNodeId": 114
-                      },
-                      "qualifiedName": {
-                        "qualifier": [],
-                        "base": "c1"
-                      },
-                      "component": {
-                        "astNodeId": 7
-                      },
-                      "baseId": 256,
-                      "maxId": 255,
-                      "file": "None",
-                      "queueSize": "None",
-                      "stackSize": "None",
-                      "priority": "None",
-                      "cpu": "None",
-                      "initSpecifierMap": {}
-                    },
-                    "portInstance": {
-                      "General": {
-                        "aNode": {
-                          "astNodeId": 3
-                        },
-                        "specifier": {
-                          "kind": {
-                            "SyncInput": {}
-                          },
-                          "name": "timeGetPort",
-                          "size": "None",
-                          "port": {
-                            "Some": {
-                              "astNodeId": 2
-                            }
-                          },
-                          "priority": "None",
-                          "queueFull": "None"
-                        },
-                        "kind": "SyncInput",
-                        "size": 1,
-                        "ty": {
-                          "DefPort": {
-                            "symbol": {
-                              "Port": {
-                                "nodeId": 200,
-                                "unqualifiedName": "Time"
-                              }
-                            }
-                          }
-                        },
-                        "importNodeIds": []
-                      }
-                    }
-                  },
-                  "portNumber": "None"
-                },
-                "isUnmatched": false
-              }
-            ]
-          ]
+        "inputConnectionMap" : [
         ],
-        "fromPortNumberMap": [
-          [
-            {
-              "from": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-                  "pos": "63.5",
-                  "includingLoc": "None"
-                },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 114
-                    },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c1"
-                    },
-                    "component": {
-                      "astNodeId": 7
-                    },
-                    "baseId": 256,
-                    "maxId": 255,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
-                  },
-                  "portInstance": {
-                    "Special": {
-                      "aNode": {
-                        "astNodeId": 6
-                      },
-                      "specifier": {
-                        "inputKind": "None",
-                        "kind": {
-                          "TimeGet": {}
-                        },
-                        "name": "timeGetOut",
-                        "priority": "None",
-                        "queueFull": "None"
-                      },
-                      "symbol": {
-                        "Port": {
-                          "nodeId": 200,
-                          "unqualifiedName": "Time"
-                        }
-                      },
-                      "priority": "None",
-                      "queueFull": "None",
-                      "importNodeIds": []
-                    }
-                  }
-                },
-                "portNumber": "None"
-              },
-              "to": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-                  "pos": "63.5",
-                  "includingLoc": "None"
-                },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 114
-                    },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c1"
-                    },
-                    "component": {
-                      "astNodeId": 7
-                    },
-                    "baseId": 256,
-                    "maxId": 255,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
-                  },
-                  "portInstance": {
-                    "General": {
-                      "aNode": {
-                        "astNodeId": 3
-                      },
-                      "specifier": {
-                        "kind": {
-                          "SyncInput": {}
-                        },
-                        "name": "timeGetPort",
-                        "size": "None",
-                        "port": {
-                          "Some": {
-                            "astNodeId": 2
-                          }
-                        },
-                        "priority": "None",
-                        "queueFull": "None"
-                      },
-                      "kind": "SyncInput",
-                      "size": 1,
-                      "ty": {
-                        "DefPort": {
-                          "symbol": {
-                            "Port": {
-                              "nodeId": 200,
-                              "unqualifiedName": "Time"
-                            }
-                          }
-                        }
-                      },
-                      "importNodeIds": []
-                    }
-                  }
-                },
-                "portNumber": "None"
-              },
-              "isUnmatched": false
-            },
-            0
-          ],
-          [
-            {
-              "from": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-                  "pos": "64.5",
-                  "includingLoc": "None"
-                },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 118
-                    },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c2"
-                    },
-                    "component": {
-                      "astNodeId": 32
-                    },
-                    "baseId": 512,
-                    "maxId": 511,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
-                  },
-                  "portInstance": {
-                    "General": {
-                      "aNode": {
-                        "astNodeId": 31
-                      },
-                      "specifier": {
-                        "kind": {
-                          "Output": {}
-                        },
-                        "name": "cmdSend",
-                        "size": "None",
-                        "port": {
-                          "Some": {
-                            "astNodeId": 30
-                          }
-                        },
-                        "priority": "None",
-                        "queueFull": "None"
-                      },
-                      "kind": "Output",
-                      "size": 1,
-                      "ty": {
-                        "DefPort": {
-                          "symbol": {
-                            "Port": {
-                              "nodeId": 193,
-                              "unqualifiedName": "Cmd"
-                            }
-                          }
-                        }
-                      },
-                      "importNodeIds": []
-                    }
-                  }
-                },
-                "portNumber": "None"
-              },
-              "to": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-                  "pos": "64.5",
-                  "includingLoc": "None"
-                },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 110
-                    },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c"
-                    },
-                    "component": {
-                      "astNodeId": 106
-                    },
-                    "baseId": 256,
-                    "maxId": 255,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
-                  },
-                  "portInstance": {
-                    "Special": {
-                      "aNode": {
-                        "astNodeId": 102
-                      },
-                      "specifier": {
-                        "inputKind": "None",
-                        "kind": {
-                          "CommandRecv": {}
-                        },
-                        "name": "cmdIn",
-                        "priority": "None",
-                        "queueFull": "None"
-                      },
-                      "symbol": {
-                        "Port": {
-                          "nodeId": 193,
-                          "unqualifiedName": "Cmd"
-                        }
-                      },
-                      "priority": "None",
-                      "queueFull": "None",
-                      "importNodeIds": []
-                    }
-                  }
-                },
-                "portNumber": "None"
-              },
-              "isUnmatched": false
-            },
-            0
-          ],
-          [
-            {
-              "from": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-                  "pos": "64.5",
-                  "includingLoc": "None"
-                },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 110
-                    },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c"
-                    },
-                    "component": {
-                      "astNodeId": 106
-                    },
-                    "baseId": 256,
-                    "maxId": 255,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
-                  },
-                  "portInstance": {
-                    "Special": {
-                      "aNode": {
-                        "astNodeId": 105
-                      },
-                      "specifier": {
-                        "inputKind": "None",
-                        "kind": {
-                          "CommandResp": {}
-                        },
-                        "name": "cmdResponseOut",
-                        "priority": "None",
-                        "queueFull": "None"
-                      },
-                      "symbol": {
-                        "Port": {
-                          "nodeId": 195,
-                          "unqualifiedName": "CmdResponse"
-                        }
-                      },
-                      "priority": "None",
-                      "queueFull": "None",
-                      "importNodeIds": []
-                    }
-                  }
-                },
-                "portNumber": "None"
-              },
-              "to": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-                  "pos": "64.5",
-                  "includingLoc": "None"
-                },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 118
-                    },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c2"
-                    },
-                    "component": {
-                      "astNodeId": 32
-                    },
-                    "baseId": 512,
-                    "maxId": 511,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
-                  },
-                  "portInstance": {
-                    "General": {
-                      "aNode": {
-                        "astNodeId": 19
-                      },
-                      "specifier": {
-                        "kind": {
-                          "SyncInput": {}
-                        },
-                        "name": "cmdResponseOut",
-                        "size": "None",
-                        "port": {
-                          "Some": {
-                            "astNodeId": 18
-                          }
-                        },
-                        "priority": "None",
-                        "queueFull": "None"
-                      },
-                      "kind": "SyncInput",
-                      "size": 1,
-                      "ty": {
-                        "DefPort": {
-                          "symbol": {
-                            "Port": {
-                              "nodeId": 195,
-                              "unqualifiedName": "CmdResponse"
-                            }
-                          }
-                        }
-                      },
-                      "importNodeIds": []
-                    }
-                  }
-                },
-                "portNumber": "None"
-              },
-              "isUnmatched": false
-            },
-            0
-          ],
-          [
-            {
-              "from": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-                  "pos": "63.5",
-                  "includingLoc": "None"
-                },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 122
-                    },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c3"
-                    },
-                    "component": {
-                      "astNodeId": 40
-                    },
-                    "baseId": 768,
-                    "maxId": 767,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
-                  },
-                  "portInstance": {
-                    "Special": {
-                      "aNode": {
-                        "astNodeId": 39
-                      },
-                      "specifier": {
-                        "inputKind": "None",
-                        "kind": {
-                          "TimeGet": {}
-                        },
-                        "name": "timeGetOut",
-                        "priority": "None",
-                        "queueFull": "None"
-                      },
-                      "symbol": {
-                        "Port": {
-                          "nodeId": 200,
-                          "unqualifiedName": "Time"
-                        }
-                      },
-                      "priority": "None",
-                      "queueFull": "None",
-                      "importNodeIds": []
-                    }
-                  }
-                },
-                "portNumber": "None"
-              },
-              "to": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-                  "pos": "63.5",
-                  "includingLoc": "None"
-                },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 114
-                    },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c1"
-                    },
-                    "component": {
-                      "astNodeId": 7
-                    },
-                    "baseId": 256,
-                    "maxId": 255,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
-                  },
-                  "portInstance": {
-                    "General": {
-                      "aNode": {
-                        "astNodeId": 3
-                      },
-                      "specifier": {
-                        "kind": {
-                          "SyncInput": {}
-                        },
-                        "name": "timeGetPort",
-                        "size": "None",
-                        "port": {
-                          "Some": {
-                            "astNodeId": 2
-                          }
-                        },
-                        "priority": "None",
-                        "queueFull": "None"
-                      },
-                      "kind": "SyncInput",
-                      "size": 1,
-                      "ty": {
-                        "DefPort": {
-                          "symbol": {
-                            "Port": {
-                              "nodeId": 200,
-                              "unqualifiedName": "Time"
-                            }
-                          }
-                        }
-                      },
-                      "importNodeIds": []
-                    }
-                  }
-                },
-                "portNumber": "None"
-              },
-              "isUnmatched": false
-            },
-            0
-          ],
-          [
-            {
-              "from": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-                  "pos": "64.5",
-                  "includingLoc": "None"
-                },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 110
-                    },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c"
-                    },
-                    "component": {
-                      "astNodeId": 106
-                    },
-                    "baseId": 256,
-                    "maxId": 255,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
-                  },
-                  "portInstance": {
-                    "Special": {
-                      "aNode": {
-                        "astNodeId": 101
-                      },
-                      "specifier": {
-                        "inputKind": "None",
-                        "kind": {
-                          "CommandReg": {}
-                        },
-                        "name": "cmdRegOut",
-                        "priority": "None",
-                        "queueFull": "None"
-                      },
-                      "symbol": {
-                        "Port": {
-                          "nodeId": 194,
-                          "unqualifiedName": "CmdReg"
-                        }
-                      },
-                      "priority": "None",
-                      "queueFull": "None",
-                      "importNodeIds": []
-                    }
-                  }
-                },
-                "portNumber": "None"
-              },
-              "to": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-                  "pos": "64.5",
-                  "includingLoc": "None"
-                },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 118
-                    },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c2"
-                    },
-                    "component": {
-                      "astNodeId": 32
-                    },
-                    "baseId": 512,
-                    "maxId": 511,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
-                  },
-                  "portInstance": {
-                    "General": {
-                      "aNode": {
-                        "astNodeId": 15
-                      },
-                      "specifier": {
-                        "kind": {
-                          "SyncInput": {}
-                        },
-                        "name": "cmdRegOut",
-                        "size": "None",
-                        "port": {
-                          "Some": {
-                            "astNodeId": 14
-                          }
-                        },
-                        "priority": "None",
-                        "queueFull": "None"
-                      },
-                      "kind": "SyncInput",
-                      "size": 1,
-                      "ty": {
-                        "DefPort": {
-                          "symbol": {
-                            "Port": {
-                              "nodeId": 194,
-                              "unqualifiedName": "CmdReg"
-                            }
-                          }
-                        }
-                      },
-                      "importNodeIds": []
-                    }
-                  }
-                },
-                "portNumber": "None"
-              },
-              "isUnmatched": false
-            },
-            0
-          ]
+        "fromPortNumberMap" : [
         ],
-        "toPortNumberMap": [
-          [
-            {
-              "from": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-                  "pos": "63.5",
-                  "includingLoc": "None"
-                },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 114
-                    },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c1"
-                    },
-                    "component": {
-                      "astNodeId": 7
-                    },
-                    "baseId": 256,
-                    "maxId": 255,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
-                  },
-                  "portInstance": {
-                    "Special": {
-                      "aNode": {
-                        "astNodeId": 6
-                      },
-                      "specifier": {
-                        "inputKind": "None",
-                        "kind": {
-                          "TimeGet": {}
-                        },
-                        "name": "timeGetOut",
-                        "priority": "None",
-                        "queueFull": "None"
-                      },
-                      "symbol": {
-                        "Port": {
-                          "nodeId": 200,
-                          "unqualifiedName": "Time"
-                        }
-                      },
-                      "priority": "None",
-                      "queueFull": "None",
-                      "importNodeIds": []
-                    }
-                  }
-                },
-                "portNumber": "None"
-              },
-              "to": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-                  "pos": "63.5",
-                  "includingLoc": "None"
-                },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 114
-                    },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c1"
-                    },
-                    "component": {
-                      "astNodeId": 7
-                    },
-                    "baseId": 256,
-                    "maxId": 255,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
-                  },
-                  "portInstance": {
-                    "General": {
-                      "aNode": {
-                        "astNodeId": 3
-                      },
-                      "specifier": {
-                        "kind": {
-                          "SyncInput": {}
-                        },
-                        "name": "timeGetPort",
-                        "size": "None",
-                        "port": {
-                          "Some": {
-                            "astNodeId": 2
-                          }
-                        },
-                        "priority": "None",
-                        "queueFull": "None"
-                      },
-                      "kind": "SyncInput",
-                      "size": 1,
-                      "ty": {
-                        "DefPort": {
-                          "symbol": {
-                            "Port": {
-                              "nodeId": 200,
-                              "unqualifiedName": "Time"
-                            }
-                          }
-                        }
-                      },
-                      "importNodeIds": []
-                    }
-                  }
-                },
-                "portNumber": "None"
-              },
-              "isUnmatched": false
-            },
-            0
-          ],
-          [
-            {
-              "from": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-                  "pos": "64.5",
-                  "includingLoc": "None"
-                },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 118
-                    },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c2"
-                    },
-                    "component": {
-                      "astNodeId": 32
-                    },
-                    "baseId": 512,
-                    "maxId": 511,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
-                  },
-                  "portInstance": {
-                    "General": {
-                      "aNode": {
-                        "astNodeId": 31
-                      },
-                      "specifier": {
-                        "kind": {
-                          "Output": {}
-                        },
-                        "name": "cmdSend",
-                        "size": "None",
-                        "port": {
-                          "Some": {
-                            "astNodeId": 30
-                          }
-                        },
-                        "priority": "None",
-                        "queueFull": "None"
-                      },
-                      "kind": "Output",
-                      "size": 1,
-                      "ty": {
-                        "DefPort": {
-                          "symbol": {
-                            "Port": {
-                              "nodeId": 193,
-                              "unqualifiedName": "Cmd"
-                            }
-                          }
-                        }
-                      },
-                      "importNodeIds": []
-                    }
-                  }
-                },
-                "portNumber": "None"
-              },
-              "to": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-                  "pos": "64.5",
-                  "includingLoc": "None"
-                },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 110
-                    },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c"
-                    },
-                    "component": {
-                      "astNodeId": 106
-                    },
-                    "baseId": 256,
-                    "maxId": 255,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
-                  },
-                  "portInstance": {
-                    "Special": {
-                      "aNode": {
-                        "astNodeId": 102
-                      },
-                      "specifier": {
-                        "inputKind": "None",
-                        "kind": {
-                          "CommandRecv": {}
-                        },
-                        "name": "cmdIn",
-                        "priority": "None",
-                        "queueFull": "None"
-                      },
-                      "symbol": {
-                        "Port": {
-                          "nodeId": 193,
-                          "unqualifiedName": "Cmd"
-                        }
-                      },
-                      "priority": "None",
-                      "queueFull": "None",
-                      "importNodeIds": []
-                    }
-                  }
-                },
-                "portNumber": "None"
-              },
-              "isUnmatched": false
-            },
-            0
-          ],
-          [
-            {
-              "from": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-                  "pos": "64.5",
-                  "includingLoc": "None"
-                },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 110
-                    },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c"
-                    },
-                    "component": {
-                      "astNodeId": 106
-                    },
-                    "baseId": 256,
-                    "maxId": 255,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
-                  },
-                  "portInstance": {
-                    "Special": {
-                      "aNode": {
-                        "astNodeId": 105
-                      },
-                      "specifier": {
-                        "inputKind": "None",
-                        "kind": {
-                          "CommandResp": {}
-                        },
-                        "name": "cmdResponseOut",
-                        "priority": "None",
-                        "queueFull": "None"
-                      },
-                      "symbol": {
-                        "Port": {
-                          "nodeId": 195,
-                          "unqualifiedName": "CmdResponse"
-                        }
-                      },
-                      "priority": "None",
-                      "queueFull": "None",
-                      "importNodeIds": []
-                    }
-                  }
-                },
-                "portNumber": "None"
-              },
-              "to": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-                  "pos": "64.5",
-                  "includingLoc": "None"
-                },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 118
-                    },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c2"
-                    },
-                    "component": {
-                      "astNodeId": 32
-                    },
-                    "baseId": 512,
-                    "maxId": 511,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
-                  },
-                  "portInstance": {
-                    "General": {
-                      "aNode": {
-                        "astNodeId": 19
-                      },
-                      "specifier": {
-                        "kind": {
-                          "SyncInput": {}
-                        },
-                        "name": "cmdResponseOut",
-                        "size": "None",
-                        "port": {
-                          "Some": {
-                            "astNodeId": 18
-                          }
-                        },
-                        "priority": "None",
-                        "queueFull": "None"
-                      },
-                      "kind": "SyncInput",
-                      "size": 1,
-                      "ty": {
-                        "DefPort": {
-                          "symbol": {
-                            "Port": {
-                              "nodeId": 195,
-                              "unqualifiedName": "CmdResponse"
-                            }
-                          }
-                        }
-                      },
-                      "importNodeIds": []
-                    }
-                  }
-                },
-                "portNumber": "None"
-              },
-              "isUnmatched": false
-            },
-            0
-          ],
-          [
-            {
-              "from": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-                  "pos": "63.5",
-                  "includingLoc": "None"
-                },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 122
-                    },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c3"
-                    },
-                    "component": {
-                      "astNodeId": 40
-                    },
-                    "baseId": 768,
-                    "maxId": 767,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
-                  },
-                  "portInstance": {
-                    "Special": {
-                      "aNode": {
-                        "astNodeId": 39
-                      },
-                      "specifier": {
-                        "inputKind": "None",
-                        "kind": {
-                          "TimeGet": {}
-                        },
-                        "name": "timeGetOut",
-                        "priority": "None",
-                        "queueFull": "None"
-                      },
-                      "symbol": {
-                        "Port": {
-                          "nodeId": 200,
-                          "unqualifiedName": "Time"
-                        }
-                      },
-                      "priority": "None",
-                      "queueFull": "None",
-                      "importNodeIds": []
-                    }
-                  }
-                },
-                "portNumber": "None"
-              },
-              "to": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-                  "pos": "63.5",
-                  "includingLoc": "None"
-                },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 114
-                    },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c1"
-                    },
-                    "component": {
-                      "astNodeId": 7
-                    },
-                    "baseId": 256,
-                    "maxId": 255,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
-                  },
-                  "portInstance": {
-                    "General": {
-                      "aNode": {
-                        "astNodeId": 3
-                      },
-                      "specifier": {
-                        "kind": {
-                          "SyncInput": {}
-                        },
-                        "name": "timeGetPort",
-                        "size": "None",
-                        "port": {
-                          "Some": {
-                            "astNodeId": 2
-                          }
-                        },
-                        "priority": "None",
-                        "queueFull": "None"
-                      },
-                      "kind": "SyncInput",
-                      "size": 1,
-                      "ty": {
-                        "DefPort": {
-                          "symbol": {
-                            "Port": {
-                              "nodeId": 200,
-                              "unqualifiedName": "Time"
-                            }
-                          }
-                        }
-                      },
-                      "importNodeIds": []
-                    }
-                  }
-                },
-                "portNumber": "None"
-              },
-              "isUnmatched": false
-            },
-            0
-          ],
-          [
-            {
-              "from": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-                  "pos": "64.5",
-                  "includingLoc": "None"
-                },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 110
-                    },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c"
-                    },
-                    "component": {
-                      "astNodeId": 106
-                    },
-                    "baseId": 256,
-                    "maxId": 255,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
-                  },
-                  "portInstance": {
-                    "Special": {
-                      "aNode": {
-                        "astNodeId": 101
-                      },
-                      "specifier": {
-                        "inputKind": "None",
-                        "kind": {
-                          "CommandReg": {}
-                        },
-                        "name": "cmdRegOut",
-                        "priority": "None",
-                        "queueFull": "None"
-                      },
-                      "symbol": {
-                        "Port": {
-                          "nodeId": 194,
-                          "unqualifiedName": "CmdReg"
-                        }
-                      },
-                      "priority": "None",
-                      "queueFull": "None",
-                      "importNodeIds": []
-                    }
-                  }
-                },
-                "portNumber": "None"
-              },
-              "to": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-                  "pos": "64.5",
-                  "includingLoc": "None"
-                },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 118
-                    },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c2"
-                    },
-                    "component": {
-                      "astNodeId": 32
-                    },
-                    "baseId": 512,
-                    "maxId": 511,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
-                  },
-                  "portInstance": {
-                    "General": {
-                      "aNode": {
-                        "astNodeId": 15
-                      },
-                      "specifier": {
-                        "kind": {
-                          "SyncInput": {}
-                        },
-                        "name": "cmdRegOut",
-                        "size": "None",
-                        "port": {
-                          "Some": {
-                            "astNodeId": 14
-                          }
-                        },
-                        "priority": "None",
-                        "queueFull": "None"
-                      },
-                      "kind": "SyncInput",
-                      "size": 1,
-                      "ty": {
-                        "DefPort": {
-                          "symbol": {
-                            "Port": {
-                              "nodeId": 194,
-                              "unqualifiedName": "CmdReg"
-                            }
-                          }
-                        }
-                      },
-                      "importNodeIds": []
-                    }
-                  }
-                },
-                "portNumber": "None"
-              },
-              "isUnmatched": false
-            },
-            0
-          ]
+        "toPortNumberMap" : [
         ],
-        "unconnectedPortSet": [
+        "unconnectedPortSet" : [
           {
-            "componentInstance": {
-              "aNode": {
-                "astNodeId": 134
+            "componentInstance" : {
+              "aNode" : {
+                "astNodeId" : 118
               },
-              "qualifiedName": {
-                "qualifier": [],
-                "base": "c6"
+              "qualifiedName" : {
+                "qualifier" : [
+                ],
+                "base" : "c2"
               },
-              "component": {
-                "astNodeId": 87
+              "component" : {
+                "astNodeId" : 37
               },
-              "baseId": 1536,
-              "maxId": 1535,
-              "file": "None",
-              "queueSize": "None",
-              "stackSize": "None",
-              "priority": "None",
-              "cpu": "None",
-              "initSpecifierMap": {}
+              "baseId" : 512,
+              "maxId" : 511,
+              "file" : "None",
+              "queueSize" : "None",
+              "stackSize" : "None",
+              "priority" : "None",
+              "cpu" : "None",
+              "initSpecifierMap" : {
+                
+              }
             },
-            "portInstance": {
-              "General": {
-                "aNode": {
-                  "astNodeId": 86
+            "portInstance" : {
+              "General" : {
+                "aNode" : {
+                  "astNodeId" : 24
                 },
-                "specifier": {
-                  "kind": {
-                    "SyncInput": {}
-                  },
-                  "name": "tlm",
-                  "size": "None",
-                  "port": {
-                    "Some": {
-                      "astNodeId": 85
+                "specifier" : {
+                  "kind" : {
+                    "SyncInput" : {
+                      
                     }
                   },
-                  "priority": "None",
-                  "queueFull": "None"
+                  "name" : "cmdResponseOut",
+                  "size" : "None",
+                  "port" : {
+                    "Some" : {
+                      "astNodeId" : 23
+                    }
+                  },
+                  "priority" : "None",
+                  "queueFull" : "None"
                 },
-                "kind": "SyncInput",
-                "size": 1,
-                "ty": {
-                  "DefPort": {
-                    "symbol": {
-                      "Port": {
-                        "nodeId": 201,
-                        "unqualifiedName": "Tlm"
+                "kind" : "SyncInput",
+                "size" : 1,
+                "ty" : {
+                  "DefPort" : {
+                    "symbol" : {
+                      "Port" : {
+                        "nodeId" : 288,
+                        "unqualifiedName" : "CmdResponse"
                       }
                     }
                   }
                 },
-                "importNodeIds": []
+                "importNodeIds" : [
+                ]
               }
             }
           },
           {
-            "componentInstance": {
-              "aNode": {
-                "astNodeId": 130
+            "componentInstance" : {
+              "aNode" : {
+                "astNodeId" : 118
               },
-              "qualifiedName": {
-                "qualifier": [],
-                "base": "c5"
+              "qualifiedName" : {
+                "qualifier" : [
+                ],
+                "base" : "c2"
               },
-              "component": {
-                "astNodeId": 74
+              "component" : {
+                "astNodeId" : 37
               },
-              "baseId": 1280,
-              "maxId": 1279,
-              "file": "None",
-              "queueSize": "None",
-              "stackSize": "None",
-              "priority": "None",
-              "cpu": "None",
-              "initSpecifierMap": {}
+              "baseId" : 512,
+              "maxId" : 511,
+              "file" : "None",
+              "queueSize" : "None",
+              "stackSize" : "None",
+              "priority" : "None",
+              "cpu" : "None",
+              "initSpecifierMap" : {
+                
+              }
             },
-            "portInstance": {
-              "General": {
-                "aNode": {
-                  "astNodeId": 73
+            "portInstance" : {
+              "General" : {
+                "aNode" : {
+                  "astNodeId" : 16
                 },
-                "specifier": {
-                  "kind": {
-                    "SyncInput": {}
-                  },
-                  "name": "paramSet",
-                  "size": "None",
-                  "port": {
-                    "Some": {
-                      "astNodeId": 72
+                "specifier" : {
+                  "kind" : {
+                    "SyncInput" : {
+                      
                     }
                   },
-                  "priority": "None",
-                  "queueFull": "None"
+                  "name" : "cmdIn",
+                  "size" : "None",
+                  "port" : {
+                    "Some" : {
+                      "astNodeId" : 15
+                    }
+                  },
+                  "priority" : "None",
+                  "queueFull" : "None"
                 },
-                "kind": "SyncInput",
-                "size": 1,
-                "ty": {
-                  "DefPort": {
-                    "symbol": {
-                      "Port": {
-                        "nodeId": 199,
-                        "unqualifiedName": "PrmSet"
+                "kind" : "SyncInput",
+                "size" : 1,
+                "ty" : {
+                  "DefPort" : {
+                    "symbol" : {
+                      "Port" : {
+                        "nodeId" : 286,
+                        "unqualifiedName" : "Cmd"
                       }
                     }
                   }
                 },
-                "importNodeIds": []
+                "importNodeIds" : [
+                ]
               }
             }
           },
           {
-            "componentInstance": {
-              "aNode": {
-                "astNodeId": 138
+            "componentInstance" : {
+              "aNode" : {
+                "astNodeId" : 118
               },
-              "qualifiedName": {
-                "qualifier": [],
-                "base": "c7"
+              "qualifiedName" : {
+                "qualifier" : [
+                ],
+                "base" : "c2"
               },
-              "component": {
-                "astNodeId": 100
+              "component" : {
+                "astNodeId" : 37
               },
-              "baseId": 1792,
-              "maxId": 1791,
-              "file": "None",
-              "queueSize": "None",
-              "stackSize": "None",
-              "priority": "None",
-              "cpu": "None",
-              "initSpecifierMap": {}
+              "baseId" : 512,
+              "maxId" : 511,
+              "file" : "None",
+              "queueSize" : "None",
+              "stackSize" : "None",
+              "priority" : "None",
+              "cpu" : "None",
+              "initSpecifierMap" : {
+                
+              }
             },
-            "portInstance": {
-              "General": {
-                "aNode": {
-                  "astNodeId": 99
+            "portInstance" : {
+              "General" : {
+                "aNode" : {
+                  "astNodeId" : 20
                 },
-                "specifier": {
-                  "kind": {
-                    "SyncInput": {}
-                  },
-                  "name": "textEventLog",
-                  "size": "None",
-                  "port": {
-                    "Some": {
-                      "astNodeId": 98
+                "specifier" : {
+                  "kind" : {
+                    "SyncInput" : {
+                      
                     }
                   },
-                  "priority": "None",
-                  "queueFull": "None"
+                  "name" : "cmdRegOut",
+                  "size" : "None",
+                  "port" : {
+                    "Some" : {
+                      "astNodeId" : 19
+                    }
+                  },
+                  "priority" : "None",
+                  "queueFull" : "None"
                 },
-                "kind": "SyncInput",
-                "size": 1,
-                "ty": {
-                  "DefPort": {
-                    "symbol": {
-                      "Port": {
-                        "nodeId": 197,
-                        "unqualifiedName": "LogText"
+                "kind" : "SyncInput",
+                "size" : 1,
+                "ty" : {
+                  "DefPort" : {
+                    "symbol" : {
+                      "Port" : {
+                        "nodeId" : 287,
+                        "unqualifiedName" : "CmdReg"
                       }
                     }
                   }
                 },
-                "importNodeIds": []
+                "importNodeIds" : [
+                ]
               }
             }
           },
           {
-            "componentInstance": {
-              "aNode": {
-                "astNodeId": 130
+            "componentInstance" : {
+              "aNode" : {
+                "astNodeId" : 130
               },
-              "qualifiedName": {
-                "qualifier": [],
-                "base": "c5"
+              "qualifiedName" : {
+                "qualifier" : [
+                ],
+                "base" : "c5"
               },
-              "component": {
-                "astNodeId": 74
+              "component" : {
+                "astNodeId" : 84
               },
-              "baseId": 1280,
-              "maxId": 1279,
-              "file": "None",
-              "queueSize": "None",
-              "stackSize": "None",
-              "priority": "None",
-              "cpu": "None",
-              "initSpecifierMap": {}
+              "baseId" : 1280,
+              "maxId" : 1279,
+              "file" : "None",
+              "queueSize" : "None",
+              "stackSize" : "None",
+              "priority" : "None",
+              "cpu" : "None",
+              "initSpecifierMap" : {
+                
+              }
             },
-            "portInstance": {
-              "General": {
-                "aNode": {
-                  "astNodeId": 61
+            "portInstance" : {
+              "General" : {
+                "aNode" : {
+                  "astNodeId" : 71
                 },
-                "specifier": {
-                  "kind": {
-                    "SyncInput": {}
-                  },
-                  "name": "paramGet",
-                  "size": "None",
-                  "port": {
-                    "Some": {
-                      "astNodeId": 60
+                "specifier" : {
+                  "kind" : {
+                    "SyncInput" : {
+                      
                     }
                   },
-                  "priority": "None",
-                  "queueFull": "None"
+                  "name" : "paramGet",
+                  "size" : "None",
+                  "port" : {
+                    "Some" : {
+                      "astNodeId" : 70
+                    }
+                  },
+                  "priority" : "None",
+                  "queueFull" : "None"
                 },
-                "kind": "SyncInput",
-                "size": 1,
-                "ty": {
-                  "DefPort": {
-                    "symbol": {
-                      "Port": {
-                        "nodeId": 198,
-                        "unqualifiedName": "PrmGet"
+                "kind" : "SyncInput",
+                "size" : 1,
+                "ty" : {
+                  "DefPort" : {
+                    "symbol" : {
+                      "Port" : {
+                        "nodeId" : 291,
+                        "unqualifiedName" : "PrmGet"
                       }
                     }
                   }
                 },
-                "importNodeIds": []
+                "importNodeIds" : [
+                ]
               }
             }
           },
           {
-            "componentInstance": {
-              "aNode": {
-                "astNodeId": 126
+            "componentInstance" : {
+              "aNode" : {
+                "astNodeId" : 118
               },
-              "qualifiedName": {
-                "qualifier": [],
-                "base": "c4"
+              "qualifiedName" : {
+                "qualifier" : [
+                ],
+                "base" : "c2"
               },
-              "component": {
-                "astNodeId": 57
+              "component" : {
+                "astNodeId" : 37
               },
-              "baseId": 1024,
-              "maxId": 1023,
-              "file": "None",
-              "queueSize": "None",
-              "stackSize": "None",
-              "priority": "None",
-              "cpu": "None",
-              "initSpecifierMap": {}
+              "baseId" : 512,
+              "maxId" : 511,
+              "file" : "None",
+              "queueSize" : "None",
+              "stackSize" : "None",
+              "priority" : "None",
+              "cpu" : "None",
+              "initSpecifierMap" : {
+                
+              }
             },
-            "portInstance": {
-              "General": {
-                "aNode": {
-                  "astNodeId": 56
+            "portInstance" : {
+              "General" : {
+                "aNode" : {
+                  "astNodeId" : 36
                 },
-                "specifier": {
-                  "kind": {
-                    "SyncInput": {}
-                  },
-                  "name": "PingReturn",
-                  "size": "None",
-                  "port": {
-                    "Some": {
-                      "astNodeId": 55
+                "specifier" : {
+                  "kind" : {
+                    "Output" : {
+                      
                     }
                   },
-                  "priority": "None",
-                  "queueFull": "None"
+                  "name" : "cmdSend",
+                  "size" : "None",
+                  "port" : {
+                    "Some" : {
+                      "astNodeId" : 35
+                    }
+                  },
+                  "priority" : "None",
+                  "queueFull" : "None"
                 },
-                "kind": "SyncInput",
-                "size": 1,
-                "ty": {
-                  "DefPort": {
-                    "symbol": {
-                      "Port": {
-                        "nodeId": 208,
-                        "unqualifiedName": "Ping"
+                "kind" : "Output",
+                "size" : 1,
+                "ty" : {
+                  "DefPort" : {
+                    "symbol" : {
+                      "Port" : {
+                        "nodeId" : 286,
+                        "unqualifiedName" : "Cmd"
                       }
                     }
                   }
                 },
-                "importNodeIds": []
+                "importNodeIds" : [
+                ]
               }
             }
           },
           {
-            "componentInstance": {
-              "aNode": {
-                "astNodeId": 118
+            "componentInstance" : {
+              "aNode" : {
+                "astNodeId" : 114
               },
-              "qualifiedName": {
-                "qualifier": [],
-                "base": "c2"
+              "qualifiedName" : {
+                "qualifier" : [
+                ],
+                "base" : "c1"
               },
-              "component": {
-                "astNodeId": 32
+              "component" : {
+                "astNodeId" : 12
               },
-              "baseId": 512,
-              "maxId": 511,
-              "file": "None",
-              "queueSize": "None",
-              "stackSize": "None",
-              "priority": "None",
-              "cpu": "None",
-              "initSpecifierMap": {}
+              "baseId" : 256,
+              "maxId" : 255,
+              "file" : "None",
+              "queueSize" : "None",
+              "stackSize" : "None",
+              "priority" : "None",
+              "cpu" : "None",
+              "initSpecifierMap" : {
+                
+              }
             },
-            "portInstance": {
-              "General": {
-                "aNode": {
-                  "astNodeId": 11
+            "portInstance" : {
+              "General" : {
+                "aNode" : {
+                  "astNodeId" : 11
                 },
-                "specifier": {
-                  "kind": {
-                    "SyncInput": {}
-                  },
-                  "name": "cmdIn",
-                  "size": "None",
-                  "port": {
-                    "Some": {
-                      "astNodeId": 10
+                "specifier" : {
+                  "kind" : {
+                    "SyncInput" : {
+                      
                     }
                   },
-                  "priority": "None",
-                  "queueFull": "None"
+                  "name" : "timeGetPort",
+                  "size" : "None",
+                  "port" : {
+                    "Some" : {
+                      "astNodeId" : 10
+                    }
+                  },
+                  "priority" : "None",
+                  "queueFull" : "None"
                 },
-                "kind": "SyncInput",
-                "size": 1,
-                "ty": {
-                  "DefPort": {
-                    "symbol": {
-                      "Port": {
-                        "nodeId": 193,
-                        "unqualifiedName": "Cmd"
+                "kind" : "SyncInput",
+                "size" : 1,
+                "ty" : {
+                  "DefPort" : {
+                    "symbol" : {
+                      "Port" : {
+                        "nodeId" : 293,
+                        "unqualifiedName" : "Time"
                       }
                     }
                   }
                 },
-                "importNodeIds": []
+                "importNodeIds" : [
+                ]
               }
             }
           },
           {
-            "componentInstance": {
-              "aNode": {
-                "astNodeId": 126
+            "componentInstance" : {
+              "aNode" : {
+                "astNodeId" : 138
               },
-              "qualifiedName": {
-                "qualifier": [],
-                "base": "c4"
+              "qualifiedName" : {
+                "qualifier" : [
+                ],
+                "base" : "c7"
               },
-              "component": {
-                "astNodeId": 57
+              "component" : {
+                "astNodeId" : 110
               },
-              "baseId": 1024,
-              "maxId": 1023,
-              "file": "None",
-              "queueSize": "None",
-              "stackSize": "None",
-              "priority": "None",
-              "cpu": "None",
-              "initSpecifierMap": {}
+              "baseId" : 1792,
+              "maxId" : 1791,
+              "file" : "None",
+              "queueSize" : "None",
+              "stackSize" : "None",
+              "priority" : "None",
+              "cpu" : "None",
+              "initSpecifierMap" : {
+                
+              }
             },
-            "portInstance": {
-              "General": {
-                "aNode": {
-                  "astNodeId": 44
+            "portInstance" : {
+              "General" : {
+                "aNode" : {
+                  "astNodeId" : 109
                 },
-                "specifier": {
-                  "kind": {
-                    "Output": {}
-                  },
-                  "name": "PingSend",
-                  "size": "None",
-                  "port": {
-                    "Some": {
-                      "astNodeId": 43
+                "specifier" : {
+                  "kind" : {
+                    "SyncInput" : {
+                      
                     }
                   },
-                  "priority": "None",
-                  "queueFull": "None"
+                  "name" : "textEventLog",
+                  "size" : "None",
+                  "port" : {
+                    "Some" : {
+                      "astNodeId" : 108
+                    }
+                  },
+                  "priority" : "None",
+                  "queueFull" : "None"
                 },
-                "kind": "Output",
-                "size": 1,
-                "ty": {
-                  "DefPort": {
-                    "symbol": {
-                      "Port": {
-                        "nodeId": 208,
-                        "unqualifiedName": "Ping"
+                "kind" : "SyncInput",
+                "size" : 1,
+                "ty" : {
+                  "DefPort" : {
+                    "symbol" : {
+                      "Port" : {
+                        "nodeId" : 290,
+                        "unqualifiedName" : "LogText"
                       }
                     }
                   }
                 },
-                "importNodeIds": []
+                "importNodeIds" : [
+                ]
               }
             }
           },
           {
-            "componentInstance": {
-              "aNode": {
-                "astNodeId": 122
+            "componentInstance" : {
+              "aNode" : {
+                "astNodeId" : 122
               },
-              "qualifiedName": {
-                "qualifier": [],
-                "base": "c3"
+              "qualifiedName" : {
+                "qualifier" : [
+                ],
+                "base" : "c3"
               },
-              "component": {
-                "astNodeId": 40
+              "component" : {
+                "astNodeId" : 50
               },
-              "baseId": 768,
-              "maxId": 767,
-              "file": "None",
-              "queueSize": "None",
-              "stackSize": "None",
-              "priority": "None",
-              "cpu": "None",
-              "initSpecifierMap": {}
+              "baseId" : 768,
+              "maxId" : 767,
+              "file" : "None",
+              "queueSize" : "None",
+              "stackSize" : "None",
+              "priority" : "None",
+              "cpu" : "None",
+              "initSpecifierMap" : {
+                
+              }
             },
-            "portInstance": {
-              "General": {
-                "aNode": {
-                  "astNodeId": 36
+            "portInstance" : {
+              "General" : {
+                "aNode" : {
+                  "astNodeId" : 49
                 },
-                "specifier": {
-                  "kind": {
-                    "SyncInput": {}
-                  },
-                  "name": "eventLog",
-                  "size": "None",
-                  "port": {
-                    "Some": {
-                      "astNodeId": 35
+                "specifier" : {
+                  "kind" : {
+                    "SyncInput" : {
+                      
                     }
                   },
-                  "priority": "None",
-                  "queueFull": "None"
+                  "name" : "eventLog",
+                  "size" : "None",
+                  "port" : {
+                    "Some" : {
+                      "astNodeId" : 48
+                    }
+                  },
+                  "priority" : "None",
+                  "queueFull" : "None"
                 },
-                "kind": "SyncInput",
-                "size": 1,
-                "ty": {
-                  "DefPort": {
-                    "symbol": {
-                      "Port": {
-                        "nodeId": 196,
-                        "unqualifiedName": "Log"
+                "kind" : "SyncInput",
+                "size" : 1,
+                "ty" : {
+                  "DefPort" : {
+                    "symbol" : {
+                      "Port" : {
+                        "nodeId" : 289,
+                        "unqualifiedName" : "Log"
                       }
                     }
                   }
                 },
-                "importNodeIds": []
+                "importNodeIds" : [
+                ]
+              }
+            }
+          },
+          {
+            "componentInstance" : {
+              "aNode" : {
+                "astNodeId" : 134
+              },
+              "qualifiedName" : {
+                "qualifier" : [
+                ],
+                "base" : "c6"
+              },
+              "component" : {
+                "astNodeId" : 97
+              },
+              "baseId" : 1536,
+              "maxId" : 1535,
+              "file" : "None",
+              "queueSize" : "None",
+              "stackSize" : "None",
+              "priority" : "None",
+              "cpu" : "None",
+              "initSpecifierMap" : {
+                
+              }
+            },
+            "portInstance" : {
+              "General" : {
+                "aNode" : {
+                  "astNodeId" : 96
+                },
+                "specifier" : {
+                  "kind" : {
+                    "SyncInput" : {
+                      
+                    }
+                  },
+                  "name" : "tlm",
+                  "size" : "None",
+                  "port" : {
+                    "Some" : {
+                      "astNodeId" : 95
+                    }
+                  },
+                  "priority" : "None",
+                  "queueFull" : "None"
+                },
+                "kind" : "SyncInput",
+                "size" : 1,
+                "ty" : {
+                  "DefPort" : {
+                    "symbol" : {
+                      "Port" : {
+                        "nodeId" : 294,
+                        "unqualifiedName" : "Tlm"
+                      }
+                    }
+                  }
+                },
+                "importNodeIds" : [
+                ]
+              }
+            }
+          },
+          {
+            "componentInstance" : {
+              "aNode" : {
+                "astNodeId" : 126
+              },
+              "qualifiedName" : {
+                "qualifier" : [
+                ],
+                "base" : "c4"
+              },
+              "component" : {
+                "astNodeId" : 67
+              },
+              "baseId" : 1024,
+              "maxId" : 1023,
+              "file" : "None",
+              "queueSize" : "None",
+              "stackSize" : "None",
+              "priority" : "None",
+              "cpu" : "None",
+              "initSpecifierMap" : {
+                
+              }
+            },
+            "portInstance" : {
+              "General" : {
+                "aNode" : {
+                  "astNodeId" : 54
+                },
+                "specifier" : {
+                  "kind" : {
+                    "Output" : {
+                      
+                    }
+                  },
+                  "name" : "PingSend",
+                  "size" : "None",
+                  "port" : {
+                    "Some" : {
+                      "astNodeId" : 53
+                    }
+                  },
+                  "priority" : "None",
+                  "queueFull" : "None"
+                },
+                "kind" : "Output",
+                "size" : 1,
+                "ty" : {
+                  "DefPort" : {
+                    "symbol" : {
+                      "Port" : {
+                        "nodeId" : 301,
+                        "unqualifiedName" : "Ping"
+                      }
+                    }
+                  }
+                },
+                "importNodeIds" : [
+                ]
+              }
+            }
+          },
+          {
+            "componentInstance" : {
+              "aNode" : {
+                "astNodeId" : 126
+              },
+              "qualifiedName" : {
+                "qualifier" : [
+                ],
+                "base" : "c4"
+              },
+              "component" : {
+                "astNodeId" : 67
+              },
+              "baseId" : 1024,
+              "maxId" : 1023,
+              "file" : "None",
+              "queueSize" : "None",
+              "stackSize" : "None",
+              "priority" : "None",
+              "cpu" : "None",
+              "initSpecifierMap" : {
+                
+              }
+            },
+            "portInstance" : {
+              "General" : {
+                "aNode" : {
+                  "astNodeId" : 66
+                },
+                "specifier" : {
+                  "kind" : {
+                    "SyncInput" : {
+                      
+                    }
+                  },
+                  "name" : "PingReturn",
+                  "size" : "None",
+                  "port" : {
+                    "Some" : {
+                      "astNodeId" : 65
+                    }
+                  },
+                  "priority" : "None",
+                  "queueFull" : "None"
+                },
+                "kind" : "SyncInput",
+                "size" : 1,
+                "ty" : {
+                  "DefPort" : {
+                    "symbol" : {
+                      "Port" : {
+                        "nodeId" : 301,
+                        "unqualifiedName" : "Ping"
+                      }
+                    }
+                  }
+                },
+                "importNodeIds" : [
+                ]
+              }
+            }
+          },
+          {
+            "componentInstance" : {
+              "aNode" : {
+                "astNodeId" : 130
+              },
+              "qualifiedName" : {
+                "qualifier" : [
+                ],
+                "base" : "c5"
+              },
+              "component" : {
+                "astNodeId" : 84
+              },
+              "baseId" : 1280,
+              "maxId" : 1279,
+              "file" : "None",
+              "queueSize" : "None",
+              "stackSize" : "None",
+              "priority" : "None",
+              "cpu" : "None",
+              "initSpecifierMap" : {
+                
+              }
+            },
+            "portInstance" : {
+              "General" : {
+                "aNode" : {
+                  "astNodeId" : 83
+                },
+                "specifier" : {
+                  "kind" : {
+                    "SyncInput" : {
+                      
+                    }
+                  },
+                  "name" : "paramSet",
+                  "size" : "None",
+                  "port" : {
+                    "Some" : {
+                      "astNodeId" : 82
+                    }
+                  },
+                  "priority" : "None",
+                  "queueFull" : "None"
+                },
+                "kind" : "SyncInput",
+                "size" : 1,
+                "ty" : {
+                  "DefPort" : {
+                    "symbol" : {
+                      "Port" : {
+                        "nodeId" : 292,
+                        "unqualifiedName" : "PrmSet"
+                      }
+                    }
+                  }
+                },
+                "importNodeIds" : [
+                ]
               }
             }
           }
         ]
       }
     },
-    "typeMap": {
-      "113": {
-        "Int": {
-          "Integer": {}
+    "typeMap" : {
+      "113" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "121": {
-        "Int": {
-          "Integer": {}
+      "121" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "117": {
-        "Int": {
-          "Integer": {}
+      "117" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "137": {
-        "Int": {
-          "Integer": {}
+      "137" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "133": {
-        "Int": {
-          "Integer": {}
+      "133" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "109": {
-        "Int": {
-          "Integer": {}
+      "125" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "125": {
-        "Int": {
-          "Integer": {}
-        }
-      },
-      "129": {
-        "Int": {
-          "Integer": {}
-        }
-      }
-    },
-    "useDefMap": {
-      "12": {
-        "Module": {
-          "nodeId": 205,
-          "unqualifiedName": "Fw"
-        }
-      },
-      "175": {
-        "ComponentInstance": {
-          "nodeId": 126,
-          "unqualifiedName": "c4"
-        }
-      },
-      "128": {
-        "Component": {
-          "nodeId": 74,
-          "unqualifiedName": "Param"
-        }
-      },
-      "33": {
-        "Module": {
-          "nodeId": 205,
-          "unqualifiedName": "Fw"
-        }
-      },
-      "55": {
-        "Port": {
-          "nodeId": 208,
-          "unqualifiedName": "Ping"
-        }
-      },
-      "10": {
-        "Port": {
-          "nodeId": 193,
-          "unqualifiedName": "Cmd"
-        }
-      },
-      "116": {
-        "Component": {
-          "nodeId": 32,
-          "unqualifiedName": "Command"
-        }
-      },
-      "43": {
-        "Port": {
-          "nodeId": 208,
-          "unqualifiedName": "Ping"
-        }
-      },
-      "108": {
-        "Component": {
-          "nodeId": 106,
-          "unqualifiedName": "C"
-        }
-      },
-      "18": {
-        "Port": {
-          "nodeId": 195,
-          "unqualifiedName": "CmdResponse"
-        }
-      },
-      "41": {
-        "Module": {
-          "nodeId": 209,
-          "unqualifiedName": "Svc"
-        }
-      },
-      "105": {
-        "Port": {
-          "nodeId": 195,
-          "unqualifiedName": "CmdResponse"
-        }
-      },
-      "98": {
-        "Port": {
-          "nodeId": 197,
-          "unqualifiedName": "LogText"
-        }
-      },
-      "169": {
-        "ComponentInstance": {
-          "nodeId": 110,
-          "unqualifiedName": "c"
-        }
-      },
-      "120": {
-        "Component": {
-          "nodeId": 40,
-          "unqualifiedName": "Event"
-        }
-      },
-      "158": {
-        "ComponentInstance": {
-          "nodeId": 134,
-          "unqualifiedName": "c6"
-        }
-      },
-      "124": {
-        "Component": {
-          "nodeId": 57,
-          "unqualifiedName": "Health"
-        }
-      },
-      "8": {
-        "Module": {
-          "nodeId": 205,
-          "unqualifiedName": "Fw"
-        }
-      },
-      "164": {
-        "ComponentInstance": {
-          "nodeId": 114,
-          "unqualifiedName": "c1"
-        }
-      },
-      "181": {
-        "ComponentInstance": {
-          "nodeId": 134,
-          "unqualifiedName": "c6"
-        }
-      },
-      "132": {
-        "Component": {
-          "nodeId": 87,
-          "unqualifiedName": "Telemetry"
-        }
-      },
-      "155": {
-        "ComponentInstance": {
-          "nodeId": 130,
-          "unqualifiedName": "c5"
-        }
-      },
-      "83": {
-        "Module": {
-          "nodeId": 205,
-          "unqualifiedName": "Fw"
-        }
-      },
-      "35": {
-        "Port": {
-          "nodeId": 196,
-          "unqualifiedName": "Log"
-        }
-      },
-      "16": {
-        "Module": {
-          "nodeId": 205,
-          "unqualifiedName": "Fw"
-        }
-      },
-      "152": {
-        "ComponentInstance": {
-          "nodeId": 126,
-          "unqualifiedName": "c4"
-        }
-      },
-      "112": {
-        "Component": {
-          "nodeId": 7,
-          "unqualifiedName": "Time"
-        }
-      },
-      "72": {
-        "Port": {
-          "nodeId": 199,
-          "unqualifiedName": "PrmSet"
-        }
-      },
-      "6": {
-        "Port": {
-          "nodeId": 200,
-          "unqualifiedName": "Time"
-        }
-      },
-      "39": {
-        "Port": {
-          "nodeId": 200,
-          "unqualifiedName": "Time"
-        }
-      },
-      "140": {
-        "ComponentInstance": {
-          "nodeId": 110,
-          "unqualifiedName": "c"
-        }
-      },
-      "60": {
-        "Port": {
-          "nodeId": 198,
-          "unqualifiedName": "PrmGet"
-        }
-      },
-      "14": {
-        "Port": {
-          "nodeId": 194,
-          "unqualifiedName": "CmdReg"
-        }
-      },
-      "102": {
-        "Port": {
-          "nodeId": 193,
-          "unqualifiedName": "Cmd"
-        }
-      },
-      "96": {
-        "Module": {
-          "nodeId": 205,
-          "unqualifiedName": "Fw"
-        }
-      },
-      "190": {
-        "ComponentInstance": {
-          "nodeId": 138,
-          "unqualifiedName": "c7"
-        }
-      },
-      "58": {
-        "Module": {
-          "nodeId": 205,
-          "unqualifiedName": "Fw"
-        }
-      },
-      "53": {
-        "Module": {
-          "nodeId": 209,
-          "unqualifiedName": "Svc"
-        }
-      },
-      "0": {
-        "Module": {
-          "nodeId": 205,
-          "unqualifiedName": "Fw"
-        }
-      },
-      "149": {
-        "ComponentInstance": {
-          "nodeId": 122,
-          "unqualifiedName": "c3"
-        }
-      },
-      "178": {
-        "ComponentInstance": {
-          "nodeId": 130,
-          "unqualifiedName": "c5"
-        }
-      },
-      "70": {
-        "Module": {
-          "nodeId": 205,
-          "unqualifiedName": "Fw"
-        }
-      },
-      "2": {
-        "Port": {
-          "nodeId": 200,
-          "unqualifiedName": "Time"
-        }
-      },
-      "167": {
-        "ComponentInstance": {
-          "nodeId": 118,
-          "unqualifiedName": "c2"
-        }
-      },
-      "101": {
-        "Port": {
-          "nodeId": 194,
-          "unqualifiedName": "CmdReg"
-        }
-      },
-      "30": {
-        "Port": {
-          "nodeId": 193,
-          "unqualifiedName": "Cmd"
-        }
-      },
-      "143": {
-        "ComponentInstance": {
-          "nodeId": 114,
-          "unqualifiedName": "c1"
-        }
-      },
-      "85": {
-        "Port": {
-          "nodeId": 201,
-          "unqualifiedName": "Tlm"
-        }
-      },
-      "172": {
-        "ComponentInstance": {
-          "nodeId": 122,
-          "unqualifiedName": "c3"
-        }
-      },
-      "28": {
-        "Module": {
-          "nodeId": 205,
-          "unqualifiedName": "Fw"
-        }
-      },
-      "161": {
-        "ComponentInstance": {
-          "nodeId": 138,
-          "unqualifiedName": "c7"
-        }
-      },
-      "136": {
-        "Component": {
-          "nodeId": 100,
-          "unqualifiedName": "TextEvent"
-        }
-      },
-      "146": {
-        "ComponentInstance": {
-          "nodeId": 118,
-          "unqualifiedName": "c2"
+      "129" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       }
     },
-    "valueMap": {
-      "113": {
-        "Integer": {
-          "value": 256
+    "useDefMap" : {
+      "51" : {
+        "Module" : {
+          "nodeId" : 302,
+          "unqualifiedName" : "Svc"
         }
       },
-      "121": {
-        "Integer": {
-          "value": 768
+      "128" : {
+        "Component" : {
+          "nodeId" : 84,
+          "unqualifiedName" : "Param"
         }
       },
-      "117": {
-        "Integer": {
-          "value": 512
+      "33" : {
+        "Module" : {
+          "nodeId" : 298,
+          "unqualifiedName" : "Fw"
         }
       },
-      "137": {
-        "Integer": {
-          "value": 1792
+      "17" : {
+        "Module" : {
+          "nodeId" : 298,
+          "unqualifiedName" : "Fw"
         }
       },
-      "133": {
-        "Integer": {
-          "value": 1536
+      "95" : {
+        "Port" : {
+          "nodeId" : 294,
+          "unqualifiedName" : "Tlm"
         }
       },
-      "109": {
-        "Integer": {
-          "value": 256
+      "53" : {
+        "Port" : {
+          "nodeId" : 301,
+          "unqualifiedName" : "Ping"
         }
       },
-      "125": {
-        "Integer": {
-          "value": 1024
+      "70" : {
+        "Port" : {
+          "nodeId" : 291,
+          "unqualifiedName" : "PrmGet"
         }
       },
-      "129": {
-        "Integer": {
-          "value": 1280
+      "283" : {
+        "ComponentInstance" : {
+          "nodeId" : 138,
+          "unqualifiedName" : "c7"
+        }
+      },
+      "247" : {
+        "ComponentInstance" : {
+          "nodeId" : 126,
+          "unqualifiedName" : "c4"
+        }
+      },
+      "63" : {
+        "Module" : {
+          "nodeId" : 302,
+          "unqualifiedName" : "Svc"
+        }
+      },
+      "136" : {
+        "Component" : {
+          "nodeId" : 110,
+          "unqualifiedName" : "TextEvent"
+        }
+      },
+      "120" : {
+        "Component" : {
+          "nodeId" : 50,
+          "unqualifiedName" : "Event"
+        }
+      },
+      "93" : {
+        "Module" : {
+          "nodeId" : 298,
+          "unqualifiedName" : "Fw"
+        }
+      },
+      "124" : {
+        "Component" : {
+          "nodeId" : 67,
+          "unqualifiedName" : "Health"
+        }
+      },
+      "8" : {
+        "Module" : {
+          "nodeId" : 298,
+          "unqualifiedName" : "Fw"
+        }
+      },
+      "19" : {
+        "Port" : {
+          "nodeId" : 287,
+          "unqualifiedName" : "CmdReg"
+        }
+      },
+      "265" : {
+        "ComponentInstance" : {
+          "nodeId" : 122,
+          "unqualifiedName" : "c3"
+        }
+      },
+      "23" : {
+        "Port" : {
+          "nodeId" : 288,
+          "unqualifiedName" : "CmdResponse"
+        }
+      },
+      "15" : {
+        "Port" : {
+          "nodeId" : 286,
+          "unqualifiedName" : "Cmd"
+        }
+      },
+      "132" : {
+        "Component" : {
+          "nodeId" : 97,
+          "unqualifiedName" : "Telemetry"
+        }
+      },
+      "262" : {
+        "ComponentInstance" : {
+          "nodeId" : 118,
+          "unqualifiedName" : "c2"
+        }
+      },
+      "250" : {
+        "ComponentInstance" : {
+          "nodeId" : 130,
+          "unqualifiedName" : "c5"
+        }
+      },
+      "244" : {
+        "ComponentInstance" : {
+          "nodeId" : 122,
+          "unqualifiedName" : "c3"
+        }
+      },
+      "68" : {
+        "Module" : {
+          "nodeId" : 298,
+          "unqualifiedName" : "Fw"
+        }
+      },
+      "13" : {
+        "Module" : {
+          "nodeId" : 298,
+          "unqualifiedName" : "Fw"
+        }
+      },
+      "46" : {
+        "Module" : {
+          "nodeId" : 298,
+          "unqualifiedName" : "Fw"
+        }
+      },
+      "253" : {
+        "ComponentInstance" : {
+          "nodeId" : 134,
+          "unqualifiedName" : "c6"
+        }
+      },
+      "35" : {
+        "Port" : {
+          "nodeId" : 286,
+          "unqualifiedName" : "Cmd"
+        }
+      },
+      "112" : {
+        "Component" : {
+          "nodeId" : 12,
+          "unqualifiedName" : "Time"
+        }
+      },
+      "268" : {
+        "ComponentInstance" : {
+          "nodeId" : 126,
+          "unqualifiedName" : "c4"
+        }
+      },
+      "10" : {
+        "Port" : {
+          "nodeId" : 293,
+          "unqualifiedName" : "Time"
+        }
+      },
+      "274" : {
+        "ComponentInstance" : {
+          "nodeId" : 134,
+          "unqualifiedName" : "c6"
+        }
+      },
+      "256" : {
+        "ComponentInstance" : {
+          "nodeId" : 138,
+          "unqualifiedName" : "c7"
+        }
+      },
+      "48" : {
+        "Port" : {
+          "nodeId" : 289,
+          "unqualifiedName" : "Log"
+        }
+      },
+      "21" : {
+        "Module" : {
+          "nodeId" : 298,
+          "unqualifiedName" : "Fw"
+        }
+      },
+      "116" : {
+        "Component" : {
+          "nodeId" : 37,
+          "unqualifiedName" : "Command"
+        }
+      },
+      "65" : {
+        "Port" : {
+          "nodeId" : 301,
+          "unqualifiedName" : "Ping"
+        }
+      },
+      "108" : {
+        "Port" : {
+          "nodeId" : 290,
+          "unqualifiedName" : "LogText"
+        }
+      },
+      "259" : {
+        "ComponentInstance" : {
+          "nodeId" : 114,
+          "unqualifiedName" : "c1"
+        }
+      },
+      "80" : {
+        "Module" : {
+          "nodeId" : 298,
+          "unqualifiedName" : "Fw"
+        }
+      },
+      "106" : {
+        "Module" : {
+          "nodeId" : 298,
+          "unqualifiedName" : "Fw"
+        }
+      },
+      "82" : {
+        "Port" : {
+          "nodeId" : 292,
+          "unqualifiedName" : "PrmSet"
+        }
+      },
+      "241" : {
+        "ComponentInstance" : {
+          "nodeId" : 118,
+          "unqualifiedName" : "c2"
+        }
+      },
+      "238" : {
+        "ComponentInstance" : {
+          "nodeId" : 114,
+          "unqualifiedName" : "c1"
+        }
+      },
+      "271" : {
+        "ComponentInstance" : {
+          "nodeId" : 130,
+          "unqualifiedName" : "c5"
         }
       }
     },
-    "stateMachineMap": {},
-    "interfaceMap": {}
+    "valueMap" : {
+      "113" : {
+        "Integer" : {
+          "value" : 256
+        }
+      },
+      "121" : {
+        "Integer" : {
+          "value" : 768
+        }
+      },
+      "117" : {
+        "Integer" : {
+          "value" : 512
+        }
+      },
+      "137" : {
+        "Integer" : {
+          "value" : 1792
+        }
+      },
+      "133" : {
+        "Integer" : {
+          "value" : 1536
+        }
+      },
+      "125" : {
+        "Integer" : {
+          "value" : 1024
+        }
+      },
+      "129" : {
+        "Integer" : {
+          "value" : 1280
+        }
+      }
+    },
+    "stateMachineMap" : {
+      
+    },
+    "dictionarySymbolSet" : [
+    ],
+    "interfaceMap" : {
+      
+    }
   }
 }

--- a/tests/patterned_connections/patterned_connections_analysis.json
+++ b/tests/patterned_connections/patterned_connections_analysis.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion": "[ fpp version ]",
+  "fppVersion": "v3.1.0a10",
   "analysis": {
     "componentInstanceMap": {
       "110": {
@@ -1010,8 +1010,8 @@
     },
     "includedFileSet": [],
     "inputFileSet": [
-      "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/fprime/defs.fpp",
-      "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp"
+      "[ local path prefix ]/compiler/tools/fpp-to-json/test/fprime/defs.fpp",
+      "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp"
     ],
     "locationSpecifierMap": [],
     "parentSymbolMap": {
@@ -1224,7 +1224,7 @@
                 "Public": {}
               },
               {
-                "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+                "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
                 "pos": "55.5",
                 "includingLoc": "None"
               }
@@ -1256,7 +1256,7 @@
                 "Public": {}
               },
               {
-                "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+                "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
                 "pos": "59.5",
                 "includingLoc": "None"
               }
@@ -1288,7 +1288,7 @@
                 "Public": {}
               },
               {
-                "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+                "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
                 "pos": "58.5",
                 "includingLoc": "None"
               }
@@ -1320,7 +1320,7 @@
                 "Public": {}
               },
               {
-                "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+                "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
                 "pos": "60.5",
                 "includingLoc": "None"
               }
@@ -1352,7 +1352,7 @@
                 "Public": {}
               },
               {
-                "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+                "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
                 "pos": "61.5",
                 "includingLoc": "None"
               }
@@ -1384,7 +1384,7 @@
                 "Public": {}
               },
               {
-                "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+                "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
                 "pos": "56.5",
                 "includingLoc": "None"
               }
@@ -1416,7 +1416,7 @@
                 "Public": {}
               },
               {
-                "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+                "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
                 "pos": "54.5",
                 "includingLoc": "None"
               }
@@ -1448,7 +1448,7 @@
                 "Public": {}
               },
               {
-                "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+                "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
                 "pos": "57.5",
                 "includingLoc": "None"
               }
@@ -1491,7 +1491,7 @@
                 "initSpecifierMap": {}
               },
               {
-                "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+                "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
                 "pos": "65.32",
                 "includingLoc": "None"
               }
@@ -1537,7 +1537,7 @@
                 "initSpecifierMap": {}
               },
               {
-                "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+                "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
                 "pos": "64.34",
                 "includingLoc": "None"
               }
@@ -1565,7 +1565,7 @@
                   "initSpecifierMap": {}
                 },
                 {
-                  "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
                   "pos": "64.39",
                   "includingLoc": "None"
                 }
@@ -1607,7 +1607,7 @@
                 "initSpecifierMap": {}
               },
               {
-                "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+                "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
                 "pos": "67.32",
                 "includingLoc": "None"
               }
@@ -1649,7 +1649,7 @@
                 "initSpecifierMap": {}
               },
               {
-                "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+                "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
                 "pos": "68.36",
                 "includingLoc": "None"
               }
@@ -1691,7 +1691,7 @@
                 "initSpecifierMap": {}
               },
               {
-                "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+                "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
                 "pos": "63.31",
                 "includingLoc": "None"
               }
@@ -1733,7 +1733,7 @@
                 "initSpecifierMap": {}
               },
               {
-                "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+                "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
                 "pos": "69.37",
                 "includingLoc": "None"
               }
@@ -1775,7 +1775,7 @@
                 "initSpecifierMap": {}
               },
               {
-                "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+                "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
                 "pos": "66.33",
                 "includingLoc": "None"
               }
@@ -1788,7 +1788,7 @@
             {
               "from": {
                 "loc": {
-                  "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
                   "pos": "64.5",
                   "includingLoc": "None"
                 },
@@ -1843,7 +1843,7 @@
               },
               "to": {
                 "loc": {
-                  "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
                   "pos": "64.5",
                   "includingLoc": "None"
                 },
@@ -1912,7 +1912,7 @@
             {
               "from": {
                 "loc": {
-                  "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
                   "pos": "64.5",
                   "includingLoc": "None"
                 },
@@ -1976,7 +1976,7 @@
               },
               "to": {
                 "loc": {
-                  "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
                   "pos": "64.5",
                   "includingLoc": "None"
                 },
@@ -2036,7 +2036,7 @@
             {
               "from": {
                 "loc": {
-                  "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
                   "pos": "64.5",
                   "includingLoc": "None"
                 },
@@ -2091,7 +2091,7 @@
               },
               "to": {
                 "loc": {
-                  "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
                   "pos": "64.5",
                   "includingLoc": "None"
                 },
@@ -2160,7 +2160,7 @@
             {
               "from": {
                 "loc": {
-                  "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
                   "pos": "63.5",
                   "includingLoc": "None"
                 },
@@ -2215,7 +2215,7 @@
               },
               "to": {
                 "loc": {
-                  "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
                   "pos": "63.5",
                   "includingLoc": "None"
                 },
@@ -2282,7 +2282,7 @@
             {
               "from": {
                 "loc": {
-                  "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
                   "pos": "63.5",
                   "includingLoc": "None"
                 },
@@ -2337,7 +2337,7 @@
               },
               "to": {
                 "loc": {
-                  "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
                   "pos": "63.5",
                   "includingLoc": "None"
                 },
@@ -2408,7 +2408,7 @@
             {
               "from": {
                 "loc": {
-                  "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
                   "pos": "64.5",
                   "includingLoc": "None"
                 },
@@ -2463,7 +2463,7 @@
               },
               "to": {
                 "loc": {
-                  "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
                   "pos": "64.5",
                   "includingLoc": "None"
                 },
@@ -2532,7 +2532,7 @@
             {
               "from": {
                 "loc": {
-                  "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
                   "pos": "64.5",
                   "includingLoc": "None"
                 },
@@ -2596,7 +2596,7 @@
               },
               "to": {
                 "loc": {
-                  "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
                   "pos": "64.5",
                   "includingLoc": "None"
                 },
@@ -2656,7 +2656,7 @@
             {
               "from": {
                 "loc": {
-                  "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
                   "pos": "64.5",
                   "includingLoc": "None"
                 },
@@ -2711,7 +2711,7 @@
               },
               "to": {
                 "loc": {
-                  "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
                   "pos": "64.5",
                   "includingLoc": "None"
                 },
@@ -2780,7 +2780,7 @@
             {
               "from": {
                 "loc": {
-                  "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
                   "pos": "63.5",
                   "includingLoc": "None"
                 },
@@ -2835,7 +2835,7 @@
               },
               "to": {
                 "loc": {
-                  "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
                   "pos": "63.5",
                   "includingLoc": "None"
                 },
@@ -2902,7 +2902,7 @@
             {
               "from": {
                 "loc": {
-                  "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
                   "pos": "63.5",
                   "includingLoc": "None"
                 },
@@ -2957,7 +2957,7 @@
               },
               "to": {
                 "loc": {
-                  "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
                   "pos": "63.5",
                   "includingLoc": "None"
                 },
@@ -3076,7 +3076,7 @@
               {
                 "from": {
                   "loc": {
-                    "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+                    "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
                     "pos": "63.5",
                     "includingLoc": "None"
                   },
@@ -3131,7 +3131,7 @@
                 },
                 "to": {
                   "loc": {
-                    "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+                    "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
                     "pos": "63.5",
                     "includingLoc": "None"
                   },
@@ -3258,7 +3258,7 @@
               {
                 "from": {
                   "loc": {
-                    "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+                    "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
                     "pos": "64.5",
                     "includingLoc": "None"
                   },
@@ -3322,7 +3322,7 @@
                 },
                 "to": {
                   "loc": {
-                    "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+                    "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
                     "pos": "64.5",
                     "includingLoc": "None"
                   },
@@ -3431,7 +3431,7 @@
               {
                 "from": {
                   "loc": {
-                    "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+                    "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
                     "pos": "63.5",
                     "includingLoc": "None"
                   },
@@ -3486,7 +3486,7 @@
                 },
                 "to": {
                   "loc": {
-                    "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+                    "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
                     "pos": "63.5",
                     "includingLoc": "None"
                   },
@@ -3604,7 +3604,7 @@
               {
                 "from": {
                   "loc": {
-                    "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+                    "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
                     "pos": "64.5",
                     "includingLoc": "None"
                   },
@@ -3659,7 +3659,7 @@
                 },
                 "to": {
                   "loc": {
-                    "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+                    "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
                     "pos": "64.5",
                     "includingLoc": "None"
                   },
@@ -3777,7 +3777,7 @@
               {
                 "from": {
                   "loc": {
-                    "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+                    "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
                     "pos": "64.5",
                     "includingLoc": "None"
                   },
@@ -3832,7 +3832,7 @@
                 },
                 "to": {
                   "loc": {
-                    "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+                    "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
                     "pos": "64.5",
                     "includingLoc": "None"
                   },
@@ -3961,7 +3961,7 @@
               {
                 "from": {
                   "loc": {
-                    "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+                    "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
                     "pos": "64.5",
                     "includingLoc": "None"
                   },
@@ -4016,7 +4016,7 @@
                 },
                 "to": {
                   "loc": {
-                    "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+                    "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
                     "pos": "64.5",
                     "includingLoc": "None"
                   },
@@ -4134,7 +4134,7 @@
               {
                 "from": {
                   "loc": {
-                    "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+                    "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
                     "pos": "64.5",
                     "includingLoc": "None"
                   },
@@ -4198,7 +4198,7 @@
                 },
                 "to": {
                   "loc": {
-                    "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+                    "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
                     "pos": "64.5",
                     "includingLoc": "None"
                   },
@@ -4316,7 +4316,7 @@
               {
                 "from": {
                   "loc": {
-                    "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+                    "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
                     "pos": "64.5",
                     "includingLoc": "None"
                   },
@@ -4371,7 +4371,7 @@
                 },
                 "to": {
                   "loc": {
-                    "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+                    "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
                     "pos": "64.5",
                     "includingLoc": "None"
                   },
@@ -4498,7 +4498,7 @@
               {
                 "from": {
                   "loc": {
-                    "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+                    "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
                     "pos": "63.5",
                     "includingLoc": "None"
                   },
@@ -4553,7 +4553,7 @@
                 },
                 "to": {
                   "loc": {
-                    "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+                    "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
                     "pos": "63.5",
                     "includingLoc": "None"
                   },
@@ -4620,7 +4620,7 @@
               {
                 "from": {
                   "loc": {
-                    "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+                    "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
                     "pos": "63.5",
                     "includingLoc": "None"
                   },
@@ -4675,7 +4675,7 @@
                 },
                 "to": {
                   "loc": {
-                    "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+                    "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
                     "pos": "63.5",
                     "includingLoc": "None"
                   },
@@ -4747,7 +4747,7 @@
             {
               "from": {
                 "loc": {
-                  "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
                   "pos": "63.5",
                   "includingLoc": "None"
                 },
@@ -4802,7 +4802,7 @@
               },
               "to": {
                 "loc": {
-                  "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
                   "pos": "63.5",
                   "includingLoc": "None"
                 },
@@ -4872,7 +4872,7 @@
             {
               "from": {
                 "loc": {
-                  "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
                   "pos": "64.5",
                   "includingLoc": "None"
                 },
@@ -4936,7 +4936,7 @@
               },
               "to": {
                 "loc": {
-                  "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
                   "pos": "64.5",
                   "includingLoc": "None"
                 },
@@ -4997,7 +4997,7 @@
             {
               "from": {
                 "loc": {
-                  "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
                   "pos": "64.5",
                   "includingLoc": "None"
                 },
@@ -5052,7 +5052,7 @@
               },
               "to": {
                 "loc": {
-                  "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
                   "pos": "64.5",
                   "includingLoc": "None"
                 },
@@ -5122,7 +5122,7 @@
             {
               "from": {
                 "loc": {
-                  "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
                   "pos": "63.5",
                   "includingLoc": "None"
                 },
@@ -5177,7 +5177,7 @@
               },
               "to": {
                 "loc": {
-                  "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
                   "pos": "63.5",
                   "includingLoc": "None"
                 },
@@ -5247,7 +5247,7 @@
             {
               "from": {
                 "loc": {
-                  "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
                   "pos": "64.5",
                   "includingLoc": "None"
                 },
@@ -5302,7 +5302,7 @@
               },
               "to": {
                 "loc": {
-                  "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
                   "pos": "64.5",
                   "includingLoc": "None"
                 },
@@ -5374,7 +5374,7 @@
             {
               "from": {
                 "loc": {
-                  "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
                   "pos": "63.5",
                   "includingLoc": "None"
                 },
@@ -5429,7 +5429,7 @@
               },
               "to": {
                 "loc": {
-                  "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
                   "pos": "63.5",
                   "includingLoc": "None"
                 },
@@ -5499,7 +5499,7 @@
             {
               "from": {
                 "loc": {
-                  "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
                   "pos": "64.5",
                   "includingLoc": "None"
                 },
@@ -5563,7 +5563,7 @@
               },
               "to": {
                 "loc": {
-                  "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
                   "pos": "64.5",
                   "includingLoc": "None"
                 },
@@ -5624,7 +5624,7 @@
             {
               "from": {
                 "loc": {
-                  "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
                   "pos": "64.5",
                   "includingLoc": "None"
                 },
@@ -5679,7 +5679,7 @@
               },
               "to": {
                 "loc": {
-                  "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
                   "pos": "64.5",
                   "includingLoc": "None"
                 },
@@ -5749,7 +5749,7 @@
             {
               "from": {
                 "loc": {
-                  "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
                   "pos": "63.5",
                   "includingLoc": "None"
                 },
@@ -5804,7 +5804,7 @@
               },
               "to": {
                 "loc": {
-                  "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
                   "pos": "63.5",
                   "includingLoc": "None"
                 },
@@ -5874,7 +5874,7 @@
             {
               "from": {
                 "loc": {
-                  "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
                   "pos": "64.5",
                   "includingLoc": "None"
                 },
@@ -5929,7 +5929,7 @@
               },
               "to": {
                 "loc": {
-                  "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
                   "pos": "64.5",
                   "includingLoc": "None"
                 },

--- a/tests/patterned_connections/patterned_connections_ast.json
+++ b/tests/patterned_connections/patterned_connections_ast.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion": "[ fpp version ]",
+  "fppVersion": "v3.1.0a10",
   "ast": [
     {
       "members": [

--- a/tests/patterned_connections/patterned_connections_ast.json
+++ b/tests/patterned_connections/patterned_connections_ast.json
@@ -1,1959 +1,1935 @@
 {
-  "fppVersion": "v3.1.0a10",
-  "ast": [
+  "fppVersion" : "v3.1.0a10-54-g11243e778",
+  "ast" : [
     {
-      "members": [
+      "members" : [
         [
-          [],
+          [
+          ],
           {
-            "DefComponent": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "kind": {
-                      "Passive": {}
+            "DefComponent" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "kind" : {
+                      "Passive" : {
+                        
+                      }
                     },
-                    "name": "Time",
-                    "members": [
+                    "name" : "Time",
+                    "members" : [
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "SpecPortInstance": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "General": {
-                                    "kind": {
-                                      "SyncInput": {}
+                          "SpecPortInstance" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "General" : {
+                                    "kind" : {
+                                      "SyncInput" : {
+                                        
+                                      }
                                     },
-                                    "name": "timeGetPort",
-                                    "size": "None",
-                                    "port": {
-                                      "Some": {
-                                        "AstNode": {
-                                          "data": {
-                                            "Qualified": {
-                                              "qualifier": {
-                                                "AstNode": {
-                                                  "data": {
-                                                    "Unqualified": {
-                                                      "name": "Fw"
+                                    "name" : "timeGetPort",
+                                    "size" : "None",
+                                    "port" : {
+                                      "Some" : {
+                                        "AstNode" : {
+                                          "data" : {
+                                            "Qualified" : {
+                                              "qualifier" : {
+                                                "AstNode" : {
+                                                  "data" : {
+                                                    "Unqualified" : {
+                                                      "name" : "Fw"
                                                     }
                                                   },
-                                                  "id": 0
+                                                  "id" : 8
                                                 }
                                               },
-                                              "name": {
-                                                "AstNode": {
-                                                  "data": "Time",
-                                                  "id": 1
+                                              "name" : {
+                                                "AstNode" : {
+                                                  "data" : "Time",
+                                                  "id" : 9
                                                 }
                                               }
                                             }
                                           },
-                                          "id": 2
+                                          "id" : 10
                                         }
                                       }
                                     },
-                                    "priority": "None",
-                                    "queueFull": "None"
+                                    "priority" : "None",
+                                    "queueFull" : "None"
                                   }
                                 },
-                                "id": 3
+                                "id" : 11
                               }
                             }
                           }
                         },
-                        []
-                      ],
-                      [
-                        [],
-                        {
-                          "SpecPortInstance": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "Special": {
-                                    "inputKind": "None",
-                                    "kind": {
-                                      "TimeGet": {}
-                                    },
-                                    "name": "timeGetOut",
-                                    "priority": "None",
-                                    "queueFull": "None"
-                                  }
-                                },
-                                "id": 6
-                              }
-                            }
-                          }
-                        },
-                        []
+                        [
+                        ]
                       ]
                     ]
                   },
-                  "id": 7
+                  "id" : 12
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          [],
+          [
+          ],
           {
-            "DefComponent": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "kind": {
-                      "Passive": {}
+            "DefComponent" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "kind" : {
+                      "Passive" : {
+                        
+                      }
                     },
-                    "name": "Command",
-                    "members": [
+                    "name" : "Command",
+                    "members" : [
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "SpecPortInstance": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "General": {
-                                    "kind": {
-                                      "SyncInput": {}
+                          "SpecPortInstance" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "General" : {
+                                    "kind" : {
+                                      "SyncInput" : {
+                                        
+                                      }
                                     },
-                                    "name": "cmdIn",
-                                    "size": "None",
-                                    "port": {
-                                      "Some": {
-                                        "AstNode": {
-                                          "data": {
-                                            "Qualified": {
-                                              "qualifier": {
-                                                "AstNode": {
-                                                  "data": {
-                                                    "Unqualified": {
-                                                      "name": "Fw"
+                                    "name" : "cmdIn",
+                                    "size" : "None",
+                                    "port" : {
+                                      "Some" : {
+                                        "AstNode" : {
+                                          "data" : {
+                                            "Qualified" : {
+                                              "qualifier" : {
+                                                "AstNode" : {
+                                                  "data" : {
+                                                    "Unqualified" : {
+                                                      "name" : "Fw"
                                                     }
                                                   },
-                                                  "id": 8
+                                                  "id" : 13
                                                 }
                                               },
-                                              "name": {
-                                                "AstNode": {
-                                                  "data": "Cmd",
-                                                  "id": 9
+                                              "name" : {
+                                                "AstNode" : {
+                                                  "data" : "Cmd",
+                                                  "id" : 14
                                                 }
                                               }
                                             }
                                           },
-                                          "id": 10
+                                          "id" : 15
                                         }
                                       }
                                     },
-                                    "priority": "None",
-                                    "queueFull": "None"
+                                    "priority" : "None",
+                                    "queueFull" : "None"
                                   }
                                 },
-                                "id": 11
+                                "id" : 16
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "SpecPortInstance": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "General": {
-                                    "kind": {
-                                      "SyncInput": {}
+                          "SpecPortInstance" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "General" : {
+                                    "kind" : {
+                                      "SyncInput" : {
+                                        
+                                      }
                                     },
-                                    "name": "cmdRegOut",
-                                    "size": "None",
-                                    "port": {
-                                      "Some": {
-                                        "AstNode": {
-                                          "data": {
-                                            "Qualified": {
-                                              "qualifier": {
-                                                "AstNode": {
-                                                  "data": {
-                                                    "Unqualified": {
-                                                      "name": "Fw"
+                                    "name" : "cmdRegOut",
+                                    "size" : "None",
+                                    "port" : {
+                                      "Some" : {
+                                        "AstNode" : {
+                                          "data" : {
+                                            "Qualified" : {
+                                              "qualifier" : {
+                                                "AstNode" : {
+                                                  "data" : {
+                                                    "Unqualified" : {
+                                                      "name" : "Fw"
                                                     }
                                                   },
-                                                  "id": 12
+                                                  "id" : 17
                                                 }
                                               },
-                                              "name": {
-                                                "AstNode": {
-                                                  "data": "CmdReg",
-                                                  "id": 13
+                                              "name" : {
+                                                "AstNode" : {
+                                                  "data" : "CmdReg",
+                                                  "id" : 18
                                                 }
                                               }
                                             }
                                           },
-                                          "id": 14
+                                          "id" : 19
                                         }
                                       }
                                     },
-                                    "priority": "None",
-                                    "queueFull": "None"
+                                    "priority" : "None",
+                                    "queueFull" : "None"
                                   }
                                 },
-                                "id": 15
+                                "id" : 20
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "SpecPortInstance": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "General": {
-                                    "kind": {
-                                      "SyncInput": {}
+                          "SpecPortInstance" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "General" : {
+                                    "kind" : {
+                                      "SyncInput" : {
+                                        
+                                      }
                                     },
-                                    "name": "cmdResponseOut",
-                                    "size": "None",
-                                    "port": {
-                                      "Some": {
-                                        "AstNode": {
-                                          "data": {
-                                            "Qualified": {
-                                              "qualifier": {
-                                                "AstNode": {
-                                                  "data": {
-                                                    "Unqualified": {
-                                                      "name": "Fw"
+                                    "name" : "cmdResponseOut",
+                                    "size" : "None",
+                                    "port" : {
+                                      "Some" : {
+                                        "AstNode" : {
+                                          "data" : {
+                                            "Qualified" : {
+                                              "qualifier" : {
+                                                "AstNode" : {
+                                                  "data" : {
+                                                    "Unqualified" : {
+                                                      "name" : "Fw"
                                                     }
                                                   },
-                                                  "id": 16
+                                                  "id" : 21
                                                 }
                                               },
-                                              "name": {
-                                                "AstNode": {
-                                                  "data": "CmdResponse",
-                                                  "id": 17
+                                              "name" : {
+                                                "AstNode" : {
+                                                  "data" : "CmdResponse",
+                                                  "id" : 22
                                                 }
                                               }
                                             }
                                           },
-                                          "id": 18
+                                          "id" : 23
                                         }
                                       }
                                     },
-                                    "priority": "None",
-                                    "queueFull": "None"
+                                    "priority" : "None",
+                                    "queueFull" : "None"
                                   }
                                 },
-                                "id": 19
+                                "id" : 24
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "SpecPortInstance": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "General": {
-                                    "kind": {
-                                      "Output": {}
+                          "SpecPortInstance" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "General" : {
+                                    "kind" : {
+                                      "Output" : {
+                                        
+                                      }
                                     },
-                                    "name": "cmdSend",
-                                    "size": "None",
-                                    "port": {
-                                      "Some": {
-                                        "AstNode": {
-                                          "data": {
-                                            "Qualified": {
-                                              "qualifier": {
-                                                "AstNode": {
-                                                  "data": {
-                                                    "Unqualified": {
-                                                      "name": "Fw"
+                                    "name" : "cmdSend",
+                                    "size" : "None",
+                                    "port" : {
+                                      "Some" : {
+                                        "AstNode" : {
+                                          "data" : {
+                                            "Qualified" : {
+                                              "qualifier" : {
+                                                "AstNode" : {
+                                                  "data" : {
+                                                    "Unqualified" : {
+                                                      "name" : "Fw"
                                                     }
                                                   },
-                                                  "id": 28
+                                                  "id" : 33
                                                 }
                                               },
-                                              "name": {
-                                                "AstNode": {
-                                                  "data": "Cmd",
-                                                  "id": 29
+                                              "name" : {
+                                                "AstNode" : {
+                                                  "data" : "Cmd",
+                                                  "id" : 34
                                                 }
                                               }
                                             }
                                           },
-                                          "id": 30
+                                          "id" : 35
                                         }
                                       }
                                     },
-                                    "priority": "None",
-                                    "queueFull": "None"
+                                    "priority" : "None",
+                                    "queueFull" : "None"
                                   }
                                 },
-                                "id": 31
+                                "id" : 36
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ]
                     ]
                   },
-                  "id": 32
+                  "id" : 37
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          [],
+          [
+          ],
           {
-            "DefComponent": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "kind": {
-                      "Passive": {}
+            "DefComponent" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "kind" : {
+                      "Passive" : {
+                        
+                      }
                     },
-                    "name": "Event",
-                    "members": [
+                    "name" : "Event",
+                    "members" : [
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "SpecPortInstance": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "General": {
-                                    "kind": {
-                                      "SyncInput": {}
+                          "SpecPortInstance" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "General" : {
+                                    "kind" : {
+                                      "SyncInput" : {
+                                        
+                                      }
                                     },
-                                    "name": "eventLog",
-                                    "size": "None",
-                                    "port": {
-                                      "Some": {
-                                        "AstNode": {
-                                          "data": {
-                                            "Qualified": {
-                                              "qualifier": {
-                                                "AstNode": {
-                                                  "data": {
-                                                    "Unqualified": {
-                                                      "name": "Fw"
+                                    "name" : "eventLog",
+                                    "size" : "None",
+                                    "port" : {
+                                      "Some" : {
+                                        "AstNode" : {
+                                          "data" : {
+                                            "Qualified" : {
+                                              "qualifier" : {
+                                                "AstNode" : {
+                                                  "data" : {
+                                                    "Unqualified" : {
+                                                      "name" : "Fw"
                                                     }
                                                   },
-                                                  "id": 33
+                                                  "id" : 46
                                                 }
                                               },
-                                              "name": {
-                                                "AstNode": {
-                                                  "data": "Log",
-                                                  "id": 34
+                                              "name" : {
+                                                "AstNode" : {
+                                                  "data" : "Log",
+                                                  "id" : 47
                                                 }
                                               }
                                             }
                                           },
-                                          "id": 35
+                                          "id" : 48
                                         }
                                       }
                                     },
-                                    "priority": "None",
-                                    "queueFull": "None"
+                                    "priority" : "None",
+                                    "queueFull" : "None"
                                   }
                                 },
-                                "id": 36
+                                "id" : 49
                               }
                             }
                           }
                         },
-                        []
-                      ],
-                      [
-                        [],
-                        {
-                          "SpecPortInstance": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "Special": {
-                                    "inputKind": "None",
-                                    "kind": {
-                                      "TimeGet": {}
-                                    },
-                                    "name": "timeGetOut",
-                                    "priority": "None",
-                                    "queueFull": "None"
-                                  }
-                                },
-                                "id": 39
-                              }
-                            }
-                          }
-                        },
-                        []
+                        [
+                        ]
                       ]
                     ]
                   },
-                  "id": 40
+                  "id" : 50
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          [],
+          [
+          ],
           {
-            "DefComponent": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "kind": {
-                      "Passive": {}
+            "DefComponent" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "kind" : {
+                      "Passive" : {
+                        
+                      }
                     },
-                    "name": "Health",
-                    "members": [
+                    "name" : "Health",
+                    "members" : [
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "SpecPortInstance": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "General": {
-                                    "kind": {
-                                      "Output": {}
+                          "SpecPortInstance" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "General" : {
+                                    "kind" : {
+                                      "Output" : {
+                                        
+                                      }
                                     },
-                                    "name": "PingSend",
-                                    "size": "None",
-                                    "port": {
-                                      "Some": {
-                                        "AstNode": {
-                                          "data": {
-                                            "Qualified": {
-                                              "qualifier": {
-                                                "AstNode": {
-                                                  "data": {
-                                                    "Unqualified": {
-                                                      "name": "Svc"
+                                    "name" : "PingSend",
+                                    "size" : "None",
+                                    "port" : {
+                                      "Some" : {
+                                        "AstNode" : {
+                                          "data" : {
+                                            "Qualified" : {
+                                              "qualifier" : {
+                                                "AstNode" : {
+                                                  "data" : {
+                                                    "Unqualified" : {
+                                                      "name" : "Svc"
                                                     }
                                                   },
-                                                  "id": 41
+                                                  "id" : 51
                                                 }
                                               },
-                                              "name": {
-                                                "AstNode": {
-                                                  "data": "Ping",
-                                                  "id": 42
+                                              "name" : {
+                                                "AstNode" : {
+                                                  "data" : "Ping",
+                                                  "id" : 52
                                                 }
                                               }
                                             }
                                           },
-                                          "id": 43
+                                          "id" : 53
                                         }
                                       }
                                     },
-                                    "priority": "None",
-                                    "queueFull": "None"
+                                    "priority" : "None",
+                                    "queueFull" : "None"
                                   }
                                 },
-                                "id": 44
+                                "id" : 54
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "SpecPortInstance": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "General": {
-                                    "kind": {
-                                      "SyncInput": {}
+                          "SpecPortInstance" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "General" : {
+                                    "kind" : {
+                                      "SyncInput" : {
+                                        
+                                      }
                                     },
-                                    "name": "PingReturn",
-                                    "size": "None",
-                                    "port": {
-                                      "Some": {
-                                        "AstNode": {
-                                          "data": {
-                                            "Qualified": {
-                                              "qualifier": {
-                                                "AstNode": {
-                                                  "data": {
-                                                    "Unqualified": {
-                                                      "name": "Svc"
+                                    "name" : "PingReturn",
+                                    "size" : "None",
+                                    "port" : {
+                                      "Some" : {
+                                        "AstNode" : {
+                                          "data" : {
+                                            "Qualified" : {
+                                              "qualifier" : {
+                                                "AstNode" : {
+                                                  "data" : {
+                                                    "Unqualified" : {
+                                                      "name" : "Svc"
                                                     }
                                                   },
-                                                  "id": 53
+                                                  "id" : 63
                                                 }
                                               },
-                                              "name": {
-                                                "AstNode": {
-                                                  "data": "Ping",
-                                                  "id": 54
+                                              "name" : {
+                                                "AstNode" : {
+                                                  "data" : "Ping",
+                                                  "id" : 64
                                                 }
                                               }
                                             }
                                           },
-                                          "id": 55
+                                          "id" : 65
                                         }
                                       }
                                     },
-                                    "priority": "None",
-                                    "queueFull": "None"
+                                    "priority" : "None",
+                                    "queueFull" : "None"
                                   }
                                 },
-                                "id": 56
+                                "id" : 66
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ]
                     ]
                   },
-                  "id": 57
+                  "id" : 67
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          [],
+          [
+          ],
           {
-            "DefComponent": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "kind": {
-                      "Passive": {}
+            "DefComponent" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "kind" : {
+                      "Passive" : {
+                        
+                      }
                     },
-                    "name": "Param",
-                    "members": [
+                    "name" : "Param",
+                    "members" : [
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "SpecPortInstance": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "General": {
-                                    "kind": {
-                                      "SyncInput": {}
+                          "SpecPortInstance" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "General" : {
+                                    "kind" : {
+                                      "SyncInput" : {
+                                        
+                                      }
                                     },
-                                    "name": "paramGet",
-                                    "size": "None",
-                                    "port": {
-                                      "Some": {
-                                        "AstNode": {
-                                          "data": {
-                                            "Qualified": {
-                                              "qualifier": {
-                                                "AstNode": {
-                                                  "data": {
-                                                    "Unqualified": {
-                                                      "name": "Fw"
+                                    "name" : "paramGet",
+                                    "size" : "None",
+                                    "port" : {
+                                      "Some" : {
+                                        "AstNode" : {
+                                          "data" : {
+                                            "Qualified" : {
+                                              "qualifier" : {
+                                                "AstNode" : {
+                                                  "data" : {
+                                                    "Unqualified" : {
+                                                      "name" : "Fw"
                                                     }
                                                   },
-                                                  "id": 58
+                                                  "id" : 68
                                                 }
                                               },
-                                              "name": {
-                                                "AstNode": {
-                                                  "data": "PrmGet",
-                                                  "id": 59
+                                              "name" : {
+                                                "AstNode" : {
+                                                  "data" : "PrmGet",
+                                                  "id" : 69
                                                 }
                                               }
                                             }
                                           },
-                                          "id": 60
+                                          "id" : 70
                                         }
                                       }
                                     },
-                                    "priority": "None",
-                                    "queueFull": "None"
+                                    "priority" : "None",
+                                    "queueFull" : "None"
                                   }
                                 },
-                                "id": 61
+                                "id" : 71
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "SpecPortInstance": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "General": {
-                                    "kind": {
-                                      "SyncInput": {}
+                          "SpecPortInstance" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "General" : {
+                                    "kind" : {
+                                      "SyncInput" : {
+                                        
+                                      }
                                     },
-                                    "name": "paramSet",
-                                    "size": "None",
-                                    "port": {
-                                      "Some": {
-                                        "AstNode": {
-                                          "data": {
-                                            "Qualified": {
-                                              "qualifier": {
-                                                "AstNode": {
-                                                  "data": {
-                                                    "Unqualified": {
-                                                      "name": "Fw"
+                                    "name" : "paramSet",
+                                    "size" : "None",
+                                    "port" : {
+                                      "Some" : {
+                                        "AstNode" : {
+                                          "data" : {
+                                            "Qualified" : {
+                                              "qualifier" : {
+                                                "AstNode" : {
+                                                  "data" : {
+                                                    "Unqualified" : {
+                                                      "name" : "Fw"
                                                     }
                                                   },
-                                                  "id": 70
+                                                  "id" : 80
                                                 }
                                               },
-                                              "name": {
-                                                "AstNode": {
-                                                  "data": "PrmSet",
-                                                  "id": 71
+                                              "name" : {
+                                                "AstNode" : {
+                                                  "data" : "PrmSet",
+                                                  "id" : 81
                                                 }
                                               }
                                             }
                                           },
-                                          "id": 72
+                                          "id" : 82
                                         }
                                       }
                                     },
-                                    "priority": "None",
-                                    "queueFull": "None"
+                                    "priority" : "None",
+                                    "queueFull" : "None"
                                   }
                                 },
-                                "id": 73
+                                "id" : 83
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ]
                     ]
                   },
-                  "id": 74
+                  "id" : 84
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          [],
+          [
+          ],
           {
-            "DefComponent": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "kind": {
-                      "Passive": {}
+            "DefComponent" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "kind" : {
+                      "Passive" : {
+                        
+                      }
                     },
-                    "name": "Telemetry",
-                    "members": [
+                    "name" : "Telemetry",
+                    "members" : [
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "SpecPortInstance": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "General": {
-                                    "kind": {
-                                      "SyncInput": {}
+                          "SpecPortInstance" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "General" : {
+                                    "kind" : {
+                                      "SyncInput" : {
+                                        
+                                      }
                                     },
-                                    "name": "tlm",
-                                    "size": "None",
-                                    "port": {
-                                      "Some": {
-                                        "AstNode": {
-                                          "data": {
-                                            "Qualified": {
-                                              "qualifier": {
-                                                "AstNode": {
-                                                  "data": {
-                                                    "Unqualified": {
-                                                      "name": "Fw"
+                                    "name" : "tlm",
+                                    "size" : "None",
+                                    "port" : {
+                                      "Some" : {
+                                        "AstNode" : {
+                                          "data" : {
+                                            "Qualified" : {
+                                              "qualifier" : {
+                                                "AstNode" : {
+                                                  "data" : {
+                                                    "Unqualified" : {
+                                                      "name" : "Fw"
                                                     }
                                                   },
-                                                  "id": 83
+                                                  "id" : 93
                                                 }
                                               },
-                                              "name": {
-                                                "AstNode": {
-                                                  "data": "Tlm",
-                                                  "id": 84
+                                              "name" : {
+                                                "AstNode" : {
+                                                  "data" : "Tlm",
+                                                  "id" : 94
                                                 }
                                               }
                                             }
                                           },
-                                          "id": 85
+                                          "id" : 95
                                         }
                                       }
                                     },
-                                    "priority": "None",
-                                    "queueFull": "None"
+                                    "priority" : "None",
+                                    "queueFull" : "None"
                                   }
                                 },
-                                "id": 86
+                                "id" : 96
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ]
                     ]
                   },
-                  "id": 87
+                  "id" : 97
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          [],
+          [
+          ],
           {
-            "DefComponent": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "kind": {
-                      "Passive": {}
+            "DefComponent" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "kind" : {
+                      "Passive" : {
+                        
+                      }
                     },
-                    "name": "TextEvent",
-                    "members": [
+                    "name" : "TextEvent",
+                    "members" : [
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "SpecPortInstance": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "General": {
-                                    "kind": {
-                                      "SyncInput": {}
+                          "SpecPortInstance" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "General" : {
+                                    "kind" : {
+                                      "SyncInput" : {
+                                        
+                                      }
                                     },
-                                    "name": "textEventLog",
-                                    "size": "None",
-                                    "port": {
-                                      "Some": {
-                                        "AstNode": {
-                                          "data": {
-                                            "Qualified": {
-                                              "qualifier": {
-                                                "AstNode": {
-                                                  "data": {
-                                                    "Unqualified": {
-                                                      "name": "Fw"
+                                    "name" : "textEventLog",
+                                    "size" : "None",
+                                    "port" : {
+                                      "Some" : {
+                                        "AstNode" : {
+                                          "data" : {
+                                            "Qualified" : {
+                                              "qualifier" : {
+                                                "AstNode" : {
+                                                  "data" : {
+                                                    "Unqualified" : {
+                                                      "name" : "Fw"
                                                     }
                                                   },
-                                                  "id": 96
+                                                  "id" : 106
                                                 }
                                               },
-                                              "name": {
-                                                "AstNode": {
-                                                  "data": "LogText",
-                                                  "id": 97
+                                              "name" : {
+                                                "AstNode" : {
+                                                  "data" : "LogText",
+                                                  "id" : 107
                                                 }
                                               }
                                             }
                                           },
-                                          "id": 98
+                                          "id" : 108
                                         }
                                       }
                                     },
-                                    "priority": "None",
-                                    "queueFull": "None"
+                                    "priority" : "None",
+                                    "queueFull" : "None"
                                   }
                                 },
-                                "id": 99
+                                "id" : 109
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ]
                     ]
                   },
-                  "id": 100
+                  "id" : 110
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          [],
+          [
+          ],
           {
-            "DefComponent": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "kind": {
-                      "Passive": {}
+            "DefComponentInstance" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "c1",
+                    "component" : {
+                      "AstNode" : {
+                        "data" : {
+                          "Unqualified" : {
+                            "name" : "Time"
+                          }
+                        },
+                        "id" : 112
+                      }
                     },
-                    "name": "C",
-                    "members": [
-                      [
-                        [],
-                        {
-                          "SpecPortInstance": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "Special": {
-                                    "inputKind": "None",
-                                    "kind": {
-                                      "CommandReg": {}
-                                    },
-                                    "name": "cmdRegOut",
-                                    "priority": "None",
-                                    "queueFull": "None"
-                                  }
-                                },
-                                "id": 101
-                              }
-                            }
+                    "baseId" : {
+                      "AstNode" : {
+                        "data" : {
+                          "ExprLiteralInt" : {
+                            "value" : "0x100"
                           }
                         },
-                        []
-                      ],
-                      [
-                        [],
-                        {
-                          "SpecPortInstance": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "Special": {
-                                    "inputKind": "None",
-                                    "kind": {
-                                      "CommandRecv": {}
-                                    },
-                                    "name": "cmdIn",
-                                    "priority": "None",
-                                    "queueFull": "None"
-                                  }
-                                },
-                                "id": 102
-                              }
-                            }
-                          }
-                        },
-                        []
-                      ],
-                      [
-                        [],
-                        {
-                          "SpecPortInstance": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "Special": {
-                                    "inputKind": "None",
-                                    "kind": {
-                                      "CommandResp": {}
-                                    },
-                                    "name": "cmdResponseOut",
-                                    "priority": "None",
-                                    "queueFull": "None"
-                                  }
-                                },
-                                "id": 105
-                              }
-                            }
-                          }
-                        },
-                        []
-                      ]
+                        "id" : 113
+                      }
+                    },
+                    "implType" : "None",
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecs" : [
                     ]
                   },
-                  "id": 106
+                  "id" : 114
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          [],
+          [
+          ],
           {
-            "DefComponentInstance": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "c",
-                    "component": {
-                      "AstNode": {
-                        "data": {
-                          "Unqualified": {
-                            "name": "C"
+            "DefComponentInstance" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "c2",
+                    "component" : {
+                      "AstNode" : {
+                        "data" : {
+                          "Unqualified" : {
+                            "name" : "Command"
                           }
                         },
-                        "id": 108
+                        "id" : 116
                       }
                     },
-                    "baseId": {
-                      "AstNode": {
-                        "data": {
-                          "ExprLiteralInt": {
-                            "value": "0x100"
+                    "baseId" : {
+                      "AstNode" : {
+                        "data" : {
+                          "ExprLiteralInt" : {
+                            "value" : "0x200"
                           }
                         },
-                        "id": 109
+                        "id" : 117
                       }
                     },
-                    "implType": "None",
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecs": []
+                    "implType" : "None",
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecs" : [
+                    ]
                   },
-                  "id": 110
+                  "id" : 118
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          [],
+          [
+          ],
           {
-            "DefComponentInstance": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "c1",
-                    "component": {
-                      "AstNode": {
-                        "data": {
-                          "Unqualified": {
-                            "name": "Time"
+            "DefComponentInstance" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "c3",
+                    "component" : {
+                      "AstNode" : {
+                        "data" : {
+                          "Unqualified" : {
+                            "name" : "Event"
                           }
                         },
-                        "id": 112
+                        "id" : 120
                       }
                     },
-                    "baseId": {
-                      "AstNode": {
-                        "data": {
-                          "ExprLiteralInt": {
-                            "value": "0x100"
+                    "baseId" : {
+                      "AstNode" : {
+                        "data" : {
+                          "ExprLiteralInt" : {
+                            "value" : "0x300"
                           }
                         },
-                        "id": 113
+                        "id" : 121
                       }
                     },
-                    "implType": "None",
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecs": []
+                    "implType" : "None",
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecs" : [
+                    ]
                   },
-                  "id": 114
+                  "id" : 122
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          [],
+          [
+          ],
           {
-            "DefComponentInstance": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "c2",
-                    "component": {
-                      "AstNode": {
-                        "data": {
-                          "Unqualified": {
-                            "name": "Command"
+            "DefComponentInstance" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "c4",
+                    "component" : {
+                      "AstNode" : {
+                        "data" : {
+                          "Unqualified" : {
+                            "name" : "Health"
                           }
                         },
-                        "id": 116
+                        "id" : 124
                       }
                     },
-                    "baseId": {
-                      "AstNode": {
-                        "data": {
-                          "ExprLiteralInt": {
-                            "value": "0x200"
+                    "baseId" : {
+                      "AstNode" : {
+                        "data" : {
+                          "ExprLiteralInt" : {
+                            "value" : "0x400"
                           }
                         },
-                        "id": 117
+                        "id" : 125
                       }
                     },
-                    "implType": "None",
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecs": []
+                    "implType" : "None",
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecs" : [
+                    ]
                   },
-                  "id": 118
+                  "id" : 126
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          [],
+          [
+          ],
           {
-            "DefComponentInstance": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "c3",
-                    "component": {
-                      "AstNode": {
-                        "data": {
-                          "Unqualified": {
-                            "name": "Event"
+            "DefComponentInstance" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "c5",
+                    "component" : {
+                      "AstNode" : {
+                        "data" : {
+                          "Unqualified" : {
+                            "name" : "Param"
                           }
                         },
-                        "id": 120
+                        "id" : 128
                       }
                     },
-                    "baseId": {
-                      "AstNode": {
-                        "data": {
-                          "ExprLiteralInt": {
-                            "value": "0x300"
+                    "baseId" : {
+                      "AstNode" : {
+                        "data" : {
+                          "ExprLiteralInt" : {
+                            "value" : "0x500"
                           }
                         },
-                        "id": 121
+                        "id" : 129
                       }
                     },
-                    "implType": "None",
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecs": []
+                    "implType" : "None",
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecs" : [
+                    ]
                   },
-                  "id": 122
+                  "id" : 130
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          [],
+          [
+          ],
           {
-            "DefComponentInstance": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "c4",
-                    "component": {
-                      "AstNode": {
-                        "data": {
-                          "Unqualified": {
-                            "name": "Health"
+            "DefComponentInstance" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "c6",
+                    "component" : {
+                      "AstNode" : {
+                        "data" : {
+                          "Unqualified" : {
+                            "name" : "Telemetry"
                           }
                         },
-                        "id": 124
+                        "id" : 132
                       }
                     },
-                    "baseId": {
-                      "AstNode": {
-                        "data": {
-                          "ExprLiteralInt": {
-                            "value": "0x400"
+                    "baseId" : {
+                      "AstNode" : {
+                        "data" : {
+                          "ExprLiteralInt" : {
+                            "value" : "0x600"
                           }
                         },
-                        "id": 125
+                        "id" : 133
                       }
                     },
-                    "implType": "None",
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecs": []
+                    "implType" : "None",
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecs" : [
+                    ]
                   },
-                  "id": 126
+                  "id" : 134
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          [],
+          [
+          ],
           {
-            "DefComponentInstance": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "c5",
-                    "component": {
-                      "AstNode": {
-                        "data": {
-                          "Unqualified": {
-                            "name": "Param"
+            "DefComponentInstance" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "c7",
+                    "component" : {
+                      "AstNode" : {
+                        "data" : {
+                          "Unqualified" : {
+                            "name" : "TextEvent"
                           }
                         },
-                        "id": 128
+                        "id" : 136
                       }
                     },
-                    "baseId": {
-                      "AstNode": {
-                        "data": {
-                          "ExprLiteralInt": {
-                            "value": "0x500"
+                    "baseId" : {
+                      "AstNode" : {
+                        "data" : {
+                          "ExprLiteralInt" : {
+                            "value" : "0x700"
                           }
                         },
-                        "id": 129
+                        "id" : 137
                       }
                     },
-                    "implType": "None",
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecs": []
+                    "implType" : "None",
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecs" : [
+                    ]
                   },
-                  "id": 130
+                  "id" : 138
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          [],
+          [
+          ],
           {
-            "DefComponentInstance": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "c6",
-                    "component": {
-                      "AstNode": {
-                        "data": {
-                          "Unqualified": {
-                            "name": "Telemetry"
-                          }
-                        },
-                        "id": 132
-                      }
-                    },
-                    "baseId": {
-                      "AstNode": {
-                        "data": {
-                          "ExprLiteralInt": {
-                            "value": "0x600"
-                          }
-                        },
-                        "id": 133
-                      }
-                    },
-                    "implType": "None",
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecs": []
-                  },
-                  "id": 134
-                }
-              }
-            }
-          },
-          []
-        ],
-        [
-          [],
-          {
-            "DefComponentInstance": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "c7",
-                    "component": {
-                      "AstNode": {
-                        "data": {
-                          "Unqualified": {
-                            "name": "TextEvent"
-                          }
-                        },
-                        "id": 136
-                      }
-                    },
-                    "baseId": {
-                      "AstNode": {
-                        "data": {
-                          "ExprLiteralInt": {
-                            "value": "0x700"
-                          }
-                        },
-                        "id": 137
-                      }
-                    },
-                    "implType": "None",
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecs": []
-                  },
-                  "id": 138
-                }
-              }
-            }
-          },
-          []
-        ],
-        [
-          [],
-          {
-            "DefTopology": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "T",
-                    "members": [
+            "DefTopology" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "T",
+                    "members" : [
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "SpecCompInstance": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "visibility": {
-                                    "Public": {}
+                          "SpecCompInstance" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "visibility" : {
+                                    "Public" : {
+                                      
+                                    }
                                   },
-                                  "instance": {
-                                    "AstNode": {
-                                      "data": {
-                                        "Unqualified": {
-                                          "name": "c"
+                                  "instance" : {
+                                    "AstNode" : {
+                                      "data" : {
+                                        "Unqualified" : {
+                                          "name" : "c1"
                                         }
                                       },
-                                      "id": 140
+                                      "id" : 238
                                     }
                                   }
                                 },
-                                "id": 141
+                                "id" : 239
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "SpecCompInstance": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "visibility": {
-                                    "Public": {}
+                          "SpecCompInstance" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "visibility" : {
+                                    "Public" : {
+                                      
+                                    }
                                   },
-                                  "instance": {
-                                    "AstNode": {
-                                      "data": {
-                                        "Unqualified": {
-                                          "name": "c1"
+                                  "instance" : {
+                                    "AstNode" : {
+                                      "data" : {
+                                        "Unqualified" : {
+                                          "name" : "c2"
                                         }
                                       },
-                                      "id": 143
+                                      "id" : 241
                                     }
                                   }
                                 },
-                                "id": 144
+                                "id" : 242
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "SpecCompInstance": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "visibility": {
-                                    "Public": {}
+                          "SpecCompInstance" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "visibility" : {
+                                    "Public" : {
+                                      
+                                    }
                                   },
-                                  "instance": {
-                                    "AstNode": {
-                                      "data": {
-                                        "Unqualified": {
-                                          "name": "c2"
+                                  "instance" : {
+                                    "AstNode" : {
+                                      "data" : {
+                                        "Unqualified" : {
+                                          "name" : "c3"
                                         }
                                       },
-                                      "id": 146
+                                      "id" : 244
                                     }
                                   }
                                 },
-                                "id": 147
+                                "id" : 245
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "SpecCompInstance": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "visibility": {
-                                    "Public": {}
+                          "SpecCompInstance" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "visibility" : {
+                                    "Public" : {
+                                      
+                                    }
                                   },
-                                  "instance": {
-                                    "AstNode": {
-                                      "data": {
-                                        "Unqualified": {
-                                          "name": "c3"
+                                  "instance" : {
+                                    "AstNode" : {
+                                      "data" : {
+                                        "Unqualified" : {
+                                          "name" : "c4"
                                         }
                                       },
-                                      "id": 149
+                                      "id" : 247
                                     }
                                   }
                                 },
-                                "id": 150
+                                "id" : 248
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "SpecCompInstance": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "visibility": {
-                                    "Public": {}
+                          "SpecCompInstance" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "visibility" : {
+                                    "Public" : {
+                                      
+                                    }
                                   },
-                                  "instance": {
-                                    "AstNode": {
-                                      "data": {
-                                        "Unqualified": {
-                                          "name": "c4"
+                                  "instance" : {
+                                    "AstNode" : {
+                                      "data" : {
+                                        "Unqualified" : {
+                                          "name" : "c5"
                                         }
                                       },
-                                      "id": 152
+                                      "id" : 250
                                     }
                                   }
                                 },
-                                "id": 153
+                                "id" : 251
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "SpecCompInstance": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "visibility": {
-                                    "Public": {}
+                          "SpecCompInstance" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "visibility" : {
+                                    "Public" : {
+                                      
+                                    }
                                   },
-                                  "instance": {
-                                    "AstNode": {
-                                      "data": {
-                                        "Unqualified": {
-                                          "name": "c5"
+                                  "instance" : {
+                                    "AstNode" : {
+                                      "data" : {
+                                        "Unqualified" : {
+                                          "name" : "c6"
                                         }
                                       },
-                                      "id": 155
+                                      "id" : 253
                                     }
                                   }
                                 },
-                                "id": 156
+                                "id" : 254
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "SpecCompInstance": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "visibility": {
-                                    "Public": {}
+                          "SpecCompInstance" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "visibility" : {
+                                    "Public" : {
+                                      
+                                    }
                                   },
-                                  "instance": {
-                                    "AstNode": {
-                                      "data": {
-                                        "Unqualified": {
-                                          "name": "c6"
+                                  "instance" : {
+                                    "AstNode" : {
+                                      "data" : {
+                                        "Unqualified" : {
+                                          "name" : "c7"
                                         }
                                       },
-                                      "id": 158
+                                      "id" : 256
                                     }
                                   }
                                 },
-                                "id": 159
+                                "id" : 257
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "SpecCompInstance": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "visibility": {
-                                    "Public": {}
-                                  },
-                                  "instance": {
-                                    "AstNode": {
-                                      "data": {
-                                        "Unqualified": {
-                                          "name": "c7"
-                                        }
-                                      },
-                                      "id": 161
-                                    }
-                                  }
-                                },
-                                "id": 162
-                              }
-                            }
-                          }
-                        },
-                        []
-                      ],
-                      [
-                        [],
-                        {
-                          "SpecConnectionGraph": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "Pattern": {
-                                    "kind": {
-                                      "Time": {}
+                          "SpecConnectionGraph" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "Pattern" : {
+                                    "kind" : {
+                                      "Time" : {
+                                        
+                                      }
                                     },
-                                    "source": {
-                                      "AstNode": {
-                                        "data": {
-                                          "Unqualified": {
-                                            "name": "c1"
+                                    "source" : {
+                                      "AstNode" : {
+                                        "data" : {
+                                          "Unqualified" : {
+                                            "name" : "c1"
                                           }
                                         },
-                                        "id": 164
+                                        "id" : 259
                                       }
                                     },
-                                    "targets": []
-                                  }
-                                },
-                                "id": 165
-                              }
-                            }
-                          }
-                        },
-                        []
-                      ],
-                      [
-                        [],
-                        {
-                          "SpecConnectionGraph": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "Pattern": {
-                                    "kind": {
-                                      "Command": {}
-                                    },
-                                    "source": {
-                                      "AstNode": {
-                                        "data": {
-                                          "Unqualified": {
-                                            "name": "c2"
-                                          }
-                                        },
-                                        "id": 167
-                                      }
-                                    },
-                                    "targets": [
-                                      {
-                                        "AstNode": {
-                                          "data": {
-                                            "Unqualified": {
-                                              "name": "c"
-                                            }
-                                          },
-                                          "id": 169
-                                        }
-                                      }
+                                    "targets" : [
                                     ]
                                   }
                                 },
-                                "id": 170
+                                "id" : 260
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "SpecConnectionGraph": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "Pattern": {
-                                    "kind": {
-                                      "Event": {}
-                                    },
-                                    "source": {
-                                      "AstNode": {
-                                        "data": {
-                                          "Unqualified": {
-                                            "name": "c3"
-                                          }
-                                        },
-                                        "id": 172
+                          "SpecConnectionGraph" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "Pattern" : {
+                                    "kind" : {
+                                      "Command" : {
+                                        
                                       }
                                     },
-                                    "targets": []
+                                    "source" : {
+                                      "AstNode" : {
+                                        "data" : {
+                                          "Unqualified" : {
+                                            "name" : "c2"
+                                          }
+                                        },
+                                        "id" : 262
+                                      }
+                                    },
+                                    "targets" : [
+                                    ]
                                   }
                                 },
-                                "id": 173
+                                "id" : 263
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "SpecConnectionGraph": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "Pattern": {
-                                    "kind": {
-                                      "Health": {}
-                                    },
-                                    "source": {
-                                      "AstNode": {
-                                        "data": {
-                                          "Unqualified": {
-                                            "name": "c4"
-                                          }
-                                        },
-                                        "id": 175
+                          "SpecConnectionGraph" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "Pattern" : {
+                                    "kind" : {
+                                      "Event" : {
+                                        
                                       }
                                     },
-                                    "targets": []
+                                    "source" : {
+                                      "AstNode" : {
+                                        "data" : {
+                                          "Unqualified" : {
+                                            "name" : "c3"
+                                          }
+                                        },
+                                        "id" : 265
+                                      }
+                                    },
+                                    "targets" : [
+                                    ]
                                   }
                                 },
-                                "id": 176
+                                "id" : 266
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "SpecConnectionGraph": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "Pattern": {
-                                    "kind": {
-                                      "Param": {}
-                                    },
-                                    "source": {
-                                      "AstNode": {
-                                        "data": {
-                                          "Unqualified": {
-                                            "name": "c5"
-                                          }
-                                        },
-                                        "id": 178
+                          "SpecConnectionGraph" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "Pattern" : {
+                                    "kind" : {
+                                      "Health" : {
+                                        
                                       }
                                     },
-                                    "targets": []
+                                    "source" : {
+                                      "AstNode" : {
+                                        "data" : {
+                                          "Unqualified" : {
+                                            "name" : "c4"
+                                          }
+                                        },
+                                        "id" : 268
+                                      }
+                                    },
+                                    "targets" : [
+                                    ]
                                   }
                                 },
-                                "id": 179
+                                "id" : 269
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "SpecConnectionGraph": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "Pattern": {
-                                    "kind": {
-                                      "Telemetry": {}
-                                    },
-                                    "source": {
-                                      "AstNode": {
-                                        "data": {
-                                          "Unqualified": {
-                                            "name": "c6"
-                                          }
-                                        },
-                                        "id": 181
+                          "SpecConnectionGraph" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "Pattern" : {
+                                    "kind" : {
+                                      "Param" : {
+                                        
                                       }
                                     },
-                                    "targets": []
+                                    "source" : {
+                                      "AstNode" : {
+                                        "data" : {
+                                          "Unqualified" : {
+                                            "name" : "c5"
+                                          }
+                                        },
+                                        "id" : 271
+                                      }
+                                    },
+                                    "targets" : [
+                                    ]
                                   }
                                 },
-                                "id": 182
+                                "id" : 272
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "SpecConnectionGraph": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "Pattern": {
-                                    "kind": {
-                                      "TextEvent": {}
-                                    },
-                                    "source": {
-                                      "AstNode": {
-                                        "data": {
-                                          "Unqualified": {
-                                            "name": "c7"
-                                          }
-                                        },
-                                        "id": 190
+                          "SpecConnectionGraph" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "Pattern" : {
+                                    "kind" : {
+                                      "Telemetry" : {
+                                        
                                       }
                                     },
-                                    "targets": []
+                                    "source" : {
+                                      "AstNode" : {
+                                        "data" : {
+                                          "Unqualified" : {
+                                            "name" : "c6"
+                                          }
+                                        },
+                                        "id" : 274
+                                      }
+                                    },
+                                    "targets" : [
+                                    ]
                                   }
                                 },
-                                "id": 191
+                                "id" : 275
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
+                      ],
+                      [
+                        [
+                        ],
+                        {
+                          "SpecConnectionGraph" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "Pattern" : {
+                                    "kind" : {
+                                      "TextEvent" : {
+                                        
+                                      }
+                                    },
+                                    "source" : {
+                                      "AstNode" : {
+                                        "data" : {
+                                          "Unqualified" : {
+                                            "name" : "c7"
+                                          }
+                                        },
+                                        "id" : 283
+                                      }
+                                    },
+                                    "targets" : [
+                                    ]
+                                  }
+                                },
+                                "id" : 284
+                              }
+                            }
+                          }
+                        },
+                        [
+                        ]
                       ]
                     ]
                   },
-                  "id": 192
+                  "id" : 285
                 }
               }
             }
           },
-          []
+          [
+          ]
         ]
       ]
     },
     {
-      "members": [
+      "members" : [
         [
-          [],
+          [
+          ],
           {
-            "DefModule": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "Fw",
-                    "members": [
+            "DefModule" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "Fw",
+                    "members" : [
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "DefPort": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "name": "Cmd",
-                                  "params": [],
-                                  "returnType": "None"
+                          "DefPort" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "name" : "Cmd",
+                                  "params" : [
+                                  ],
+                                  "returnType" : "None"
                                 },
-                                "id": 193
+                                "id" : 286
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "DefPort": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "name": "CmdReg",
-                                  "params": [],
-                                  "returnType": "None"
+                          "DefPort" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "name" : "CmdReg",
+                                  "params" : [
+                                  ],
+                                  "returnType" : "None"
                                 },
-                                "id": 194
+                                "id" : 287
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "DefPort": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "name": "CmdResponse",
-                                  "params": [],
-                                  "returnType": "None"
+                          "DefPort" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "name" : "CmdResponse",
+                                  "params" : [
+                                  ],
+                                  "returnType" : "None"
                                 },
-                                "id": 195
+                                "id" : 288
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "DefPort": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "name": "Log",
-                                  "params": [],
-                                  "returnType": "None"
+                          "DefPort" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "name" : "Log",
+                                  "params" : [
+                                  ],
+                                  "returnType" : "None"
                                 },
-                                "id": 196
+                                "id" : 289
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "DefPort": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "name": "LogText",
-                                  "params": [],
-                                  "returnType": "None"
+                          "DefPort" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "name" : "LogText",
+                                  "params" : [
+                                  ],
+                                  "returnType" : "None"
                                 },
-                                "id": 197
+                                "id" : 290
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "DefPort": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "name": "PrmGet",
-                                  "params": [],
-                                  "returnType": "None"
+                          "DefPort" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "name" : "PrmGet",
+                                  "params" : [
+                                  ],
+                                  "returnType" : "None"
                                 },
-                                "id": 198
+                                "id" : 291
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "DefPort": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "name": "PrmSet",
-                                  "params": [],
-                                  "returnType": "None"
+                          "DefPort" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "name" : "PrmSet",
+                                  "params" : [
+                                  ],
+                                  "returnType" : "None"
                                 },
-                                "id": 199
+                                "id" : 292
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "DefPort": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "name": "Time",
-                                  "params": [],
-                                  "returnType": "None"
+                          "DefPort" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "name" : "Time",
+                                  "params" : [
+                                  ],
+                                  "returnType" : "None"
                                 },
-                                "id": 200
+                                "id" : 293
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "DefPort": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "name": "Tlm",
-                                  "params": [],
-                                  "returnType": "None"
+                          "DefPort" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "name" : "Tlm",
+                                  "params" : [
+                                  ],
+                                  "returnType" : "None"
                                 },
-                                "id": 201
+                                "id" : 294
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "DefPort": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "name": "TlmGet",
-                                  "params": [],
-                                  "returnType": "None"
+                          "DefPort" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "name" : "TlmGet",
+                                  "params" : [
+                                  ],
+                                  "returnType" : "None"
                                 },
-                                "id": 204
+                                "id" : 297
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ]
                     ]
                   },
-                  "id": 205
+                  "id" : 298
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          [],
+          [
+          ],
           {
-            "DefModule": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "Svc",
-                    "members": [
+            "DefModule" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "Svc",
+                    "members" : [
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "DefPort": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "name": "Ping",
-                                  "params": [],
-                                  "returnType": "None"
+                          "DefPort" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "name" : "Ping",
+                                  "params" : [
+                                  ],
+                                  "returnType" : "None"
                                 },
-                                "id": 208
+                                "id" : 301
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ]
                     ]
                   },
-                  "id": 209
+                  "id" : 302
                 }
               }
             }
           },
-          []
+          [
+          ]
         ]
       ]
     }

--- a/tests/patterned_connections/patterned_connections_locations.json
+++ b/tests/patterned_connections/patterned_connections_locations.json
@@ -1,1055 +1,1520 @@
 {
-  "fppVersion": "v3.1.0a10",
-  "locationMap": {
-    "0": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "2.34",
-      "includingLoc": "None"
-    },
-    "1": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "2.37",
-      "includingLoc": "None"
-    },
-    "2": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "2.34",
-      "includingLoc": "None"
-    },
-    "3": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "2.5",
-      "includingLoc": "None"
-    },
-    "4": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "4.5",
-      "includingLoc": "None"
-    },
-    "5": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "4.5",
-      "includingLoc": "None"
-    },
-    "6": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "4.5",
-      "includingLoc": "None"
-    },
-    "7": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "1.1",
-      "includingLoc": "None"
-    },
-    "8": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "8.28",
-      "includingLoc": "None"
-    },
-    "9": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "8.31",
-      "includingLoc": "None"
-    },
-    "10": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "8.28",
-      "includingLoc": "None"
-    },
-    "11": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "8.5",
-      "includingLoc": "None"
-    },
-    "12": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "9.32",
-      "includingLoc": "None"
-    },
-    "13": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "9.35",
-      "includingLoc": "None"
-    },
-    "14": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "9.32",
-      "includingLoc": "None"
-    },
-    "15": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "9.5",
-      "includingLoc": "None"
-    },
-    "16": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "10.37",
-      "includingLoc": "None"
-    },
-    "17": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "10.40",
-      "includingLoc": "None"
-    },
-    "18": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "10.37",
-      "includingLoc": "None"
-    },
-    "19": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "10.5",
-      "includingLoc": "None"
-    },
-    "20": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "11.26",
-      "includingLoc": "None"
-    },
-    "21": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "11.29",
-      "includingLoc": "None"
-    },
-    "22": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "11.26",
-      "includingLoc": "None"
-    },
-    "23": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "11.5",
-      "includingLoc": "None"
-    },
-    "24": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "11.26",
-      "includingLoc": "None"
-    },
-    "25": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "11.29",
-      "includingLoc": "None"
-    },
-    "26": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "11.26",
-      "includingLoc": "None"
-    },
-    "27": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "11.5",
-      "includingLoc": "None"
-    },
-    "28": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "11.26",
-      "includingLoc": "None"
-    },
-    "29": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "11.29",
-      "includingLoc": "None"
-    },
-    "30": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "11.26",
-      "includingLoc": "None"
-    },
-    "31": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "11.5",
-      "includingLoc": "None"
-    },
-    "32": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "7.1",
-      "includingLoc": "None"
-    },
-    "33": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "15.31",
-      "includingLoc": "None"
-    },
-    "34": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "15.34",
-      "includingLoc": "None"
-    },
-    "35": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "15.31",
-      "includingLoc": "None"
-    },
-    "36": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "15.5",
-      "includingLoc": "None"
-    },
-    "37": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "16.5",
-      "includingLoc": "None"
-    },
-    "38": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "16.5",
-      "includingLoc": "None"
-    },
-    "39": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "16.5",
-      "includingLoc": "None"
-    },
-    "40": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "14.1",
-      "includingLoc": "None"
-    },
-    "41": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "21.27",
-      "includingLoc": "None"
-    },
-    "42": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "21.31",
-      "includingLoc": "None"
-    },
-    "43": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "21.27",
-      "includingLoc": "None"
-    },
-    "44": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "21.5",
-      "includingLoc": "None"
-    },
-    "45": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "22.33",
-      "includingLoc": "None"
-    },
-    "46": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "22.37",
-      "includingLoc": "None"
-    },
-    "47": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "22.33",
-      "includingLoc": "None"
-    },
-    "48": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "22.5",
-      "includingLoc": "None"
-    },
-    "49": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "22.33",
-      "includingLoc": "None"
-    },
-    "50": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "22.37",
-      "includingLoc": "None"
-    },
-    "51": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "22.33",
-      "includingLoc": "None"
-    },
-    "52": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "22.5",
-      "includingLoc": "None"
-    },
-    "53": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "22.33",
-      "includingLoc": "None"
-    },
-    "54": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "22.37",
-      "includingLoc": "None"
-    },
-    "55": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "22.33",
-      "includingLoc": "None"
-    },
-    "56": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "22.5",
-      "includingLoc": "None"
-    },
-    "57": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "20.1",
-      "includingLoc": "None"
-    },
-    "58": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "26.31",
-      "includingLoc": "None"
-    },
-    "59": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "26.34",
-      "includingLoc": "None"
-    },
-    "60": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "26.31",
-      "includingLoc": "None"
-    },
-    "61": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "26.5",
-      "includingLoc": "None"
-    },
-    "62": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "27.31",
-      "includingLoc": "None"
-    },
-    "63": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "27.34",
-      "includingLoc": "None"
-    },
-    "64": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "27.31",
-      "includingLoc": "None"
-    },
-    "65": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "27.5",
-      "includingLoc": "None"
-    },
-    "66": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "27.31",
-      "includingLoc": "None"
-    },
-    "67": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "27.34",
-      "includingLoc": "None"
-    },
-    "68": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "27.31",
-      "includingLoc": "None"
-    },
-    "69": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "27.5",
-      "includingLoc": "None"
-    },
-    "70": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "27.31",
-      "includingLoc": "None"
-    },
-    "71": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "27.34",
-      "includingLoc": "None"
-    },
-    "72": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "27.31",
-      "includingLoc": "None"
-    },
-    "73": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "27.5",
-      "includingLoc": "None"
-    },
-    "74": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "25.1",
-      "includingLoc": "None"
-    },
-    "75": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "31.26",
-      "includingLoc": "None"
-    },
-    "76": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "31.29",
-      "includingLoc": "None"
-    },
-    "77": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "31.26",
-      "includingLoc": "None"
-    },
-    "78": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "31.5",
-      "includingLoc": "None"
-    },
-    "79": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "31.26",
-      "includingLoc": "None"
-    },
-    "80": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "31.29",
-      "includingLoc": "None"
-    },
-    "81": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "31.26",
-      "includingLoc": "None"
-    },
-    "82": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "31.5",
-      "includingLoc": "None"
-    },
-    "83": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "31.26",
-      "includingLoc": "None"
-    },
-    "84": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "31.29",
-      "includingLoc": "None"
-    },
-    "85": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "31.26",
-      "includingLoc": "None"
-    },
-    "86": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "31.5",
-      "includingLoc": "None"
-    },
-    "87": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "30.1",
-      "includingLoc": "None"
-    },
-    "88": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "35.35",
-      "includingLoc": "None"
-    },
-    "89": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "35.38",
-      "includingLoc": "None"
-    },
-    "90": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "35.35",
-      "includingLoc": "None"
-    },
-    "91": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "35.5",
-      "includingLoc": "None"
-    },
-    "92": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "35.35",
-      "includingLoc": "None"
-    },
-    "93": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "35.38",
-      "includingLoc": "None"
-    },
-    "94": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "35.35",
-      "includingLoc": "None"
-    },
-    "95": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "35.5",
-      "includingLoc": "None"
-    },
-    "96": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "35.35",
-      "includingLoc": "None"
-    },
-    "97": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "35.38",
-      "includingLoc": "None"
-    },
-    "98": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "35.35",
-      "includingLoc": "None"
-    },
-    "99": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "35.5",
-      "includingLoc": "None"
-    },
-    "100": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "34.1",
-      "includingLoc": "None"
-    },
-    "101": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "39.5",
-      "includingLoc": "None"
-    },
-    "102": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "40.5",
-      "includingLoc": "None"
-    },
-    "103": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "41.5",
-      "includingLoc": "None"
-    },
-    "104": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "41.5",
-      "includingLoc": "None"
-    },
-    "105": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "41.5",
-      "includingLoc": "None"
-    },
-    "106": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "38.1",
-      "includingLoc": "None"
-    },
-    "107": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "44.13",
-      "includingLoc": "None"
-    },
-    "108": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "44.13",
-      "includingLoc": "None"
-    },
-    "109": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "44.23",
-      "includingLoc": "None"
-    },
-    "110": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "44.1",
-      "includingLoc": "None"
-    },
-    "111": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "45.14",
-      "includingLoc": "None"
-    },
-    "112": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "45.14",
-      "includingLoc": "None"
-    },
-    "113": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "45.27",
-      "includingLoc": "None"
-    },
-    "114": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "45.1",
-      "includingLoc": "None"
-    },
-    "115": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "46.14",
-      "includingLoc": "None"
-    },
-    "116": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "46.14",
-      "includingLoc": "None"
-    },
-    "117": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "46.30",
-      "includingLoc": "None"
-    },
-    "118": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "46.1",
-      "includingLoc": "None"
-    },
-    "119": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "47.14",
-      "includingLoc": "None"
-    },
-    "120": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "47.14",
-      "includingLoc": "None"
-    },
-    "121": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "47.28",
-      "includingLoc": "None"
-    },
-    "122": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "47.1",
-      "includingLoc": "None"
-    },
-    "123": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "48.14",
-      "includingLoc": "None"
-    },
-    "124": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "48.14",
-      "includingLoc": "None"
-    },
-    "125": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "48.29",
-      "includingLoc": "None"
-    },
-    "126": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "48.1",
-      "includingLoc": "None"
-    },
-    "127": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "49.14",
-      "includingLoc": "None"
-    },
-    "128": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "49.14",
-      "includingLoc": "None"
-    },
-    "129": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "49.28",
-      "includingLoc": "None"
-    },
-    "130": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "49.1",
-      "includingLoc": "None"
-    },
-    "131": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "50.14",
-      "includingLoc": "None"
-    },
-    "132": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "50.14",
-      "includingLoc": "None"
-    },
-    "133": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "50.32",
-      "includingLoc": "None"
-    },
-    "134": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "50.1",
-      "includingLoc": "None"
-    },
-    "135": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "51.14",
-      "includingLoc": "None"
-    },
-    "136": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "51.14",
-      "includingLoc": "None"
-    },
-    "137": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "51.32",
-      "includingLoc": "None"
-    },
-    "138": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "51.1",
-      "includingLoc": "None"
-    },
-    "139": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "54.14",
-      "includingLoc": "None"
-    },
-    "140": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "54.14",
-      "includingLoc": "None"
-    },
-    "141": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "54.5",
-      "includingLoc": "None"
-    },
-    "142": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "55.14",
-      "includingLoc": "None"
-    },
-    "143": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "55.14",
-      "includingLoc": "None"
-    },
-    "144": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "55.5",
-      "includingLoc": "None"
-    },
-    "145": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "56.14",
-      "includingLoc": "None"
-    },
-    "146": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "56.14",
-      "includingLoc": "None"
-    },
-    "147": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "56.5",
-      "includingLoc": "None"
-    },
-    "148": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "57.14",
-      "includingLoc": "None"
-    },
-    "149": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "57.14",
-      "includingLoc": "None"
-    },
-    "150": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "57.5",
-      "includingLoc": "None"
-    },
-    "151": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "58.14",
-      "includingLoc": "None"
-    },
-    "152": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "58.14",
-      "includingLoc": "None"
-    },
-    "153": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "58.5",
-      "includingLoc": "None"
-    },
-    "154": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "59.14",
-      "includingLoc": "None"
-    },
-    "155": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "59.14",
-      "includingLoc": "None"
-    },
-    "156": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "59.5",
-      "includingLoc": "None"
-    },
-    "157": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "60.14",
-      "includingLoc": "None"
-    },
-    "158": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "60.14",
-      "includingLoc": "None"
-    },
-    "159": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "60.5",
-      "includingLoc": "None"
-    },
-    "160": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "61.14",
-      "includingLoc": "None"
-    },
-    "161": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "61.14",
-      "includingLoc": "None"
-    },
-    "162": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "61.5",
-      "includingLoc": "None"
-    },
-    "163": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "63.31",
-      "includingLoc": "None"
-    },
-    "164": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "63.31",
-      "includingLoc": "None"
-    },
-    "165": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "63.5",
-      "includingLoc": "None"
-    },
-    "166": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "64.34",
-      "includingLoc": "None"
-    },
-    "167": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "64.34",
-      "includingLoc": "None"
-    },
-    "168": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "64.39",
-      "includingLoc": "None"
-    },
-    "169": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "64.39",
-      "includingLoc": "None"
-    },
-    "170": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "64.5",
-      "includingLoc": "None"
-    },
-    "171": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "65.32",
-      "includingLoc": "None"
-    },
-    "172": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "65.32",
-      "includingLoc": "None"
-    },
-    "173": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "65.5",
-      "includingLoc": "None"
-    },
-    "174": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "66.33",
-      "includingLoc": "None"
-    },
-    "175": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "66.33",
-      "includingLoc": "None"
-    },
-    "176": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "66.5",
-      "includingLoc": "None"
-    },
-    "177": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "67.32",
-      "includingLoc": "None"
-    },
-    "178": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "67.32",
-      "includingLoc": "None"
-    },
-    "179": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "67.5",
-      "includingLoc": "None"
-    },
-    "180": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "68.36",
-      "includingLoc": "None"
-    },
-    "181": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "68.36",
-      "includingLoc": "None"
-    },
-    "182": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "68.5",
-      "includingLoc": "None"
-    },
-    "183": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "69.37",
-      "includingLoc": "None"
-    },
-    "184": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "69.37",
-      "includingLoc": "None"
-    },
-    "185": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "69.5",
-      "includingLoc": "None"
-    },
-    "186": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "69.37",
-      "includingLoc": "None"
-    },
-    "187": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "69.37",
-      "includingLoc": "None"
-    },
-    "188": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "69.5",
-      "includingLoc": "None"
-    },
-    "189": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "69.37",
-      "includingLoc": "None"
-    },
-    "190": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "69.37",
-      "includingLoc": "None"
-    },
-    "191": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "69.5",
-      "includingLoc": "None"
-    },
-    "192": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
-      "pos": "53.1",
-      "includingLoc": "None"
-    },
-    "193": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/fprime/defs.fpp",
-      "pos": "4.3",
-      "includingLoc": "None"
-    },
-    "194": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/fprime/defs.fpp",
-      "pos": "5.3",
-      "includingLoc": "None"
-    },
-    "195": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/fprime/defs.fpp",
-      "pos": "6.3",
-      "includingLoc": "None"
-    },
-    "196": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/fprime/defs.fpp",
-      "pos": "7.3",
-      "includingLoc": "None"
-    },
-    "197": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/fprime/defs.fpp",
-      "pos": "8.3",
-      "includingLoc": "None"
-    },
-    "198": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/fprime/defs.fpp",
-      "pos": "9.3",
-      "includingLoc": "None"
-    },
-    "199": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/fprime/defs.fpp",
-      "pos": "10.3",
-      "includingLoc": "None"
-    },
-    "200": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/fprime/defs.fpp",
-      "pos": "11.3",
-      "includingLoc": "None"
-    },
-    "201": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/fprime/defs.fpp",
-      "pos": "12.3",
-      "includingLoc": "None"
-    },
-    "202": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/fprime/defs.fpp",
-      "pos": "13.3",
-      "includingLoc": "None"
-    },
-    "203": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/fprime/defs.fpp",
-      "pos": "13.3",
-      "includingLoc": "None"
-    },
-    "204": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/fprime/defs.fpp",
-      "pos": "13.3",
-      "includingLoc": "None"
-    },
-    "205": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/fprime/defs.fpp",
-      "pos": "3.1",
-      "includingLoc": "None"
-    },
-    "206": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/fprime/defs.fpp",
-      "pos": "17.3",
-      "includingLoc": "None"
-    },
-    "207": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/fprime/defs.fpp",
-      "pos": "17.3",
-      "includingLoc": "None"
-    },
-    "208": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/fprime/defs.fpp",
-      "pos": "17.3",
-      "includingLoc": "None"
-    },
-    "209": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/fprime/defs.fpp",
-      "pos": "16.1",
-      "includingLoc": "None"
+  "fppVersion" : "v3.1.0a10-54-g11243e778",
+  "locationMap" : {
+    "0" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "2.34",
+      "includingLoc" : "None"
+    },
+    "1" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "2.37",
+      "includingLoc" : "None"
+    },
+    "2" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "2.34",
+      "includingLoc" : "None"
+    },
+    "3" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "2.5",
+      "includingLoc" : "None"
+    },
+    "4" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "2.34",
+      "includingLoc" : "None"
+    },
+    "5" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "2.37",
+      "includingLoc" : "None"
+    },
+    "6" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "2.34",
+      "includingLoc" : "None"
+    },
+    "7" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "2.5",
+      "includingLoc" : "None"
+    },
+    "8" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "2.34",
+      "includingLoc" : "None"
+    },
+    "9" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "2.37",
+      "includingLoc" : "None"
+    },
+    "10" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "2.34",
+      "includingLoc" : "None"
+    },
+    "11" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "2.5",
+      "includingLoc" : "None"
+    },
+    "12" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "1.1",
+      "includingLoc" : "None"
+    },
+    "13" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "6.28",
+      "includingLoc" : "None"
+    },
+    "14" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "6.31",
+      "includingLoc" : "None"
+    },
+    "15" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "6.28",
+      "includingLoc" : "None"
+    },
+    "16" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "6.5",
+      "includingLoc" : "None"
+    },
+    "17" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "7.32",
+      "includingLoc" : "None"
+    },
+    "18" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "7.35",
+      "includingLoc" : "None"
+    },
+    "19" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "7.32",
+      "includingLoc" : "None"
+    },
+    "20" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "7.5",
+      "includingLoc" : "None"
+    },
+    "21" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "8.37",
+      "includingLoc" : "None"
+    },
+    "22" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "8.40",
+      "includingLoc" : "None"
+    },
+    "23" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "8.37",
+      "includingLoc" : "None"
+    },
+    "24" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "8.5",
+      "includingLoc" : "None"
+    },
+    "25" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "9.26",
+      "includingLoc" : "None"
+    },
+    "26" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "9.29",
+      "includingLoc" : "None"
+    },
+    "27" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "9.26",
+      "includingLoc" : "None"
+    },
+    "28" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "9.5",
+      "includingLoc" : "None"
+    },
+    "29" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "9.26",
+      "includingLoc" : "None"
+    },
+    "30" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "9.29",
+      "includingLoc" : "None"
+    },
+    "31" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "9.26",
+      "includingLoc" : "None"
+    },
+    "32" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "9.5",
+      "includingLoc" : "None"
+    },
+    "33" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "9.26",
+      "includingLoc" : "None"
+    },
+    "34" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "9.29",
+      "includingLoc" : "None"
+    },
+    "35" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "9.26",
+      "includingLoc" : "None"
+    },
+    "36" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "9.5",
+      "includingLoc" : "None"
+    },
+    "37" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "5.1",
+      "includingLoc" : "None"
+    },
+    "38" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "13.31",
+      "includingLoc" : "None"
+    },
+    "39" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "13.34",
+      "includingLoc" : "None"
+    },
+    "40" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "13.31",
+      "includingLoc" : "None"
+    },
+    "41" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "13.5",
+      "includingLoc" : "None"
+    },
+    "42" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "13.31",
+      "includingLoc" : "None"
+    },
+    "43" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "13.34",
+      "includingLoc" : "None"
+    },
+    "44" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "13.31",
+      "includingLoc" : "None"
+    },
+    "45" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "13.5",
+      "includingLoc" : "None"
+    },
+    "46" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "13.31",
+      "includingLoc" : "None"
+    },
+    "47" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "13.34",
+      "includingLoc" : "None"
+    },
+    "48" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "13.31",
+      "includingLoc" : "None"
+    },
+    "49" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "13.5",
+      "includingLoc" : "None"
+    },
+    "50" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "12.1",
+      "includingLoc" : "None"
+    },
+    "51" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "17.27",
+      "includingLoc" : "None"
+    },
+    "52" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "17.31",
+      "includingLoc" : "None"
+    },
+    "53" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "17.27",
+      "includingLoc" : "None"
+    },
+    "54" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "17.5",
+      "includingLoc" : "None"
+    },
+    "55" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "18.33",
+      "includingLoc" : "None"
+    },
+    "56" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "18.37",
+      "includingLoc" : "None"
+    },
+    "57" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "18.33",
+      "includingLoc" : "None"
+    },
+    "58" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "18.5",
+      "includingLoc" : "None"
+    },
+    "59" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "18.33",
+      "includingLoc" : "None"
+    },
+    "60" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "18.37",
+      "includingLoc" : "None"
+    },
+    "61" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "18.33",
+      "includingLoc" : "None"
+    },
+    "62" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "18.5",
+      "includingLoc" : "None"
+    },
+    "63" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "18.33",
+      "includingLoc" : "None"
+    },
+    "64" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "18.37",
+      "includingLoc" : "None"
+    },
+    "65" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "18.33",
+      "includingLoc" : "None"
+    },
+    "66" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "18.5",
+      "includingLoc" : "None"
+    },
+    "67" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "16.1",
+      "includingLoc" : "None"
+    },
+    "68" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "22.31",
+      "includingLoc" : "None"
+    },
+    "69" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "22.34",
+      "includingLoc" : "None"
+    },
+    "70" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "22.31",
+      "includingLoc" : "None"
+    },
+    "71" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "22.5",
+      "includingLoc" : "None"
+    },
+    "72" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "23.31",
+      "includingLoc" : "None"
+    },
+    "73" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "23.34",
+      "includingLoc" : "None"
+    },
+    "74" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "23.31",
+      "includingLoc" : "None"
+    },
+    "75" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "23.5",
+      "includingLoc" : "None"
+    },
+    "76" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "23.31",
+      "includingLoc" : "None"
+    },
+    "77" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "23.34",
+      "includingLoc" : "None"
+    },
+    "78" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "23.31",
+      "includingLoc" : "None"
+    },
+    "79" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "23.5",
+      "includingLoc" : "None"
+    },
+    "80" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "23.31",
+      "includingLoc" : "None"
+    },
+    "81" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "23.34",
+      "includingLoc" : "None"
+    },
+    "82" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "23.31",
+      "includingLoc" : "None"
+    },
+    "83" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "23.5",
+      "includingLoc" : "None"
+    },
+    "84" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "21.1",
+      "includingLoc" : "None"
+    },
+    "85" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "27.26",
+      "includingLoc" : "None"
+    },
+    "86" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "27.29",
+      "includingLoc" : "None"
+    },
+    "87" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "27.26",
+      "includingLoc" : "None"
+    },
+    "88" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "27.5",
+      "includingLoc" : "None"
+    },
+    "89" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "27.26",
+      "includingLoc" : "None"
+    },
+    "90" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "27.29",
+      "includingLoc" : "None"
+    },
+    "91" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "27.26",
+      "includingLoc" : "None"
+    },
+    "92" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "27.5",
+      "includingLoc" : "None"
+    },
+    "93" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "27.26",
+      "includingLoc" : "None"
+    },
+    "94" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "27.29",
+      "includingLoc" : "None"
+    },
+    "95" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "27.26",
+      "includingLoc" : "None"
+    },
+    "96" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "27.5",
+      "includingLoc" : "None"
+    },
+    "97" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "26.1",
+      "includingLoc" : "None"
+    },
+    "98" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "31.35",
+      "includingLoc" : "None"
+    },
+    "99" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "31.38",
+      "includingLoc" : "None"
+    },
+    "100" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "31.35",
+      "includingLoc" : "None"
+    },
+    "101" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "31.5",
+      "includingLoc" : "None"
+    },
+    "102" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "31.35",
+      "includingLoc" : "None"
+    },
+    "103" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "31.38",
+      "includingLoc" : "None"
+    },
+    "104" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "31.35",
+      "includingLoc" : "None"
+    },
+    "105" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "31.5",
+      "includingLoc" : "None"
+    },
+    "106" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "31.35",
+      "includingLoc" : "None"
+    },
+    "107" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "31.38",
+      "includingLoc" : "None"
+    },
+    "108" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "31.35",
+      "includingLoc" : "None"
+    },
+    "109" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "31.5",
+      "includingLoc" : "None"
+    },
+    "110" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "30.1",
+      "includingLoc" : "None"
+    },
+    "111" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "34.14",
+      "includingLoc" : "None"
+    },
+    "112" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "34.14",
+      "includingLoc" : "None"
+    },
+    "113" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "34.27",
+      "includingLoc" : "None"
+    },
+    "114" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "34.1",
+      "includingLoc" : "None"
+    },
+    "115" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "35.14",
+      "includingLoc" : "None"
+    },
+    "116" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "35.14",
+      "includingLoc" : "None"
+    },
+    "117" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "35.30",
+      "includingLoc" : "None"
+    },
+    "118" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "35.1",
+      "includingLoc" : "None"
+    },
+    "119" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "36.14",
+      "includingLoc" : "None"
+    },
+    "120" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "36.14",
+      "includingLoc" : "None"
+    },
+    "121" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "36.28",
+      "includingLoc" : "None"
+    },
+    "122" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "36.1",
+      "includingLoc" : "None"
+    },
+    "123" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "37.14",
+      "includingLoc" : "None"
+    },
+    "124" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "37.14",
+      "includingLoc" : "None"
+    },
+    "125" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "37.29",
+      "includingLoc" : "None"
+    },
+    "126" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "37.1",
+      "includingLoc" : "None"
+    },
+    "127" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "38.14",
+      "includingLoc" : "None"
+    },
+    "128" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "38.14",
+      "includingLoc" : "None"
+    },
+    "129" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "38.28",
+      "includingLoc" : "None"
+    },
+    "130" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "38.1",
+      "includingLoc" : "None"
+    },
+    "131" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "39.14",
+      "includingLoc" : "None"
+    },
+    "132" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "39.14",
+      "includingLoc" : "None"
+    },
+    "133" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "39.32",
+      "includingLoc" : "None"
+    },
+    "134" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "39.1",
+      "includingLoc" : "None"
+    },
+    "135" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "40.14",
+      "includingLoc" : "None"
+    },
+    "136" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "40.14",
+      "includingLoc" : "None"
+    },
+    "137" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "40.32",
+      "includingLoc" : "None"
+    },
+    "138" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "40.1",
+      "includingLoc" : "None"
+    },
+    "139" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "43.14",
+      "includingLoc" : "None"
+    },
+    "140" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "43.14",
+      "includingLoc" : "None"
+    },
+    "141" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "43.5",
+      "includingLoc" : "None"
+    },
+    "142" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "44.14",
+      "includingLoc" : "None"
+    },
+    "143" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "44.14",
+      "includingLoc" : "None"
+    },
+    "144" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "44.5",
+      "includingLoc" : "None"
+    },
+    "145" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "45.14",
+      "includingLoc" : "None"
+    },
+    "146" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "45.14",
+      "includingLoc" : "None"
+    },
+    "147" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "45.5",
+      "includingLoc" : "None"
+    },
+    "148" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "46.14",
+      "includingLoc" : "None"
+    },
+    "149" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "46.14",
+      "includingLoc" : "None"
+    },
+    "150" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "46.5",
+      "includingLoc" : "None"
+    },
+    "151" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "47.14",
+      "includingLoc" : "None"
+    },
+    "152" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "47.14",
+      "includingLoc" : "None"
+    },
+    "153" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "47.5",
+      "includingLoc" : "None"
+    },
+    "154" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "48.14",
+      "includingLoc" : "None"
+    },
+    "155" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "48.14",
+      "includingLoc" : "None"
+    },
+    "156" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "48.5",
+      "includingLoc" : "None"
+    },
+    "157" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "49.14",
+      "includingLoc" : "None"
+    },
+    "158" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "49.14",
+      "includingLoc" : "None"
+    },
+    "159" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "49.5",
+      "includingLoc" : "None"
+    },
+    "160" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "51.31",
+      "includingLoc" : "None"
+    },
+    "161" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "51.31",
+      "includingLoc" : "None"
+    },
+    "162" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "51.5",
+      "includingLoc" : "None"
+    },
+    "163" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "52.34",
+      "includingLoc" : "None"
+    },
+    "164" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "52.34",
+      "includingLoc" : "None"
+    },
+    "165" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "52.5",
+      "includingLoc" : "None"
+    },
+    "166" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "53.32",
+      "includingLoc" : "None"
+    },
+    "167" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "53.32",
+      "includingLoc" : "None"
+    },
+    "168" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "53.5",
+      "includingLoc" : "None"
+    },
+    "169" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "54.33",
+      "includingLoc" : "None"
+    },
+    "170" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "54.33",
+      "includingLoc" : "None"
+    },
+    "171" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "54.5",
+      "includingLoc" : "None"
+    },
+    "172" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "55.32",
+      "includingLoc" : "None"
+    },
+    "173" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "55.32",
+      "includingLoc" : "None"
+    },
+    "174" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "55.5",
+      "includingLoc" : "None"
+    },
+    "175" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "56.36",
+      "includingLoc" : "None"
+    },
+    "176" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "56.36",
+      "includingLoc" : "None"
+    },
+    "177" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "56.5",
+      "includingLoc" : "None"
+    },
+    "178" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "57.37",
+      "includingLoc" : "None"
+    },
+    "179" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "57.37",
+      "includingLoc" : "None"
+    },
+    "180" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "57.5",
+      "includingLoc" : "None"
+    },
+    "181" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "57.37",
+      "includingLoc" : "None"
+    },
+    "182" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "57.37",
+      "includingLoc" : "None"
+    },
+    "183" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "57.5",
+      "includingLoc" : "None"
+    },
+    "184" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "57.37",
+      "includingLoc" : "None"
+    },
+    "185" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "57.37",
+      "includingLoc" : "None"
+    },
+    "186" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "57.5",
+      "includingLoc" : "None"
+    },
+    "187" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "42.1",
+      "includingLoc" : "None"
+    },
+    "188" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "43.14",
+      "includingLoc" : "None"
+    },
+    "189" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "43.14",
+      "includingLoc" : "None"
+    },
+    "190" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "43.5",
+      "includingLoc" : "None"
+    },
+    "191" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "44.14",
+      "includingLoc" : "None"
+    },
+    "192" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "44.14",
+      "includingLoc" : "None"
+    },
+    "193" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "44.5",
+      "includingLoc" : "None"
+    },
+    "194" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "45.14",
+      "includingLoc" : "None"
+    },
+    "195" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "45.14",
+      "includingLoc" : "None"
+    },
+    "196" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "45.5",
+      "includingLoc" : "None"
+    },
+    "197" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "46.14",
+      "includingLoc" : "None"
+    },
+    "198" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "46.14",
+      "includingLoc" : "None"
+    },
+    "199" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "46.5",
+      "includingLoc" : "None"
+    },
+    "200" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "47.14",
+      "includingLoc" : "None"
+    },
+    "201" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "47.14",
+      "includingLoc" : "None"
+    },
+    "202" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "47.5",
+      "includingLoc" : "None"
+    },
+    "203" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "48.14",
+      "includingLoc" : "None"
+    },
+    "204" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "48.14",
+      "includingLoc" : "None"
+    },
+    "205" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "48.5",
+      "includingLoc" : "None"
+    },
+    "206" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "49.14",
+      "includingLoc" : "None"
+    },
+    "207" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "49.14",
+      "includingLoc" : "None"
+    },
+    "208" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "49.5",
+      "includingLoc" : "None"
+    },
+    "209" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "51.31",
+      "includingLoc" : "None"
+    },
+    "210" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "51.31",
+      "includingLoc" : "None"
+    },
+    "211" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "51.5",
+      "includingLoc" : "None"
+    },
+    "212" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "52.34",
+      "includingLoc" : "None"
+    },
+    "213" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "52.34",
+      "includingLoc" : "None"
+    },
+    "214" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "52.5",
+      "includingLoc" : "None"
+    },
+    "215" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "53.32",
+      "includingLoc" : "None"
+    },
+    "216" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "53.32",
+      "includingLoc" : "None"
+    },
+    "217" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "53.5",
+      "includingLoc" : "None"
+    },
+    "218" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "54.33",
+      "includingLoc" : "None"
+    },
+    "219" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "54.33",
+      "includingLoc" : "None"
+    },
+    "220" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "54.5",
+      "includingLoc" : "None"
+    },
+    "221" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "55.32",
+      "includingLoc" : "None"
+    },
+    "222" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "55.32",
+      "includingLoc" : "None"
+    },
+    "223" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "55.5",
+      "includingLoc" : "None"
+    },
+    "224" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "56.36",
+      "includingLoc" : "None"
+    },
+    "225" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "56.36",
+      "includingLoc" : "None"
+    },
+    "226" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "56.5",
+      "includingLoc" : "None"
+    },
+    "227" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "57.37",
+      "includingLoc" : "None"
+    },
+    "228" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "57.37",
+      "includingLoc" : "None"
+    },
+    "229" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "57.5",
+      "includingLoc" : "None"
+    },
+    "230" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "57.37",
+      "includingLoc" : "None"
+    },
+    "231" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "57.37",
+      "includingLoc" : "None"
+    },
+    "232" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "57.5",
+      "includingLoc" : "None"
+    },
+    "233" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "57.37",
+      "includingLoc" : "None"
+    },
+    "234" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "57.37",
+      "includingLoc" : "None"
+    },
+    "235" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "57.5",
+      "includingLoc" : "None"
+    },
+    "236" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "42.1",
+      "includingLoc" : "None"
+    },
+    "237" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "43.14",
+      "includingLoc" : "None"
+    },
+    "238" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "43.14",
+      "includingLoc" : "None"
+    },
+    "239" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "43.5",
+      "includingLoc" : "None"
+    },
+    "240" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "44.14",
+      "includingLoc" : "None"
+    },
+    "241" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "44.14",
+      "includingLoc" : "None"
+    },
+    "242" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "44.5",
+      "includingLoc" : "None"
+    },
+    "243" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "45.14",
+      "includingLoc" : "None"
+    },
+    "244" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "45.14",
+      "includingLoc" : "None"
+    },
+    "245" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "45.5",
+      "includingLoc" : "None"
+    },
+    "246" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "46.14",
+      "includingLoc" : "None"
+    },
+    "247" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "46.14",
+      "includingLoc" : "None"
+    },
+    "248" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "46.5",
+      "includingLoc" : "None"
+    },
+    "249" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "47.14",
+      "includingLoc" : "None"
+    },
+    "250" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "47.14",
+      "includingLoc" : "None"
+    },
+    "251" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "47.5",
+      "includingLoc" : "None"
+    },
+    "252" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "48.14",
+      "includingLoc" : "None"
+    },
+    "253" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "48.14",
+      "includingLoc" : "None"
+    },
+    "254" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "48.5",
+      "includingLoc" : "None"
+    },
+    "255" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "49.14",
+      "includingLoc" : "None"
+    },
+    "256" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "49.14",
+      "includingLoc" : "None"
+    },
+    "257" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "49.5",
+      "includingLoc" : "None"
+    },
+    "258" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "51.31",
+      "includingLoc" : "None"
+    },
+    "259" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "51.31",
+      "includingLoc" : "None"
+    },
+    "260" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "51.5",
+      "includingLoc" : "None"
+    },
+    "261" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "52.34",
+      "includingLoc" : "None"
+    },
+    "262" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "52.34",
+      "includingLoc" : "None"
+    },
+    "263" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "52.5",
+      "includingLoc" : "None"
+    },
+    "264" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "53.32",
+      "includingLoc" : "None"
+    },
+    "265" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "53.32",
+      "includingLoc" : "None"
+    },
+    "266" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "53.5",
+      "includingLoc" : "None"
+    },
+    "267" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "54.33",
+      "includingLoc" : "None"
+    },
+    "268" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "54.33",
+      "includingLoc" : "None"
+    },
+    "269" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "54.5",
+      "includingLoc" : "None"
+    },
+    "270" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "55.32",
+      "includingLoc" : "None"
+    },
+    "271" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "55.32",
+      "includingLoc" : "None"
+    },
+    "272" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "55.5",
+      "includingLoc" : "None"
+    },
+    "273" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "56.36",
+      "includingLoc" : "None"
+    },
+    "274" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "56.36",
+      "includingLoc" : "None"
+    },
+    "275" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "56.5",
+      "includingLoc" : "None"
+    },
+    "276" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "57.37",
+      "includingLoc" : "None"
+    },
+    "277" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "57.37",
+      "includingLoc" : "None"
+    },
+    "278" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "57.5",
+      "includingLoc" : "None"
+    },
+    "279" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "57.37",
+      "includingLoc" : "None"
+    },
+    "280" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "57.37",
+      "includingLoc" : "None"
+    },
+    "281" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "57.5",
+      "includingLoc" : "None"
+    },
+    "282" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "57.37",
+      "includingLoc" : "None"
+    },
+    "283" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "57.37",
+      "includingLoc" : "None"
+    },
+    "284" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "57.5",
+      "includingLoc" : "None"
+    },
+    "285" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "pos" : "42.1",
+      "includingLoc" : "None"
+    },
+    "286" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/fprime/defs.fpp",
+      "pos" : "4.3",
+      "includingLoc" : "None"
+    },
+    "287" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/fprime/defs.fpp",
+      "pos" : "5.3",
+      "includingLoc" : "None"
+    },
+    "288" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/fprime/defs.fpp",
+      "pos" : "6.3",
+      "includingLoc" : "None"
+    },
+    "289" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/fprime/defs.fpp",
+      "pos" : "7.3",
+      "includingLoc" : "None"
+    },
+    "290" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/fprime/defs.fpp",
+      "pos" : "8.3",
+      "includingLoc" : "None"
+    },
+    "291" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/fprime/defs.fpp",
+      "pos" : "9.3",
+      "includingLoc" : "None"
+    },
+    "292" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/fprime/defs.fpp",
+      "pos" : "10.3",
+      "includingLoc" : "None"
+    },
+    "293" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/fprime/defs.fpp",
+      "pos" : "11.3",
+      "includingLoc" : "None"
+    },
+    "294" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/fprime/defs.fpp",
+      "pos" : "12.3",
+      "includingLoc" : "None"
+    },
+    "295" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/fprime/defs.fpp",
+      "pos" : "13.3",
+      "includingLoc" : "None"
+    },
+    "296" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/fprime/defs.fpp",
+      "pos" : "13.3",
+      "includingLoc" : "None"
+    },
+    "297" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/fprime/defs.fpp",
+      "pos" : "13.3",
+      "includingLoc" : "None"
+    },
+    "298" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/fprime/defs.fpp",
+      "pos" : "3.1",
+      "includingLoc" : "None"
+    },
+    "299" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/fprime/defs.fpp",
+      "pos" : "17.3",
+      "includingLoc" : "None"
+    },
+    "300" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/fprime/defs.fpp",
+      "pos" : "17.3",
+      "includingLoc" : "None"
+    },
+    "301" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/fprime/defs.fpp",
+      "pos" : "17.3",
+      "includingLoc" : "None"
+    },
+    "302" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/fprime/defs.fpp",
+      "pos" : "16.1",
+      "includingLoc" : "None"
     }
   }
 }

--- a/tests/patterned_connections/patterned_connections_locations.json
+++ b/tests/patterned_connections/patterned_connections_locations.json
@@ -1,1053 +1,1053 @@
 {
-  "fppVersion": "[ fpp version ]",
+  "fppVersion": "v3.1.0a10",
   "locationMap": {
     "0": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "2.34",
       "includingLoc": "None"
     },
     "1": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "2.37",
       "includingLoc": "None"
     },
     "2": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "2.34",
       "includingLoc": "None"
     },
     "3": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "2.5",
       "includingLoc": "None"
     },
     "4": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "4.5",
       "includingLoc": "None"
     },
     "5": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "4.5",
       "includingLoc": "None"
     },
     "6": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "4.5",
       "includingLoc": "None"
     },
     "7": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "1.1",
       "includingLoc": "None"
     },
     "8": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "8.28",
       "includingLoc": "None"
     },
     "9": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "8.31",
       "includingLoc": "None"
     },
     "10": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "8.28",
       "includingLoc": "None"
     },
     "11": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "8.5",
       "includingLoc": "None"
     },
     "12": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "9.32",
       "includingLoc": "None"
     },
     "13": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "9.35",
       "includingLoc": "None"
     },
     "14": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "9.32",
       "includingLoc": "None"
     },
     "15": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "9.5",
       "includingLoc": "None"
     },
     "16": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "10.37",
       "includingLoc": "None"
     },
     "17": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "10.40",
       "includingLoc": "None"
     },
     "18": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "10.37",
       "includingLoc": "None"
     },
     "19": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "10.5",
       "includingLoc": "None"
     },
     "20": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "11.26",
       "includingLoc": "None"
     },
     "21": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "11.29",
       "includingLoc": "None"
     },
     "22": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "11.26",
       "includingLoc": "None"
     },
     "23": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "11.5",
       "includingLoc": "None"
     },
     "24": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "11.26",
       "includingLoc": "None"
     },
     "25": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "11.29",
       "includingLoc": "None"
     },
     "26": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "11.26",
       "includingLoc": "None"
     },
     "27": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "11.5",
       "includingLoc": "None"
     },
     "28": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "11.26",
       "includingLoc": "None"
     },
     "29": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "11.29",
       "includingLoc": "None"
     },
     "30": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "11.26",
       "includingLoc": "None"
     },
     "31": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "11.5",
       "includingLoc": "None"
     },
     "32": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "7.1",
       "includingLoc": "None"
     },
     "33": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "15.31",
       "includingLoc": "None"
     },
     "34": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "15.34",
       "includingLoc": "None"
     },
     "35": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "15.31",
       "includingLoc": "None"
     },
     "36": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "15.5",
       "includingLoc": "None"
     },
     "37": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "16.5",
       "includingLoc": "None"
     },
     "38": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "16.5",
       "includingLoc": "None"
     },
     "39": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "16.5",
       "includingLoc": "None"
     },
     "40": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "14.1",
       "includingLoc": "None"
     },
     "41": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "21.27",
       "includingLoc": "None"
     },
     "42": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "21.31",
       "includingLoc": "None"
     },
     "43": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "21.27",
       "includingLoc": "None"
     },
     "44": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "21.5",
       "includingLoc": "None"
     },
     "45": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "22.33",
       "includingLoc": "None"
     },
     "46": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "22.37",
       "includingLoc": "None"
     },
     "47": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "22.33",
       "includingLoc": "None"
     },
     "48": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "22.5",
       "includingLoc": "None"
     },
     "49": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "22.33",
       "includingLoc": "None"
     },
     "50": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "22.37",
       "includingLoc": "None"
     },
     "51": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "22.33",
       "includingLoc": "None"
     },
     "52": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "22.5",
       "includingLoc": "None"
     },
     "53": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "22.33",
       "includingLoc": "None"
     },
     "54": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "22.37",
       "includingLoc": "None"
     },
     "55": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "22.33",
       "includingLoc": "None"
     },
     "56": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "22.5",
       "includingLoc": "None"
     },
     "57": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "20.1",
       "includingLoc": "None"
     },
     "58": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "26.31",
       "includingLoc": "None"
     },
     "59": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "26.34",
       "includingLoc": "None"
     },
     "60": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "26.31",
       "includingLoc": "None"
     },
     "61": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "26.5",
       "includingLoc": "None"
     },
     "62": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "27.31",
       "includingLoc": "None"
     },
     "63": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "27.34",
       "includingLoc": "None"
     },
     "64": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "27.31",
       "includingLoc": "None"
     },
     "65": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "27.5",
       "includingLoc": "None"
     },
     "66": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "27.31",
       "includingLoc": "None"
     },
     "67": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "27.34",
       "includingLoc": "None"
     },
     "68": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "27.31",
       "includingLoc": "None"
     },
     "69": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "27.5",
       "includingLoc": "None"
     },
     "70": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "27.31",
       "includingLoc": "None"
     },
     "71": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "27.34",
       "includingLoc": "None"
     },
     "72": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "27.31",
       "includingLoc": "None"
     },
     "73": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "27.5",
       "includingLoc": "None"
     },
     "74": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "25.1",
       "includingLoc": "None"
     },
     "75": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "31.26",
       "includingLoc": "None"
     },
     "76": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "31.29",
       "includingLoc": "None"
     },
     "77": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "31.26",
       "includingLoc": "None"
     },
     "78": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "31.5",
       "includingLoc": "None"
     },
     "79": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "31.26",
       "includingLoc": "None"
     },
     "80": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "31.29",
       "includingLoc": "None"
     },
     "81": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "31.26",
       "includingLoc": "None"
     },
     "82": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "31.5",
       "includingLoc": "None"
     },
     "83": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "31.26",
       "includingLoc": "None"
     },
     "84": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "31.29",
       "includingLoc": "None"
     },
     "85": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "31.26",
       "includingLoc": "None"
     },
     "86": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "31.5",
       "includingLoc": "None"
     },
     "87": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "30.1",
       "includingLoc": "None"
     },
     "88": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "35.35",
       "includingLoc": "None"
     },
     "89": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "35.38",
       "includingLoc": "None"
     },
     "90": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "35.35",
       "includingLoc": "None"
     },
     "91": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "35.5",
       "includingLoc": "None"
     },
     "92": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "35.35",
       "includingLoc": "None"
     },
     "93": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "35.38",
       "includingLoc": "None"
     },
     "94": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "35.35",
       "includingLoc": "None"
     },
     "95": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "35.5",
       "includingLoc": "None"
     },
     "96": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "35.35",
       "includingLoc": "None"
     },
     "97": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "35.38",
       "includingLoc": "None"
     },
     "98": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "35.35",
       "includingLoc": "None"
     },
     "99": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "35.5",
       "includingLoc": "None"
     },
     "100": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "34.1",
       "includingLoc": "None"
     },
     "101": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "39.5",
       "includingLoc": "None"
     },
     "102": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "40.5",
       "includingLoc": "None"
     },
     "103": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "41.5",
       "includingLoc": "None"
     },
     "104": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "41.5",
       "includingLoc": "None"
     },
     "105": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "41.5",
       "includingLoc": "None"
     },
     "106": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "38.1",
       "includingLoc": "None"
     },
     "107": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "44.13",
       "includingLoc": "None"
     },
     "108": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "44.13",
       "includingLoc": "None"
     },
     "109": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "44.23",
       "includingLoc": "None"
     },
     "110": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "44.1",
       "includingLoc": "None"
     },
     "111": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "45.14",
       "includingLoc": "None"
     },
     "112": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "45.14",
       "includingLoc": "None"
     },
     "113": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "45.27",
       "includingLoc": "None"
     },
     "114": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "45.1",
       "includingLoc": "None"
     },
     "115": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "46.14",
       "includingLoc": "None"
     },
     "116": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "46.14",
       "includingLoc": "None"
     },
     "117": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "46.30",
       "includingLoc": "None"
     },
     "118": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "46.1",
       "includingLoc": "None"
     },
     "119": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "47.14",
       "includingLoc": "None"
     },
     "120": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "47.14",
       "includingLoc": "None"
     },
     "121": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "47.28",
       "includingLoc": "None"
     },
     "122": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "47.1",
       "includingLoc": "None"
     },
     "123": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "48.14",
       "includingLoc": "None"
     },
     "124": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "48.14",
       "includingLoc": "None"
     },
     "125": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "48.29",
       "includingLoc": "None"
     },
     "126": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "48.1",
       "includingLoc": "None"
     },
     "127": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "49.14",
       "includingLoc": "None"
     },
     "128": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "49.14",
       "includingLoc": "None"
     },
     "129": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "49.28",
       "includingLoc": "None"
     },
     "130": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "49.1",
       "includingLoc": "None"
     },
     "131": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "50.14",
       "includingLoc": "None"
     },
     "132": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "50.14",
       "includingLoc": "None"
     },
     "133": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "50.32",
       "includingLoc": "None"
     },
     "134": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "50.1",
       "includingLoc": "None"
     },
     "135": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "51.14",
       "includingLoc": "None"
     },
     "136": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "51.14",
       "includingLoc": "None"
     },
     "137": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "51.32",
       "includingLoc": "None"
     },
     "138": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "51.1",
       "includingLoc": "None"
     },
     "139": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "54.14",
       "includingLoc": "None"
     },
     "140": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "54.14",
       "includingLoc": "None"
     },
     "141": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "54.5",
       "includingLoc": "None"
     },
     "142": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "55.14",
       "includingLoc": "None"
     },
     "143": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "55.14",
       "includingLoc": "None"
     },
     "144": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "55.5",
       "includingLoc": "None"
     },
     "145": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "56.14",
       "includingLoc": "None"
     },
     "146": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "56.14",
       "includingLoc": "None"
     },
     "147": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "56.5",
       "includingLoc": "None"
     },
     "148": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "57.14",
       "includingLoc": "None"
     },
     "149": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "57.14",
       "includingLoc": "None"
     },
     "150": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "57.5",
       "includingLoc": "None"
     },
     "151": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "58.14",
       "includingLoc": "None"
     },
     "152": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "58.14",
       "includingLoc": "None"
     },
     "153": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "58.5",
       "includingLoc": "None"
     },
     "154": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "59.14",
       "includingLoc": "None"
     },
     "155": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "59.14",
       "includingLoc": "None"
     },
     "156": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "59.5",
       "includingLoc": "None"
     },
     "157": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "60.14",
       "includingLoc": "None"
     },
     "158": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "60.14",
       "includingLoc": "None"
     },
     "159": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "60.5",
       "includingLoc": "None"
     },
     "160": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "61.14",
       "includingLoc": "None"
     },
     "161": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "61.14",
       "includingLoc": "None"
     },
     "162": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "61.5",
       "includingLoc": "None"
     },
     "163": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "63.31",
       "includingLoc": "None"
     },
     "164": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "63.31",
       "includingLoc": "None"
     },
     "165": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "63.5",
       "includingLoc": "None"
     },
     "166": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "64.34",
       "includingLoc": "None"
     },
     "167": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "64.34",
       "includingLoc": "None"
     },
     "168": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "64.39",
       "includingLoc": "None"
     },
     "169": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "64.39",
       "includingLoc": "None"
     },
     "170": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "64.5",
       "includingLoc": "None"
     },
     "171": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "65.32",
       "includingLoc": "None"
     },
     "172": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "65.32",
       "includingLoc": "None"
     },
     "173": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "65.5",
       "includingLoc": "None"
     },
     "174": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "66.33",
       "includingLoc": "None"
     },
     "175": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "66.33",
       "includingLoc": "None"
     },
     "176": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "66.5",
       "includingLoc": "None"
     },
     "177": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "67.32",
       "includingLoc": "None"
     },
     "178": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "67.32",
       "includingLoc": "None"
     },
     "179": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "67.5",
       "includingLoc": "None"
     },
     "180": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "68.36",
       "includingLoc": "None"
     },
     "181": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "68.36",
       "includingLoc": "None"
     },
     "182": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "68.5",
       "includingLoc": "None"
     },
     "183": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "69.37",
       "includingLoc": "None"
     },
     "184": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "69.37",
       "includingLoc": "None"
     },
     "185": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "69.5",
       "includingLoc": "None"
     },
     "186": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "69.37",
       "includingLoc": "None"
     },
     "187": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "69.37",
       "includingLoc": "None"
     },
     "188": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "69.5",
       "includingLoc": "None"
     },
     "189": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "69.37",
       "includingLoc": "None"
     },
     "190": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "69.37",
       "includingLoc": "None"
     },
     "191": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "69.5",
       "includingLoc": "None"
     },
     "192": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",
       "pos": "53.1",
       "includingLoc": "None"
     },
     "193": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/fprime/defs.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/fprime/defs.fpp",
       "pos": "4.3",
       "includingLoc": "None"
     },
     "194": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/fprime/defs.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/fprime/defs.fpp",
       "pos": "5.3",
       "includingLoc": "None"
     },
     "195": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/fprime/defs.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/fprime/defs.fpp",
       "pos": "6.3",
       "includingLoc": "None"
     },
     "196": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/fprime/defs.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/fprime/defs.fpp",
       "pos": "7.3",
       "includingLoc": "None"
     },
     "197": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/fprime/defs.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/fprime/defs.fpp",
       "pos": "8.3",
       "includingLoc": "None"
     },
     "198": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/fprime/defs.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/fprime/defs.fpp",
       "pos": "9.3",
       "includingLoc": "None"
     },
     "199": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/fprime/defs.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/fprime/defs.fpp",
       "pos": "10.3",
       "includingLoc": "None"
     },
     "200": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/fprime/defs.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/fprime/defs.fpp",
       "pos": "11.3",
       "includingLoc": "None"
     },
     "201": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/fprime/defs.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/fprime/defs.fpp",
       "pos": "12.3",
       "includingLoc": "None"
     },
     "202": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/fprime/defs.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/fprime/defs.fpp",
       "pos": "13.3",
       "includingLoc": "None"
     },
     "203": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/fprime/defs.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/fprime/defs.fpp",
       "pos": "13.3",
       "includingLoc": "None"
     },
     "204": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/fprime/defs.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/fprime/defs.fpp",
       "pos": "13.3",
       "includingLoc": "None"
     },
     "205": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/fprime/defs.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/fprime/defs.fpp",
       "pos": "3.1",
       "includingLoc": "None"
     },
     "206": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/fprime/defs.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/fprime/defs.fpp",
       "pos": "17.3",
       "includingLoc": "None"
     },
     "207": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/fprime/defs.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/fprime/defs.fpp",
       "pos": "17.3",
       "includingLoc": "None"
     },
     "208": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/fprime/defs.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/fprime/defs.fpp",
       "pos": "17.3",
       "includingLoc": "None"
     },
     "209": {
-      "file": "/Users/jawest/Documents/fprime-infrastructure/new-fpp/fpp/compiler/tools/fpp-to-json/test/fprime/defs.fpp",
+      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/fprime/defs.fpp",
       "pos": "16.1",
       "includingLoc": "None"
     }

--- a/tests/ports/ports_analysis.json
+++ b/tests/ports/ports_analysis.json
@@ -1,959 +1,819 @@
 {
-  "fppVersion" : "v3.1.0a10-46-g5b2da7ca1",
-  "analysis" : {
-    "componentInstanceMap" : {
-      "88" : {
-        "aNode" : {
-          "astNodeId" : 88
+  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
+  "analysis": {
+    "componentInstanceMap": {
+      "88": {
+        "aNode": {
+          "astNodeId": 88
         },
-        "qualifiedName" : {
-          "qualifier" : [
-          ],
-          "base" : "i"
+        "qualifiedName": {
+          "qualifier": [],
+          "base": "i"
         },
-        "component" : {
-          "astNodeId" : 81
+        "component": {
+          "astNodeId": 81
         },
-        "baseId" : 8448,
-        "maxId" : 8447,
-        "file" : "None",
-        "queueSize" : {
-          "Some" : 10
+        "baseId": 8448,
+        "maxId": 8447,
+        "file": "None",
+        "queueSize": {
+          "Some": 10
         },
-        "stackSize" : "None",
-        "priority" : "None",
-        "cpu" : "None",
-        "initSpecifierMap" : {
-          
-        }
+        "stackSize": "None",
+        "priority": "None",
+        "cpu": "None",
+        "initSpecifierMap": {}
       }
     },
-    "componentMap" : {
-      "81" : {
-        "aNode" : {
-          "astNodeId" : 81
+    "componentMap": {
+      "81": {
+        "aNode": {
+          "astNodeId": 81
         },
-        "portMap" : {
-          "productRecvIn" : {
-            "Special" : {
-              "aNode" : {
-                "astNodeId" : 80
+        "portMap": {
+          "productRecvIn": {
+            "Special": {
+              "aNode": {
+                "astNodeId": 80
               },
-              "specifier" : {
-                "inputKind" : {
-                  "Some" : {
-                    "Async" : {
-                      
-                    }
+              "specifier": {
+                "inputKind": {
+                  "Some": {
+                    "Async": {}
                   }
                 },
-                "kind" : {
-                  "ProductRecv" : {
-                    
-                  }
+                "kind": {
+                  "ProductRecv": {}
                 },
-                "name" : "productRecvIn",
-                "priority" : "None",
-                "queueFull" : "None"
+                "name": "productRecvIn",
+                "priority": "None",
+                "queueFull": "None"
               },
-              "symbol" : {
-                "Port" : {
-                  "nodeId" : 67,
-                  "unqualifiedName" : "DpResponse"
+              "symbol": {
+                "Port": {
+                  "nodeId": 67,
+                  "unqualifiedName": "DpResponse"
                 }
               },
-              "priority" : "None",
-              "queueFull" : {
-                "Some" : {
-                  "Assert" : {
-                    
-                  }
+              "priority": "None",
+              "queueFull": {
+                "Some": {
+                  "Assert": {}
                 }
               },
-              "importNodeIds" : [
-              ]
+              "importNodeIds": []
             }
           }
         },
-        "specialPortMap" : {
-          "product recv" : {
-            "aNode" : {
-              "astNodeId" : 80
+        "specialPortMap": {
+          "product recv": {
+            "aNode": {
+              "astNodeId": 80
             },
-            "specifier" : {
-              "inputKind" : {
-                "Some" : {
-                  "Async" : {
-                    
-                  }
+            "specifier": {
+              "inputKind": {
+                "Some": {
+                  "Async": {}
                 }
               },
-              "kind" : {
-                "ProductRecv" : {
-                  
-                }
+              "kind": {
+                "ProductRecv": {}
               },
-              "name" : "productRecvIn",
-              "priority" : "None",
-              "queueFull" : "None"
+              "name": "productRecvIn",
+              "priority": "None",
+              "queueFull": "None"
             },
-            "symbol" : {
-              "Port" : {
-                "nodeId" : 67,
-                "unqualifiedName" : "DpResponse"
+            "symbol": {
+              "Port": {
+                "nodeId": 67,
+                "unqualifiedName": "DpResponse"
               }
             },
-            "priority" : "None",
-            "queueFull" : {
-              "Some" : {
-                "Assert" : {
-                  
-                }
+            "priority": "None",
+            "queueFull": {
+              "Some": {
+                "Assert": {}
               }
             },
-            "importNodeIds" : [
-            ]
+            "importNodeIds": []
           }
         },
-        "commandMap" : {
-          
-        },
-        "defaultOpcode" : 0,
-        "tlmChannelMap" : {
-          
-        },
-        "tlmChannelNameMap" : {
-          
-        },
-        "defaultTlmChannelId" : 0,
-        "eventMap" : {
-          
-        },
-        "defaultEventId" : 0,
-        "paramMap" : {
-          
-        },
-        "specPortMatchingList" : [
-        ],
-        "stateMachineInstanceMap" : {
-          
-        },
-        "portMatchingList" : [
-        ],
-        "defaultParamId" : 0,
-        "containerMap" : {
-          
-        },
-        "defaultContainerId" : 0,
-        "recordMap" : {
-          
-        },
-        "defaultRecordId" : 0
+        "commandMap": {},
+        "defaultOpcode": 0,
+        "tlmChannelMap": {},
+        "tlmChannelNameMap": {},
+        "defaultTlmChannelId": 0,
+        "eventMap": {},
+        "defaultEventId": 0,
+        "paramMap": {},
+        "specPortMatchingList": [],
+        "stateMachineInstanceMap": {},
+        "portMatchingList": [],
+        "defaultParamId": 0,
+        "containerMap": {},
+        "defaultContainerId": 0,
+        "recordMap": {},
+        "defaultRecordId": 0
       }
     },
-    "includedFileSet" : [
-    ],
-    "inputFileSet" : [
+    "includedFileSet": [],
+    "inputFileSet": [
       "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp"
     ],
-    "locationSpecifierMap" : [
-    ],
-    "parentSymbolMap" : {
-      "67" : {
-        "Module" : {
-          "nodeId" : 68,
-          "unqualifiedName" : "Fw"
+    "locationSpecifierMap": [],
+    "parentSymbolMap": {
+      "67": {
+        "Module": {
+          "nodeId": 68,
+          "unqualifiedName": "Fw"
         }
       },
-      "23" : {
-        "Enum" : {
-          "nodeId" : 24,
-          "unqualifiedName" : "E"
+      "23": {
+        "Enum": {
+          "nodeId": 24,
+          "unqualifiedName": "E"
         }
       },
-      "50" : {
-        "Enum" : {
-          "nodeId" : 54,
-          "unqualifiedName" : "Status"
+      "50": {
+        "Enum": {
+          "nodeId": 54,
+          "unqualifiedName": "Status"
         }
       },
-      "69" : {
-        "Module" : {
-          "nodeId" : 82,
-          "unqualifiedName" : "M"
+      "69": {
+        "Module": {
+          "nodeId": 82,
+          "unqualifiedName": "M"
         }
       },
-      "53" : {
-        "Enum" : {
-          "nodeId" : 54,
-          "unqualifiedName" : "Status"
+      "53": {
+        "Enum": {
+          "nodeId": 54,
+          "unqualifiedName": "Status"
         }
       },
-      "20" : {
-        "Enum" : {
-          "nodeId" : 24,
-          "unqualifiedName" : "E"
+      "20": {
+        "Enum": {
+          "nodeId": 24,
+          "unqualifiedName": "E"
         }
       },
-      "81" : {
-        "Module" : {
-          "nodeId" : 82,
-          "unqualifiedName" : "M"
+      "81": {
+        "Module": {
+          "nodeId": 82,
+          "unqualifiedName": "M"
         }
       },
-      "118" : {
-        "Module" : {
-          "nodeId" : 82,
-          "unqualifiedName" : "M"
+      "118": {
+        "Module": {
+          "nodeId": 82,
+          "unqualifiedName": "M"
         }
       }
     },
-    "symbolScopeMap" : {
-      "68" : {
-        "map" : {
-          "Port" : {
-            "map" : {
-              "DpResponse" : {
-                "Port" : {
-                  "nodeId" : 67,
-                  "unqualifiedName" : "DpResponse"
+    "symbolScopeMap": {
+      "68": {
+        "map": {
+          "Port": {
+            "map": {
+              "DpResponse": {
+                "Port": {
+                  "nodeId": 67,
+                  "unqualifiedName": "DpResponse"
                 }
               }
             }
           }
         }
       },
-      "24" : {
-        "map" : {
-          "Value" : {
-            "map" : {
-              "A" : {
-                "EnumConstant" : {
-                  "nodeId" : 20,
-                  "unqualifiedName" : "A"
+      "24": {
+        "map": {
+          "Value": {
+            "map": {
+              "A": {
+                "EnumConstant": {
+                  "nodeId": 20,
+                  "unqualifiedName": "A"
                 }
               },
-              "B" : {
-                "EnumConstant" : {
-                  "nodeId" : 23,
-                  "unqualifiedName" : "B"
+              "B": {
+                "EnumConstant": {
+                  "nodeId": 23,
+                  "unqualifiedName": "B"
                 }
               }
             }
           }
         }
       },
-      "54" : {
-        "map" : {
-          "Value" : {
-            "map" : {
-              "SUCCEED" : {
-                "EnumConstant" : {
-                  "nodeId" : 50,
-                  "unqualifiedName" : "SUCCEED"
+      "54": {
+        "map": {
+          "Value": {
+            "map": {
+              "SUCCEED": {
+                "EnumConstant": {
+                  "nodeId": 50,
+                  "unqualifiedName": "SUCCEED"
                 }
               },
-              "FAIL" : {
-                "EnumConstant" : {
-                  "nodeId" : 53,
-                  "unqualifiedName" : "FAIL"
+              "FAIL": {
+                "EnumConstant": {
+                  "nodeId": 53,
+                  "unqualifiedName": "FAIL"
                 }
               }
             }
           }
         }
       },
-      "82" : {
-        "map" : {
-          "Topology" : {
-            "map" : {
-              "T" : {
-                "Topology" : {
-                  "nodeId" : 118,
-                  "unqualifiedName" : "T"
+      "82": {
+        "map": {
+          "Topology": {
+            "map": {
+              "T": {
+                "Topology": {
+                  "nodeId": 118,
+                  "unqualifiedName": "T"
                 }
               }
             }
           },
-          "StateMachine" : {
-            "map" : {
-              "Q" : {
-                "Component" : {
-                  "nodeId" : 81,
-                  "unqualifiedName" : "Q"
+          "StateMachine": {
+            "map": {
+              "Q": {
+                "Component": {
+                  "nodeId": 81,
+                  "unqualifiedName": "Q"
                 }
               }
             }
           },
-          "Value" : {
-            "map" : {
-              "Q" : {
-                "Component" : {
-                  "nodeId" : 81,
-                  "unqualifiedName" : "Q"
+          "Value": {
+            "map": {
+              "Q": {
+                "Component": {
+                  "nodeId": 81,
+                  "unqualifiedName": "Q"
                 }
               }
             }
           },
-          "Port" : {
-            "map" : {
-              "P" : {
-                "Port" : {
-                  "nodeId" : 69,
-                  "unqualifiedName" : "P"
+          "Port": {
+            "map": {
+              "P": {
+                "Port": {
+                  "nodeId": 69,
+                  "unqualifiedName": "P"
                 }
               }
             }
           },
-          "Component" : {
-            "map" : {
-              "Q" : {
-                "Component" : {
-                  "nodeId" : 81,
-                  "unqualifiedName" : "Q"
+          "Component": {
+            "map": {
+              "Q": {
+                "Component": {
+                  "nodeId": 81,
+                  "unqualifiedName": "Q"
                 }
               }
             }
           },
-          "Type" : {
-            "map" : {
-              "Q" : {
-                "Component" : {
-                  "nodeId" : 81,
-                  "unqualifiedName" : "Q"
+          "Type": {
+            "map": {
+              "Q": {
+                "Component": {
+                  "nodeId": 81,
+                  "unqualifiedName": "Q"
                 }
               }
             }
           }
         }
       },
-      "81" : {
-        "map" : {
-          
-        }
+      "81": {
+        "map": {}
       }
     },
-    "topologyMap" : {
-      "118" : {
-        "aNode" : {
-          "astNodeId" : 118
+    "topologyMap": {
+      "118": {
+        "aNode": {
+          "astNodeId": 118
         },
-        "directImportMap" : {
-          
-        },
-        "transitiveImportSet" : [
-        ],
-        "instanceMap" : [
+        "directImportMap": {},
+        "transitiveImportSet": [],
+        "instanceMap": [
           [
             {
-              "aNode" : {
-                "astNodeId" : 88
+              "aNode": {
+                "astNodeId": 88
               },
-              "qualifiedName" : {
-                "qualifier" : [
-                ],
-                "base" : "i"
+              "qualifiedName": {
+                "qualifier": [],
+                "base": "i"
               },
-              "component" : {
-                "astNodeId" : 81
+              "component": {
+                "astNodeId": 81
               },
-              "baseId" : 8448,
-              "maxId" : 8447,
-              "file" : "None",
-              "queueSize" : {
-                "Some" : 10
+              "baseId": 8448,
+              "maxId": 8447,
+              "file": "None",
+              "queueSize": {
+                "Some": 10
               },
-              "stackSize" : "None",
-              "priority" : "None",
-              "cpu" : "None",
-              "initSpecifierMap" : {
-                
-              }
+              "stackSize": "None",
+              "priority": "None",
+              "cpu": "None",
+              "initSpecifierMap": {}
             },
             [
               {
-                "Public" : {
-                  
-                }
+                "Public": {}
               },
               {
-                "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-                "pos" : "39.9",
-                "includingLoc" : "None"
+                "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+                "pos": "39.9",
+                "includingLoc": "None"
               }
             ]
           ]
         ],
-        "patternMap" : {
-          
-        },
-        "connectionMap" : {
-          
-        },
-        "localConnectionMap" : {
-          
-        },
-        "outputConnectionMap" : [
-        ],
-        "inputConnectionMap" : [
-        ],
-        "fromPortNumberMap" : [
-        ],
-        "toPortNumberMap" : [
-        ],
-        "unconnectedPortSet" : [
+        "patternMap": {},
+        "connectionMap": {},
+        "localConnectionMap": {},
+        "outputConnectionMap": [],
+        "inputConnectionMap": [],
+        "fromPortNumberMap": [],
+        "toPortNumberMap": [],
+        "unconnectedPortSet": [
           {
-            "componentInstance" : {
-              "aNode" : {
-                "astNodeId" : 88
+            "componentInstance": {
+              "aNode": {
+                "astNodeId": 88
               },
-              "qualifiedName" : {
-                "qualifier" : [
-                ],
-                "base" : "i"
+              "qualifiedName": {
+                "qualifier": [],
+                "base": "i"
               },
-              "component" : {
-                "astNodeId" : 81
+              "component": {
+                "astNodeId": 81
               },
-              "baseId" : 8448,
-              "maxId" : 8447,
-              "file" : "None",
-              "queueSize" : {
-                "Some" : 10
+              "baseId": 8448,
+              "maxId": 8447,
+              "file": "None",
+              "queueSize": {
+                "Some": 10
               },
-              "stackSize" : "None",
-              "priority" : "None",
-              "cpu" : "None",
-              "initSpecifierMap" : {
-                
-              }
+              "stackSize": "None",
+              "priority": "None",
+              "cpu": "None",
+              "initSpecifierMap": {}
             },
-            "portInstance" : {
-              "Special" : {
-                "aNode" : {
-                  "astNodeId" : 80
+            "portInstance": {
+              "Special": {
+                "aNode": {
+                  "astNodeId": 80
                 },
-                "specifier" : {
-                  "inputKind" : {
-                    "Some" : {
-                      "Async" : {
-                        
-                      }
+                "specifier": {
+                  "inputKind": {
+                    "Some": {
+                      "Async": {}
                     }
                   },
-                  "kind" : {
-                    "ProductRecv" : {
-                      
-                    }
+                  "kind": {
+                    "ProductRecv": {}
                   },
-                  "name" : "productRecvIn",
-                  "priority" : "None",
-                  "queueFull" : "None"
+                  "name": "productRecvIn",
+                  "priority": "None",
+                  "queueFull": "None"
                 },
-                "symbol" : {
-                  "Port" : {
-                    "nodeId" : 67,
-                    "unqualifiedName" : "DpResponse"
+                "symbol": {
+                  "Port": {
+                    "nodeId": 67,
+                    "unqualifiedName": "DpResponse"
                   }
                 },
-                "priority" : "None",
-                "queueFull" : {
-                  "Some" : {
-                    "Assert" : {
-                      
-                    }
+                "priority": "None",
+                "queueFull": {
+                  "Some": {
+                    "Assert": {}
                   }
                 },
-                "importNodeIds" : [
-                ]
+                "importNodeIds": []
               }
             }
           }
         ]
       }
     },
-    "typeMap" : {
-      "23" : {
-        "Enum" : {
-          "node" : {
-            "astNodeId" : 24
+    "typeMap": {
+      "23": {
+        "Enum": {
+          "node": {
+            "astNodeId": 24
           },
-          "repType" : {
-            "kind" : {
-              "I32" : {
-                
-              }
+          "repType": {
+            "kind": {
+              "I32": {}
             }
           },
-          "default" : "None"
+          "default": "None"
         }
       },
-      "44" : {
-        "AbsType" : {
-          "node" : {
-            "astNodeId" : 25
+      "44": {
+        "AbsType": {
+          "node": {
+            "astNodeId": 25
           }
         }
       },
-      "50" : {
-        "Enum" : {
-          "node" : {
-            "astNodeId" : 54
+      "50": {
+        "Enum": {
+          "node": {
+            "astNodeId": 54
           },
-          "repType" : {
-            "kind" : {
-              "I32" : {
-                
-              }
+          "repType": {
+            "kind": {
+              "I32": {}
             }
           },
-          "default" : "None"
+          "default": "None"
         }
       },
-      "24" : {
-        "Enum" : {
-          "node" : {
-            "astNodeId" : 24
+      "24": {
+        "Enum": {
+          "node": {
+            "astNodeId": 24
           },
-          "repType" : {
-            "kind" : {
-              "I32" : {
-                
-              }
+          "repType": {
+            "kind": {
+              "I32": {}
             }
           },
-          "default" : {
-            "Some" : {
-              "value" : [
-                "A",
-                0
-              ],
-              "t" : {
-                "node" : {
-                  "astNodeId" : 24
+          "default": {
+            "Some": {
+              "value": ["A", 0],
+              "t": {
+                "node": {
+                  "astNodeId": 24
                 },
-                "repType" : {
-                  "kind" : {
-                    "I32" : {
-                      
-                    }
+                "repType": {
+                  "kind": {
+                    "I32": {}
                   }
                 },
-                "default" : "None"
+                "default": "None"
               }
             }
           }
         }
       },
-      "48" : {
-        "AbsType" : {
-          "node" : {
-            "astNodeId" : 25
+      "48": {
+        "AbsType": {
+          "node": {
+            "astNodeId": 25
           }
         }
       },
-      "54" : {
-        "Enum" : {
-          "node" : {
-            "astNodeId" : 54
+      "54": {
+        "Enum": {
+          "node": {
+            "astNodeId": 54
           },
-          "repType" : {
-            "kind" : {
-              "I32" : {
-                
-              }
+          "repType": {
+            "kind": {
+              "I32": {}
             }
           },
-          "default" : {
-            "Some" : {
-              "value" : [
-                "SUCCEED",
-                0
-              ],
-              "t" : {
-                "node" : {
-                  "astNodeId" : 54
+          "default": {
+            "Some": {
+              "value": ["SUCCEED", 0],
+              "t": {
+                "node": {
+                  "astNodeId": 54
                 },
-                "repType" : {
-                  "kind" : {
-                    "I32" : {
-                      
-                    }
+                "repType": {
+                  "kind": {
+                    "I32": {}
                   }
                 },
-                "default" : "None"
+                "default": "None"
               }
             }
           }
         }
       },
-      "32" : {
-        "AbsType" : {
-          "node" : {
-            "astNodeId" : 25
+      "32": {
+        "AbsType": {
+          "node": {
+            "astNodeId": 25
           }
         }
       },
-      "6" : {
-        "Int" : {
-          "PrimitiveInt" : {
-            "kind" : {
-              "U32" : {
-                
-              }
+      "6": {
+        "Int": {
+          "PrimitiveInt": {
+            "kind": {
+              "U32": {}
             }
           }
         }
       },
-      "53" : {
-        "Enum" : {
-          "node" : {
-            "astNodeId" : 54
+      "53": {
+        "Enum": {
+          "node": {
+            "astNodeId": 54
           },
-          "repType" : {
-            "kind" : {
-              "I32" : {
-                
-              }
+          "repType": {
+            "kind": {
+              "I32": {}
             }
           },
-          "default" : "None"
+          "default": "None"
         }
       },
-      "20" : {
-        "Enum" : {
-          "node" : {
-            "astNodeId" : 24
+      "20": {
+        "Enum": {
+          "node": {
+            "astNodeId": 24
           },
-          "repType" : {
-            "kind" : {
-              "I32" : {
-                
-              }
+          "repType": {
+            "kind": {
+              "I32": {}
             }
           },
-          "default" : "None"
+          "default": "None"
         }
       },
-      "86" : {
-        "Int" : {
-          "Integer" : {
-            
-          }
+      "86": {
+        "Int": {
+          "Integer": {}
         }
       },
-      "63" : {
-        "Enum" : {
-          "node" : {
-            "astNodeId" : 54
+      "63": {
+        "Enum": {
+          "node": {
+            "astNodeId": 54
           },
-          "repType" : {
-            "kind" : {
-              "I32" : {
-                
-              }
+          "repType": {
+            "kind": {
+              "I32": {}
             }
           },
-          "default" : {
-            "Some" : {
-              "value" : [
-                "SUCCEED",
-                0
-              ],
-              "t" : {
-                "node" : {
-                  "astNodeId" : 54
+          "default": {
+            "Some": {
+              "value": ["SUCCEED", 0],
+              "t": {
+                "node": {
+                  "astNodeId": 54
                 },
-                "repType" : {
-                  "kind" : {
-                    "I32" : {
-                      
-                    }
+                "repType": {
+                  "kind": {
+                    "I32": {}
                   }
                 },
-                "default" : "None"
+                "default": "None"
               }
             }
           }
         }
       },
-      "28" : {
-        "Enum" : {
-          "node" : {
-            "astNodeId" : 24
+      "28": {
+        "Enum": {
+          "node": {
+            "astNodeId": 24
           },
-          "repType" : {
-            "kind" : {
-              "I32" : {
-                
-              }
+          "repType": {
+            "kind": {
+              "I32": {}
             }
           },
-          "default" : {
-            "Some" : {
-              "value" : [
-                "A",
-                0
-              ],
-              "t" : {
-                "node" : {
-                  "astNodeId" : 24
+          "default": {
+            "Some": {
+              "value": ["A", 0],
+              "t": {
+                "node": {
+                  "astNodeId": 24
                 },
-                "repType" : {
-                  "kind" : {
-                    "I32" : {
-                      
-                    }
+                "repType": {
+                  "kind": {
+                    "I32": {}
                   }
                 },
-                "default" : "None"
+                "default": "None"
               }
             }
           }
         }
       },
-      "11" : {
-        "Primitive" : {
-          "Float" : {
-            "kind" : {
-              "F32" : {
-                
-              }
+      "11": {
+        "Primitive": {
+          "Float": {
+            "kind": {
+              "F32": {}
             }
           }
         }
       },
-      "9" : {
-        "Int" : {
-          "PrimitiveInt" : {
-            "kind" : {
-              "I32" : {
-                
-              }
+      "9": {
+        "Int": {
+          "PrimitiveInt": {
+            "kind": {
+              "I32": {}
             }
           }
         }
       },
-      "59" : {
-        "Int" : {
-          "PrimitiveInt" : {
-            "kind" : {
-              "U32" : {
-                
-              }
+      "59": {
+        "Int": {
+          "PrimitiveInt": {
+            "kind": {
+              "U32": {}
             }
           }
         }
       },
-      "87" : {
-        "Int" : {
-          "Integer" : {
-            
-          }
+      "87": {
+        "Int": {
+          "Integer": {}
         }
       },
-      "17" : {
-        "String" : {
-          "size" : "None"
+      "17": {
+        "String": {
+          "size": "None"
         }
       },
-      "25" : {
-        "AbsType" : {
-          "node" : {
-            "astNodeId" : 25
+      "25": {
+        "AbsType": {
+          "node": {
+            "astNodeId": 25
           }
         }
       }
     },
-    "useDefMap" : {
-      "62" : {
-        "Enum" : {
-          "nodeId" : 54,
-          "unqualifiedName" : "Status"
+    "useDefMap": {
+      "62": {
+        "Enum": {
+          "nodeId": 54,
+          "unqualifiedName": "Status"
         }
       },
-      "44" : {
-        "AbsType" : {
-          "nodeId" : 25,
-          "unqualifiedName" : "T"
+      "44": {
+        "AbsType": {
+          "nodeId": 25,
+          "unqualifiedName": "T"
         }
       },
-      "83" : {
-        "Module" : {
-          "nodeId" : 82,
-          "unqualifiedName" : "M"
+      "83": {
+        "Module": {
+          "nodeId": 82,
+          "unqualifiedName": "M"
         }
       },
-      "43" : {
-        "AbsType" : {
-          "nodeId" : 25,
-          "unqualifiedName" : "T"
+      "43": {
+        "AbsType": {
+          "nodeId": 25,
+          "unqualifiedName": "T"
         }
       },
-      "32" : {
-        "AbsType" : {
-          "nodeId" : 25,
-          "unqualifiedName" : "T"
+      "32": {
+        "AbsType": {
+          "nodeId": 25,
+          "unqualifiedName": "T"
         }
       },
-      "80" : {
-        "Port" : {
-          "nodeId" : 67,
-          "unqualifiedName" : "DpResponse"
+      "80": {
+        "Port": {
+          "nodeId": 67,
+          "unqualifiedName": "DpResponse"
         }
       },
-      "27" : {
-        "Enum" : {
-          "nodeId" : 24,
-          "unqualifiedName" : "E"
+      "27": {
+        "Enum": {
+          "nodeId": 24,
+          "unqualifiedName": "E"
         }
       },
-      "63" : {
-        "Enum" : {
-          "nodeId" : 54,
-          "unqualifiedName" : "Status"
+      "63": {
+        "Enum": {
+          "nodeId": 54,
+          "unqualifiedName": "Status"
         }
       },
-      "85" : {
-        "Component" : {
-          "nodeId" : 81,
-          "unqualifiedName" : "Q"
+      "85": {
+        "Component": {
+          "nodeId": 81,
+          "unqualifiedName": "Q"
         }
       },
-      "28" : {
-        "Enum" : {
-          "nodeId" : 24,
-          "unqualifiedName" : "E"
+      "28": {
+        "Enum": {
+          "nodeId": 24,
+          "unqualifiedName": "E"
         }
       },
-      "48" : {
-        "AbsType" : {
-          "nodeId" : 25,
-          "unqualifiedName" : "T"
+      "48": {
+        "AbsType": {
+          "nodeId": 25,
+          "unqualifiedName": "T"
         }
       },
-      "116" : {
-        "ComponentInstance" : {
-          "nodeId" : 88,
-          "unqualifiedName" : "i"
+      "116": {
+        "ComponentInstance": {
+          "nodeId": 88,
+          "unqualifiedName": "i"
         }
       },
-      "47" : {
-        "AbsType" : {
-          "nodeId" : 25,
-          "unqualifiedName" : "T"
+      "47": {
+        "AbsType": {
+          "nodeId": 25,
+          "unqualifiedName": "T"
         }
       },
-      "31" : {
-        "AbsType" : {
-          "nodeId" : 25,
-          "unqualifiedName" : "T"
+      "31": {
+        "AbsType": {
+          "nodeId": 25,
+          "unqualifiedName": "T"
         }
       }
     },
-    "valueMap" : {
-      "23" : {
-        "EnumConstant" : {
-          "value" : [
-            "B",
-            1
-          ],
-          "t" : {
-            "node" : {
-              "astNodeId" : 24
+    "valueMap": {
+      "23": {
+        "EnumConstant": {
+          "value": ["B", 1],
+          "t": {
+            "node": {
+              "astNodeId": 24
             },
-            "repType" : {
-              "kind" : {
-                "I32" : {
-                  
-                }
+            "repType": {
+              "kind": {
+                "I32": {}
               }
             },
-            "default" : "None"
+            "default": "None"
           }
         }
       },
-      "50" : {
-        "EnumConstant" : {
-          "value" : [
-            "SUCCEED",
-            0
-          ],
-          "t" : {
-            "node" : {
-              "astNodeId" : 54
+      "50": {
+        "EnumConstant": {
+          "value": ["SUCCEED", 0],
+          "t": {
+            "node": {
+              "astNodeId": 54
             },
-            "repType" : {
-              "kind" : {
-                "I32" : {
-                  
-                }
+            "repType": {
+              "kind": {
+                "I32": {}
               }
             },
-            "default" : "None"
+            "default": "None"
           }
         }
       },
-      "87" : {
-        "Integer" : {
-          "value" : 10
+      "87": {
+        "Integer": {
+          "value": 10
         }
       },
-      "53" : {
-        "EnumConstant" : {
-          "value" : [
-            "FAIL",
-            1
-          ],
-          "t" : {
-            "node" : {
-              "astNodeId" : 54
+      "53": {
+        "EnumConstant": {
+          "value": ["FAIL", 1],
+          "t": {
+            "node": {
+              "astNodeId": 54
             },
-            "repType" : {
-              "kind" : {
-                "I32" : {
-                  
-                }
+            "repType": {
+              "kind": {
+                "I32": {}
               }
             },
-            "default" : "None"
+            "default": "None"
           }
         }
       },
-      "20" : {
-        "EnumConstant" : {
-          "value" : [
-            "A",
-            0
-          ],
-          "t" : {
-            "node" : {
-              "astNodeId" : 24
+      "20": {
+        "EnumConstant": {
+          "value": ["A", 0],
+          "t": {
+            "node": {
+              "astNodeId": 24
             },
-            "repType" : {
-              "kind" : {
-                "I32" : {
-                  
-                }
+            "repType": {
+              "kind": {
+                "I32": {}
               }
             },
-            "default" : "None"
+            "default": "None"
           }
         }
       },
-      "86" : {
-        "Integer" : {
-          "value" : 8448
+      "86": {
+        "Integer": {
+          "value": 8448
         }
       }
     },
-    "stateMachineMap" : {
-      
-    },
-    "dictionarySymbolSet" : [
-    ],
-    "interfaceMap" : {
-      
-    }
+    "stateMachineMap": {},
+    "dictionarySymbolSet": [],
+    "interfaceMap": {}
   }
 }

--- a/tests/ports/ports_analysis.json
+++ b/tests/ports/ports_analysis.json
@@ -1,819 +1,959 @@
 {
-  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
-  "analysis": {
-    "componentInstanceMap": {
-      "88": {
-        "aNode": {
-          "astNodeId": 88
+  "fppVersion" : "v3.1.0a10-54-g11243e778",
+  "analysis" : {
+    "componentInstanceMap" : {
+      "88" : {
+        "aNode" : {
+          "astNodeId" : 88
         },
-        "qualifiedName": {
-          "qualifier": [],
-          "base": "i"
+        "qualifiedName" : {
+          "qualifier" : [
+          ],
+          "base" : "i"
         },
-        "component": {
-          "astNodeId": 81
+        "component" : {
+          "astNodeId" : 81
         },
-        "baseId": 8448,
-        "maxId": 8447,
-        "file": "None",
-        "queueSize": {
-          "Some": 10
+        "baseId" : 8448,
+        "maxId" : 8447,
+        "file" : "None",
+        "queueSize" : {
+          "Some" : 10
         },
-        "stackSize": "None",
-        "priority": "None",
-        "cpu": "None",
-        "initSpecifierMap": {}
+        "stackSize" : "None",
+        "priority" : "None",
+        "cpu" : "None",
+        "initSpecifierMap" : {
+          
+        }
       }
     },
-    "componentMap": {
-      "81": {
-        "aNode": {
-          "astNodeId": 81
+    "componentMap" : {
+      "81" : {
+        "aNode" : {
+          "astNodeId" : 81
         },
-        "portMap": {
-          "productRecvIn": {
-            "Special": {
-              "aNode": {
-                "astNodeId": 80
+        "portMap" : {
+          "productRecvIn" : {
+            "Special" : {
+              "aNode" : {
+                "astNodeId" : 80
               },
-              "specifier": {
-                "inputKind": {
-                  "Some": {
-                    "Async": {}
+              "specifier" : {
+                "inputKind" : {
+                  "Some" : {
+                    "Async" : {
+                      
+                    }
                   }
                 },
-                "kind": {
-                  "ProductRecv": {}
+                "kind" : {
+                  "ProductRecv" : {
+                    
+                  }
                 },
-                "name": "productRecvIn",
-                "priority": "None",
-                "queueFull": "None"
+                "name" : "productRecvIn",
+                "priority" : "None",
+                "queueFull" : "None"
               },
-              "symbol": {
-                "Port": {
-                  "nodeId": 67,
-                  "unqualifiedName": "DpResponse"
+              "symbol" : {
+                "Port" : {
+                  "nodeId" : 67,
+                  "unqualifiedName" : "DpResponse"
                 }
               },
-              "priority": "None",
-              "queueFull": {
-                "Some": {
-                  "Assert": {}
+              "priority" : "None",
+              "queueFull" : {
+                "Some" : {
+                  "Assert" : {
+                    
+                  }
                 }
               },
-              "importNodeIds": []
+              "importNodeIds" : [
+              ]
             }
           }
         },
-        "specialPortMap": {
-          "product recv": {
-            "aNode": {
-              "astNodeId": 80
+        "specialPortMap" : {
+          "product recv" : {
+            "aNode" : {
+              "astNodeId" : 80
             },
-            "specifier": {
-              "inputKind": {
-                "Some": {
-                  "Async": {}
+            "specifier" : {
+              "inputKind" : {
+                "Some" : {
+                  "Async" : {
+                    
+                  }
                 }
               },
-              "kind": {
-                "ProductRecv": {}
+              "kind" : {
+                "ProductRecv" : {
+                  
+                }
               },
-              "name": "productRecvIn",
-              "priority": "None",
-              "queueFull": "None"
+              "name" : "productRecvIn",
+              "priority" : "None",
+              "queueFull" : "None"
             },
-            "symbol": {
-              "Port": {
-                "nodeId": 67,
-                "unqualifiedName": "DpResponse"
+            "symbol" : {
+              "Port" : {
+                "nodeId" : 67,
+                "unqualifiedName" : "DpResponse"
               }
             },
-            "priority": "None",
-            "queueFull": {
-              "Some": {
-                "Assert": {}
+            "priority" : "None",
+            "queueFull" : {
+              "Some" : {
+                "Assert" : {
+                  
+                }
               }
             },
-            "importNodeIds": []
+            "importNodeIds" : [
+            ]
           }
         },
-        "commandMap": {},
-        "defaultOpcode": 0,
-        "tlmChannelMap": {},
-        "tlmChannelNameMap": {},
-        "defaultTlmChannelId": 0,
-        "eventMap": {},
-        "defaultEventId": 0,
-        "paramMap": {},
-        "specPortMatchingList": [],
-        "stateMachineInstanceMap": {},
-        "portMatchingList": [],
-        "defaultParamId": 0,
-        "containerMap": {},
-        "defaultContainerId": 0,
-        "recordMap": {},
-        "defaultRecordId": 0
+        "commandMap" : {
+          
+        },
+        "defaultOpcode" : 0,
+        "tlmChannelMap" : {
+          
+        },
+        "tlmChannelNameMap" : {
+          
+        },
+        "defaultTlmChannelId" : 0,
+        "eventMap" : {
+          
+        },
+        "defaultEventId" : 0,
+        "paramMap" : {
+          
+        },
+        "specPortMatchingList" : [
+        ],
+        "stateMachineInstanceMap" : {
+          
+        },
+        "portMatchingList" : [
+        ],
+        "defaultParamId" : 0,
+        "containerMap" : {
+          
+        },
+        "defaultContainerId" : 0,
+        "recordMap" : {
+          
+        },
+        "defaultRecordId" : 0
       }
     },
-    "includedFileSet": [],
-    "inputFileSet": [
+    "includedFileSet" : [
+    ],
+    "inputFileSet" : [
       "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp"
     ],
-    "locationSpecifierMap": [],
-    "parentSymbolMap": {
-      "67": {
-        "Module": {
-          "nodeId": 68,
-          "unqualifiedName": "Fw"
+    "locationSpecifierMap" : [
+    ],
+    "parentSymbolMap" : {
+      "67" : {
+        "Module" : {
+          "nodeId" : 68,
+          "unqualifiedName" : "Fw"
         }
       },
-      "23": {
-        "Enum": {
-          "nodeId": 24,
-          "unqualifiedName": "E"
+      "23" : {
+        "Enum" : {
+          "nodeId" : 24,
+          "unqualifiedName" : "E"
         }
       },
-      "50": {
-        "Enum": {
-          "nodeId": 54,
-          "unqualifiedName": "Status"
+      "50" : {
+        "Enum" : {
+          "nodeId" : 54,
+          "unqualifiedName" : "Status"
         }
       },
-      "69": {
-        "Module": {
-          "nodeId": 82,
-          "unqualifiedName": "M"
+      "69" : {
+        "Module" : {
+          "nodeId" : 82,
+          "unqualifiedName" : "M"
         }
       },
-      "53": {
-        "Enum": {
-          "nodeId": 54,
-          "unqualifiedName": "Status"
+      "53" : {
+        "Enum" : {
+          "nodeId" : 54,
+          "unqualifiedName" : "Status"
         }
       },
-      "20": {
-        "Enum": {
-          "nodeId": 24,
-          "unqualifiedName": "E"
+      "20" : {
+        "Enum" : {
+          "nodeId" : 24,
+          "unqualifiedName" : "E"
         }
       },
-      "81": {
-        "Module": {
-          "nodeId": 82,
-          "unqualifiedName": "M"
+      "81" : {
+        "Module" : {
+          "nodeId" : 82,
+          "unqualifiedName" : "M"
         }
       },
-      "118": {
-        "Module": {
-          "nodeId": 82,
-          "unqualifiedName": "M"
+      "118" : {
+        "Module" : {
+          "nodeId" : 82,
+          "unqualifiedName" : "M"
         }
       }
     },
-    "symbolScopeMap": {
-      "68": {
-        "map": {
-          "Port": {
-            "map": {
-              "DpResponse": {
-                "Port": {
-                  "nodeId": 67,
-                  "unqualifiedName": "DpResponse"
+    "symbolScopeMap" : {
+      "68" : {
+        "map" : {
+          "Port" : {
+            "map" : {
+              "DpResponse" : {
+                "Port" : {
+                  "nodeId" : 67,
+                  "unqualifiedName" : "DpResponse"
                 }
               }
             }
           }
         }
       },
-      "24": {
-        "map": {
-          "Value": {
-            "map": {
-              "A": {
-                "EnumConstant": {
-                  "nodeId": 20,
-                  "unqualifiedName": "A"
+      "24" : {
+        "map" : {
+          "Value" : {
+            "map" : {
+              "A" : {
+                "EnumConstant" : {
+                  "nodeId" : 20,
+                  "unqualifiedName" : "A"
                 }
               },
-              "B": {
-                "EnumConstant": {
-                  "nodeId": 23,
-                  "unqualifiedName": "B"
+              "B" : {
+                "EnumConstant" : {
+                  "nodeId" : 23,
+                  "unqualifiedName" : "B"
                 }
               }
             }
           }
         }
       },
-      "54": {
-        "map": {
-          "Value": {
-            "map": {
-              "SUCCEED": {
-                "EnumConstant": {
-                  "nodeId": 50,
-                  "unqualifiedName": "SUCCEED"
+      "54" : {
+        "map" : {
+          "Value" : {
+            "map" : {
+              "SUCCEED" : {
+                "EnumConstant" : {
+                  "nodeId" : 50,
+                  "unqualifiedName" : "SUCCEED"
                 }
               },
-              "FAIL": {
-                "EnumConstant": {
-                  "nodeId": 53,
-                  "unqualifiedName": "FAIL"
+              "FAIL" : {
+                "EnumConstant" : {
+                  "nodeId" : 53,
+                  "unqualifiedName" : "FAIL"
                 }
               }
             }
           }
         }
       },
-      "82": {
-        "map": {
-          "Topology": {
-            "map": {
-              "T": {
-                "Topology": {
-                  "nodeId": 118,
-                  "unqualifiedName": "T"
+      "82" : {
+        "map" : {
+          "Topology" : {
+            "map" : {
+              "T" : {
+                "Topology" : {
+                  "nodeId" : 118,
+                  "unqualifiedName" : "T"
                 }
               }
             }
           },
-          "StateMachine": {
-            "map": {
-              "Q": {
-                "Component": {
-                  "nodeId": 81,
-                  "unqualifiedName": "Q"
+          "StateMachine" : {
+            "map" : {
+              "Q" : {
+                "Component" : {
+                  "nodeId" : 81,
+                  "unqualifiedName" : "Q"
                 }
               }
             }
           },
-          "Value": {
-            "map": {
-              "Q": {
-                "Component": {
-                  "nodeId": 81,
-                  "unqualifiedName": "Q"
+          "Value" : {
+            "map" : {
+              "Q" : {
+                "Component" : {
+                  "nodeId" : 81,
+                  "unqualifiedName" : "Q"
                 }
               }
             }
           },
-          "Port": {
-            "map": {
-              "P": {
-                "Port": {
-                  "nodeId": 69,
-                  "unqualifiedName": "P"
+          "Port" : {
+            "map" : {
+              "P" : {
+                "Port" : {
+                  "nodeId" : 69,
+                  "unqualifiedName" : "P"
                 }
               }
             }
           },
-          "Component": {
-            "map": {
-              "Q": {
-                "Component": {
-                  "nodeId": 81,
-                  "unqualifiedName": "Q"
+          "Component" : {
+            "map" : {
+              "Q" : {
+                "Component" : {
+                  "nodeId" : 81,
+                  "unqualifiedName" : "Q"
                 }
               }
             }
           },
-          "Type": {
-            "map": {
-              "Q": {
-                "Component": {
-                  "nodeId": 81,
-                  "unqualifiedName": "Q"
+          "Type" : {
+            "map" : {
+              "Q" : {
+                "Component" : {
+                  "nodeId" : 81,
+                  "unqualifiedName" : "Q"
                 }
               }
             }
           }
         }
       },
-      "81": {
-        "map": {}
+      "81" : {
+        "map" : {
+          
+        }
       }
     },
-    "topologyMap": {
-      "118": {
-        "aNode": {
-          "astNodeId": 118
+    "topologyMap" : {
+      "118" : {
+        "aNode" : {
+          "astNodeId" : 118
         },
-        "directImportMap": {},
-        "transitiveImportSet": [],
-        "instanceMap": [
+        "directImportMap" : {
+          
+        },
+        "transitiveImportSet" : [
+        ],
+        "instanceMap" : [
           [
             {
-              "aNode": {
-                "astNodeId": 88
+              "aNode" : {
+                "astNodeId" : 88
               },
-              "qualifiedName": {
-                "qualifier": [],
-                "base": "i"
+              "qualifiedName" : {
+                "qualifier" : [
+                ],
+                "base" : "i"
               },
-              "component": {
-                "astNodeId": 81
+              "component" : {
+                "astNodeId" : 81
               },
-              "baseId": 8448,
-              "maxId": 8447,
-              "file": "None",
-              "queueSize": {
-                "Some": 10
+              "baseId" : 8448,
+              "maxId" : 8447,
+              "file" : "None",
+              "queueSize" : {
+                "Some" : 10
               },
-              "stackSize": "None",
-              "priority": "None",
-              "cpu": "None",
-              "initSpecifierMap": {}
+              "stackSize" : "None",
+              "priority" : "None",
+              "cpu" : "None",
+              "initSpecifierMap" : {
+                
+              }
             },
             [
               {
-                "Public": {}
+                "Public" : {
+                  
+                }
               },
               {
-                "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-                "pos": "39.9",
-                "includingLoc": "None"
+                "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+                "pos" : "39.9",
+                "includingLoc" : "None"
               }
             ]
           ]
         ],
-        "patternMap": {},
-        "connectionMap": {},
-        "localConnectionMap": {},
-        "outputConnectionMap": [],
-        "inputConnectionMap": [],
-        "fromPortNumberMap": [],
-        "toPortNumberMap": [],
-        "unconnectedPortSet": [
+        "patternMap" : {
+          
+        },
+        "connectionMap" : {
+          
+        },
+        "localConnectionMap" : {
+          
+        },
+        "outputConnectionMap" : [
+        ],
+        "inputConnectionMap" : [
+        ],
+        "fromPortNumberMap" : [
+        ],
+        "toPortNumberMap" : [
+        ],
+        "unconnectedPortSet" : [
           {
-            "componentInstance": {
-              "aNode": {
-                "astNodeId": 88
+            "componentInstance" : {
+              "aNode" : {
+                "astNodeId" : 88
               },
-              "qualifiedName": {
-                "qualifier": [],
-                "base": "i"
+              "qualifiedName" : {
+                "qualifier" : [
+                ],
+                "base" : "i"
               },
-              "component": {
-                "astNodeId": 81
+              "component" : {
+                "astNodeId" : 81
               },
-              "baseId": 8448,
-              "maxId": 8447,
-              "file": "None",
-              "queueSize": {
-                "Some": 10
+              "baseId" : 8448,
+              "maxId" : 8447,
+              "file" : "None",
+              "queueSize" : {
+                "Some" : 10
               },
-              "stackSize": "None",
-              "priority": "None",
-              "cpu": "None",
-              "initSpecifierMap": {}
+              "stackSize" : "None",
+              "priority" : "None",
+              "cpu" : "None",
+              "initSpecifierMap" : {
+                
+              }
             },
-            "portInstance": {
-              "Special": {
-                "aNode": {
-                  "astNodeId": 80
+            "portInstance" : {
+              "Special" : {
+                "aNode" : {
+                  "astNodeId" : 80
                 },
-                "specifier": {
-                  "inputKind": {
-                    "Some": {
-                      "Async": {}
+                "specifier" : {
+                  "inputKind" : {
+                    "Some" : {
+                      "Async" : {
+                        
+                      }
                     }
                   },
-                  "kind": {
-                    "ProductRecv": {}
+                  "kind" : {
+                    "ProductRecv" : {
+                      
+                    }
                   },
-                  "name": "productRecvIn",
-                  "priority": "None",
-                  "queueFull": "None"
+                  "name" : "productRecvIn",
+                  "priority" : "None",
+                  "queueFull" : "None"
                 },
-                "symbol": {
-                  "Port": {
-                    "nodeId": 67,
-                    "unqualifiedName": "DpResponse"
+                "symbol" : {
+                  "Port" : {
+                    "nodeId" : 67,
+                    "unqualifiedName" : "DpResponse"
                   }
                 },
-                "priority": "None",
-                "queueFull": {
-                  "Some": {
-                    "Assert": {}
+                "priority" : "None",
+                "queueFull" : {
+                  "Some" : {
+                    "Assert" : {
+                      
+                    }
                   }
                 },
-                "importNodeIds": []
+                "importNodeIds" : [
+                ]
               }
             }
           }
         ]
       }
     },
-    "typeMap": {
-      "23": {
-        "Enum": {
-          "node": {
-            "astNodeId": 24
+    "typeMap" : {
+      "23" : {
+        "Enum" : {
+          "node" : {
+            "astNodeId" : 24
           },
-          "repType": {
-            "kind": {
-              "I32": {}
+          "repType" : {
+            "kind" : {
+              "I32" : {
+                
+              }
             }
           },
-          "default": "None"
+          "default" : "None"
         }
       },
-      "44": {
-        "AbsType": {
-          "node": {
-            "astNodeId": 25
+      "44" : {
+        "AbsType" : {
+          "node" : {
+            "astNodeId" : 25
           }
         }
       },
-      "50": {
-        "Enum": {
-          "node": {
-            "astNodeId": 54
+      "50" : {
+        "Enum" : {
+          "node" : {
+            "astNodeId" : 54
           },
-          "repType": {
-            "kind": {
-              "I32": {}
+          "repType" : {
+            "kind" : {
+              "I32" : {
+                
+              }
             }
           },
-          "default": "None"
+          "default" : "None"
         }
       },
-      "24": {
-        "Enum": {
-          "node": {
-            "astNodeId": 24
+      "24" : {
+        "Enum" : {
+          "node" : {
+            "astNodeId" : 24
           },
-          "repType": {
-            "kind": {
-              "I32": {}
+          "repType" : {
+            "kind" : {
+              "I32" : {
+                
+              }
             }
           },
-          "default": {
-            "Some": {
-              "value": ["A", 0],
-              "t": {
-                "node": {
-                  "astNodeId": 24
+          "default" : {
+            "Some" : {
+              "value" : [
+                "A",
+                0
+              ],
+              "t" : {
+                "node" : {
+                  "astNodeId" : 24
                 },
-                "repType": {
-                  "kind": {
-                    "I32": {}
+                "repType" : {
+                  "kind" : {
+                    "I32" : {
+                      
+                    }
                   }
                 },
-                "default": "None"
+                "default" : "None"
               }
             }
           }
         }
       },
-      "48": {
-        "AbsType": {
-          "node": {
-            "astNodeId": 25
+      "48" : {
+        "AbsType" : {
+          "node" : {
+            "astNodeId" : 25
           }
         }
       },
-      "54": {
-        "Enum": {
-          "node": {
-            "astNodeId": 54
+      "54" : {
+        "Enum" : {
+          "node" : {
+            "astNodeId" : 54
           },
-          "repType": {
-            "kind": {
-              "I32": {}
+          "repType" : {
+            "kind" : {
+              "I32" : {
+                
+              }
             }
           },
-          "default": {
-            "Some": {
-              "value": ["SUCCEED", 0],
-              "t": {
-                "node": {
-                  "astNodeId": 54
+          "default" : {
+            "Some" : {
+              "value" : [
+                "SUCCEED",
+                0
+              ],
+              "t" : {
+                "node" : {
+                  "astNodeId" : 54
                 },
-                "repType": {
-                  "kind": {
-                    "I32": {}
+                "repType" : {
+                  "kind" : {
+                    "I32" : {
+                      
+                    }
                   }
                 },
-                "default": "None"
+                "default" : "None"
               }
             }
           }
         }
       },
-      "32": {
-        "AbsType": {
-          "node": {
-            "astNodeId": 25
+      "32" : {
+        "AbsType" : {
+          "node" : {
+            "astNodeId" : 25
           }
         }
       },
-      "6": {
-        "Int": {
-          "PrimitiveInt": {
-            "kind": {
-              "U32": {}
-            }
-          }
-        }
-      },
-      "53": {
-        "Enum": {
-          "node": {
-            "astNodeId": 54
-          },
-          "repType": {
-            "kind": {
-              "I32": {}
-            }
-          },
-          "default": "None"
-        }
-      },
-      "20": {
-        "Enum": {
-          "node": {
-            "astNodeId": 24
-          },
-          "repType": {
-            "kind": {
-              "I32": {}
-            }
-          },
-          "default": "None"
-        }
-      },
-      "86": {
-        "Int": {
-          "Integer": {}
-        }
-      },
-      "63": {
-        "Enum": {
-          "node": {
-            "astNodeId": 54
-          },
-          "repType": {
-            "kind": {
-              "I32": {}
-            }
-          },
-          "default": {
-            "Some": {
-              "value": ["SUCCEED", 0],
-              "t": {
-                "node": {
-                  "astNodeId": 54
-                },
-                "repType": {
-                  "kind": {
-                    "I32": {}
-                  }
-                },
-                "default": "None"
+      "6" : {
+        "Int" : {
+          "PrimitiveInt" : {
+            "kind" : {
+              "U32" : {
+                
               }
             }
           }
         }
       },
-      "28": {
-        "Enum": {
-          "node": {
-            "astNodeId": 24
+      "53" : {
+        "Enum" : {
+          "node" : {
+            "astNodeId" : 54
           },
-          "repType": {
-            "kind": {
-              "I32": {}
+          "repType" : {
+            "kind" : {
+              "I32" : {
+                
+              }
             }
           },
-          "default": {
-            "Some": {
-              "value": ["A", 0],
-              "t": {
-                "node": {
-                  "astNodeId": 24
+          "default" : "None"
+        }
+      },
+      "20" : {
+        "Enum" : {
+          "node" : {
+            "astNodeId" : 24
+          },
+          "repType" : {
+            "kind" : {
+              "I32" : {
+                
+              }
+            }
+          },
+          "default" : "None"
+        }
+      },
+      "86" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
+        }
+      },
+      "63" : {
+        "Enum" : {
+          "node" : {
+            "astNodeId" : 54
+          },
+          "repType" : {
+            "kind" : {
+              "I32" : {
+                
+              }
+            }
+          },
+          "default" : {
+            "Some" : {
+              "value" : [
+                "SUCCEED",
+                0
+              ],
+              "t" : {
+                "node" : {
+                  "astNodeId" : 54
                 },
-                "repType": {
-                  "kind": {
-                    "I32": {}
+                "repType" : {
+                  "kind" : {
+                    "I32" : {
+                      
+                    }
                   }
                 },
-                "default": "None"
+                "default" : "None"
               }
             }
           }
         }
       },
-      "11": {
-        "Primitive": {
-          "Float": {
-            "kind": {
-              "F32": {}
+      "28" : {
+        "Enum" : {
+          "node" : {
+            "astNodeId" : 24
+          },
+          "repType" : {
+            "kind" : {
+              "I32" : {
+                
+              }
+            }
+          },
+          "default" : {
+            "Some" : {
+              "value" : [
+                "A",
+                0
+              ],
+              "t" : {
+                "node" : {
+                  "astNodeId" : 24
+                },
+                "repType" : {
+                  "kind" : {
+                    "I32" : {
+                      
+                    }
+                  }
+                },
+                "default" : "None"
+              }
             }
           }
         }
       },
-      "9": {
-        "Int": {
-          "PrimitiveInt": {
-            "kind": {
-              "I32": {}
+      "11" : {
+        "Primitive" : {
+          "Float" : {
+            "kind" : {
+              "F32" : {
+                
+              }
             }
           }
         }
       },
-      "59": {
-        "Int": {
-          "PrimitiveInt": {
-            "kind": {
-              "U32": {}
+      "9" : {
+        "Int" : {
+          "PrimitiveInt" : {
+            "kind" : {
+              "I32" : {
+                
+              }
             }
           }
         }
       },
-      "87": {
-        "Int": {
-          "Integer": {}
+      "59" : {
+        "Int" : {
+          "PrimitiveInt" : {
+            "kind" : {
+              "U32" : {
+                
+              }
+            }
+          }
         }
       },
-      "17": {
-        "String": {
-          "size": "None"
+      "87" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "25": {
-        "AbsType": {
-          "node": {
-            "astNodeId": 25
+      "17" : {
+        "String" : {
+          "size" : "None"
+        }
+      },
+      "25" : {
+        "AbsType" : {
+          "node" : {
+            "astNodeId" : 25
           }
         }
       }
     },
-    "useDefMap": {
-      "62": {
-        "Enum": {
-          "nodeId": 54,
-          "unqualifiedName": "Status"
+    "useDefMap" : {
+      "62" : {
+        "Enum" : {
+          "nodeId" : 54,
+          "unqualifiedName" : "Status"
         }
       },
-      "44": {
-        "AbsType": {
-          "nodeId": 25,
-          "unqualifiedName": "T"
+      "44" : {
+        "AbsType" : {
+          "nodeId" : 25,
+          "unqualifiedName" : "T"
         }
       },
-      "83": {
-        "Module": {
-          "nodeId": 82,
-          "unqualifiedName": "M"
+      "83" : {
+        "Module" : {
+          "nodeId" : 82,
+          "unqualifiedName" : "M"
         }
       },
-      "43": {
-        "AbsType": {
-          "nodeId": 25,
-          "unqualifiedName": "T"
+      "43" : {
+        "AbsType" : {
+          "nodeId" : 25,
+          "unqualifiedName" : "T"
         }
       },
-      "32": {
-        "AbsType": {
-          "nodeId": 25,
-          "unqualifiedName": "T"
+      "32" : {
+        "AbsType" : {
+          "nodeId" : 25,
+          "unqualifiedName" : "T"
         }
       },
-      "80": {
-        "Port": {
-          "nodeId": 67,
-          "unqualifiedName": "DpResponse"
+      "80" : {
+        "Port" : {
+          "nodeId" : 67,
+          "unqualifiedName" : "DpResponse"
         }
       },
-      "27": {
-        "Enum": {
-          "nodeId": 24,
-          "unqualifiedName": "E"
+      "27" : {
+        "Enum" : {
+          "nodeId" : 24,
+          "unqualifiedName" : "E"
         }
       },
-      "63": {
-        "Enum": {
-          "nodeId": 54,
-          "unqualifiedName": "Status"
+      "63" : {
+        "Enum" : {
+          "nodeId" : 54,
+          "unqualifiedName" : "Status"
         }
       },
-      "85": {
-        "Component": {
-          "nodeId": 81,
-          "unqualifiedName": "Q"
+      "85" : {
+        "Component" : {
+          "nodeId" : 81,
+          "unqualifiedName" : "Q"
         }
       },
-      "28": {
-        "Enum": {
-          "nodeId": 24,
-          "unqualifiedName": "E"
+      "28" : {
+        "Enum" : {
+          "nodeId" : 24,
+          "unqualifiedName" : "E"
         }
       },
-      "48": {
-        "AbsType": {
-          "nodeId": 25,
-          "unqualifiedName": "T"
+      "48" : {
+        "AbsType" : {
+          "nodeId" : 25,
+          "unqualifiedName" : "T"
         }
       },
-      "116": {
-        "ComponentInstance": {
-          "nodeId": 88,
-          "unqualifiedName": "i"
+      "116" : {
+        "ComponentInstance" : {
+          "nodeId" : 88,
+          "unqualifiedName" : "i"
         }
       },
-      "47": {
-        "AbsType": {
-          "nodeId": 25,
-          "unqualifiedName": "T"
+      "47" : {
+        "AbsType" : {
+          "nodeId" : 25,
+          "unqualifiedName" : "T"
         }
       },
-      "31": {
-        "AbsType": {
-          "nodeId": 25,
-          "unqualifiedName": "T"
+      "31" : {
+        "AbsType" : {
+          "nodeId" : 25,
+          "unqualifiedName" : "T"
         }
       }
     },
-    "valueMap": {
-      "23": {
-        "EnumConstant": {
-          "value": ["B", 1],
-          "t": {
-            "node": {
-              "astNodeId": 24
+    "valueMap" : {
+      "23" : {
+        "EnumConstant" : {
+          "value" : [
+            "B",
+            1
+          ],
+          "t" : {
+            "node" : {
+              "astNodeId" : 24
             },
-            "repType": {
-              "kind": {
-                "I32": {}
+            "repType" : {
+              "kind" : {
+                "I32" : {
+                  
+                }
               }
             },
-            "default": "None"
+            "default" : "None"
           }
         }
       },
-      "50": {
-        "EnumConstant": {
-          "value": ["SUCCEED", 0],
-          "t": {
-            "node": {
-              "astNodeId": 54
+      "50" : {
+        "EnumConstant" : {
+          "value" : [
+            "SUCCEED",
+            0
+          ],
+          "t" : {
+            "node" : {
+              "astNodeId" : 54
             },
-            "repType": {
-              "kind": {
-                "I32": {}
+            "repType" : {
+              "kind" : {
+                "I32" : {
+                  
+                }
               }
             },
-            "default": "None"
+            "default" : "None"
           }
         }
       },
-      "87": {
-        "Integer": {
-          "value": 10
+      "87" : {
+        "Integer" : {
+          "value" : 10
         }
       },
-      "53": {
-        "EnumConstant": {
-          "value": ["FAIL", 1],
-          "t": {
-            "node": {
-              "astNodeId": 54
+      "53" : {
+        "EnumConstant" : {
+          "value" : [
+            "FAIL",
+            1
+          ],
+          "t" : {
+            "node" : {
+              "astNodeId" : 54
             },
-            "repType": {
-              "kind": {
-                "I32": {}
+            "repType" : {
+              "kind" : {
+                "I32" : {
+                  
+                }
               }
             },
-            "default": "None"
+            "default" : "None"
           }
         }
       },
-      "20": {
-        "EnumConstant": {
-          "value": ["A", 0],
-          "t": {
-            "node": {
-              "astNodeId": 24
+      "20" : {
+        "EnumConstant" : {
+          "value" : [
+            "A",
+            0
+          ],
+          "t" : {
+            "node" : {
+              "astNodeId" : 24
             },
-            "repType": {
-              "kind": {
-                "I32": {}
+            "repType" : {
+              "kind" : {
+                "I32" : {
+                  
+                }
               }
             },
-            "default": "None"
+            "default" : "None"
           }
         }
       },
-      "86": {
-        "Integer": {
-          "value": 8448
+      "86" : {
+        "Integer" : {
+          "value" : 8448
         }
       }
     },
-    "stateMachineMap": {},
-    "dictionarySymbolSet": [],
-    "interfaceMap": {}
+    "stateMachineMap" : {
+      
+    },
+    "dictionarySymbolSet" : [
+    ],
+    "interfaceMap" : {
+      
+    }
   }
 }

--- a/tests/ports/ports_analysis.json
+++ b/tests/ports/ports_analysis.json
@@ -1,819 +1,959 @@
 {
-  "fppVersion": "[ fpp version ]",
-  "analysis": {
-    "componentInstanceMap": {
-      "88": {
-        "aNode": {
-          "astNodeId": 88
+  "fppVersion" : "v3.1.0a10-46-g5b2da7ca1",
+  "analysis" : {
+    "componentInstanceMap" : {
+      "88" : {
+        "aNode" : {
+          "astNodeId" : 88
         },
-        "qualifiedName": {
-          "qualifier": [],
-          "base": "i"
+        "qualifiedName" : {
+          "qualifier" : [
+          ],
+          "base" : "i"
         },
-        "component": {
-          "astNodeId": 81
+        "component" : {
+          "astNodeId" : 81
         },
-        "baseId": 8448,
-        "maxId": 8447,
-        "file": "None",
-        "queueSize": {
-          "Some": 10
+        "baseId" : 8448,
+        "maxId" : 8447,
+        "file" : "None",
+        "queueSize" : {
+          "Some" : 10
         },
-        "stackSize": "None",
-        "priority": "None",
-        "cpu": "None",
-        "initSpecifierMap": {}
+        "stackSize" : "None",
+        "priority" : "None",
+        "cpu" : "None",
+        "initSpecifierMap" : {
+          
+        }
       }
     },
-    "componentMap": {
-      "81": {
-        "aNode": {
-          "astNodeId": 81
+    "componentMap" : {
+      "81" : {
+        "aNode" : {
+          "astNodeId" : 81
         },
-        "portMap": {
-          "productRecvIn": {
-            "Special": {
-              "aNode": {
-                "astNodeId": 80
+        "portMap" : {
+          "productRecvIn" : {
+            "Special" : {
+              "aNode" : {
+                "astNodeId" : 80
               },
-              "specifier": {
-                "inputKind": {
-                  "Some": {
-                    "Async": {}
+              "specifier" : {
+                "inputKind" : {
+                  "Some" : {
+                    "Async" : {
+                      
+                    }
                   }
                 },
-                "kind": {
-                  "ProductRecv": {}
+                "kind" : {
+                  "ProductRecv" : {
+                    
+                  }
                 },
-                "name": "productRecvIn",
-                "priority": "None",
-                "queueFull": "None"
+                "name" : "productRecvIn",
+                "priority" : "None",
+                "queueFull" : "None"
               },
-              "symbol": {
-                "Port": {
-                  "nodeId": 67,
-                  "unqualifiedName": "DpResponse"
+              "symbol" : {
+                "Port" : {
+                  "nodeId" : 67,
+                  "unqualifiedName" : "DpResponse"
                 }
               },
-              "priority": "None",
-              "queueFull": {
-                "Some": {
-                  "Assert": {}
+              "priority" : "None",
+              "queueFull" : {
+                "Some" : {
+                  "Assert" : {
+                    
+                  }
                 }
               },
-              "importNodeIds": []
+              "importNodeIds" : [
+              ]
             }
           }
         },
-        "specialPortMap": {
-          "product recv": {
-            "aNode": {
-              "astNodeId": 80
+        "specialPortMap" : {
+          "product recv" : {
+            "aNode" : {
+              "astNodeId" : 80
             },
-            "specifier": {
-              "inputKind": {
-                "Some": {
-                  "Async": {}
+            "specifier" : {
+              "inputKind" : {
+                "Some" : {
+                  "Async" : {
+                    
+                  }
                 }
               },
-              "kind": {
-                "ProductRecv": {}
+              "kind" : {
+                "ProductRecv" : {
+                  
+                }
               },
-              "name": "productRecvIn",
-              "priority": "None",
-              "queueFull": "None"
+              "name" : "productRecvIn",
+              "priority" : "None",
+              "queueFull" : "None"
             },
-            "symbol": {
-              "Port": {
-                "nodeId": 67,
-                "unqualifiedName": "DpResponse"
+            "symbol" : {
+              "Port" : {
+                "nodeId" : 67,
+                "unqualifiedName" : "DpResponse"
               }
             },
-            "priority": "None",
-            "queueFull": {
-              "Some": {
-                "Assert": {}
+            "priority" : "None",
+            "queueFull" : {
+              "Some" : {
+                "Assert" : {
+                  
+                }
               }
             },
-            "importNodeIds": []
+            "importNodeIds" : [
+            ]
           }
         },
-        "commandMap": {},
-        "defaultOpcode": 0,
-        "tlmChannelMap": {},
-        "tlmChannelNameMap": {},
-        "defaultTlmChannelId": 0,
-        "eventMap": {},
-        "defaultEventId": 0,
-        "paramMap": {},
-        "specPortMatchingList": [],
-        "stateMachineInstanceMap": {},
-        "portMatchingList": [],
-        "defaultParamId": 0,
-        "containerMap": {},
-        "defaultContainerId": 0,
-        "recordMap": {},
-        "defaultRecordId": 0
+        "commandMap" : {
+          
+        },
+        "defaultOpcode" : 0,
+        "tlmChannelMap" : {
+          
+        },
+        "tlmChannelNameMap" : {
+          
+        },
+        "defaultTlmChannelId" : 0,
+        "eventMap" : {
+          
+        },
+        "defaultEventId" : 0,
+        "paramMap" : {
+          
+        },
+        "specPortMatchingList" : [
+        ],
+        "stateMachineInstanceMap" : {
+          
+        },
+        "portMatchingList" : [
+        ],
+        "defaultParamId" : 0,
+        "containerMap" : {
+          
+        },
+        "defaultContainerId" : 0,
+        "recordMap" : {
+          
+        },
+        "defaultRecordId" : 0
       }
     },
-    "includedFileSet": [],
-    "inputFileSet": [
+    "includedFileSet" : [
+    ],
+    "inputFileSet" : [
       "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp"
     ],
-    "locationSpecifierMap": [],
-    "parentSymbolMap": {
-      "67": {
-        "Module": {
-          "nodeId": 68,
-          "unqualifiedName": "Fw"
+    "locationSpecifierMap" : [
+    ],
+    "parentSymbolMap" : {
+      "67" : {
+        "Module" : {
+          "nodeId" : 68,
+          "unqualifiedName" : "Fw"
         }
       },
-      "23": {
-        "Enum": {
-          "nodeId": 24,
-          "unqualifiedName": "E"
+      "23" : {
+        "Enum" : {
+          "nodeId" : 24,
+          "unqualifiedName" : "E"
         }
       },
-      "50": {
-        "Enum": {
-          "nodeId": 54,
-          "unqualifiedName": "Status"
+      "50" : {
+        "Enum" : {
+          "nodeId" : 54,
+          "unqualifiedName" : "Status"
         }
       },
-      "69": {
-        "Module": {
-          "nodeId": 82,
-          "unqualifiedName": "M"
+      "69" : {
+        "Module" : {
+          "nodeId" : 82,
+          "unqualifiedName" : "M"
         }
       },
-      "53": {
-        "Enum": {
-          "nodeId": 54,
-          "unqualifiedName": "Status"
+      "53" : {
+        "Enum" : {
+          "nodeId" : 54,
+          "unqualifiedName" : "Status"
         }
       },
-      "20": {
-        "Enum": {
-          "nodeId": 24,
-          "unqualifiedName": "E"
+      "20" : {
+        "Enum" : {
+          "nodeId" : 24,
+          "unqualifiedName" : "E"
         }
       },
-      "81": {
-        "Module": {
-          "nodeId": 82,
-          "unqualifiedName": "M"
+      "81" : {
+        "Module" : {
+          "nodeId" : 82,
+          "unqualifiedName" : "M"
         }
       },
-      "118": {
-        "Module": {
-          "nodeId": 82,
-          "unqualifiedName": "M"
+      "118" : {
+        "Module" : {
+          "nodeId" : 82,
+          "unqualifiedName" : "M"
         }
       }
     },
-    "symbolScopeMap": {
-      "68": {
-        "map": {
-          "Port": {
-            "map": {
-              "DpResponse": {
-                "Port": {
-                  "nodeId": 67,
-                  "unqualifiedName": "DpResponse"
+    "symbolScopeMap" : {
+      "68" : {
+        "map" : {
+          "Port" : {
+            "map" : {
+              "DpResponse" : {
+                "Port" : {
+                  "nodeId" : 67,
+                  "unqualifiedName" : "DpResponse"
                 }
               }
             }
           }
         }
       },
-      "24": {
-        "map": {
-          "Value": {
-            "map": {
-              "A": {
-                "EnumConstant": {
-                  "nodeId": 20,
-                  "unqualifiedName": "A"
+      "24" : {
+        "map" : {
+          "Value" : {
+            "map" : {
+              "A" : {
+                "EnumConstant" : {
+                  "nodeId" : 20,
+                  "unqualifiedName" : "A"
                 }
               },
-              "B": {
-                "EnumConstant": {
-                  "nodeId": 23,
-                  "unqualifiedName": "B"
+              "B" : {
+                "EnumConstant" : {
+                  "nodeId" : 23,
+                  "unqualifiedName" : "B"
                 }
               }
             }
           }
         }
       },
-      "54": {
-        "map": {
-          "Value": {
-            "map": {
-              "SUCCEED": {
-                "EnumConstant": {
-                  "nodeId": 50,
-                  "unqualifiedName": "SUCCEED"
+      "54" : {
+        "map" : {
+          "Value" : {
+            "map" : {
+              "SUCCEED" : {
+                "EnumConstant" : {
+                  "nodeId" : 50,
+                  "unqualifiedName" : "SUCCEED"
                 }
               },
-              "FAIL": {
-                "EnumConstant": {
-                  "nodeId": 53,
-                  "unqualifiedName": "FAIL"
+              "FAIL" : {
+                "EnumConstant" : {
+                  "nodeId" : 53,
+                  "unqualifiedName" : "FAIL"
                 }
               }
             }
           }
         }
       },
-      "82": {
-        "map": {
-          "Topology": {
-            "map": {
-              "T": {
-                "Topology": {
-                  "nodeId": 118,
-                  "unqualifiedName": "T"
+      "82" : {
+        "map" : {
+          "Topology" : {
+            "map" : {
+              "T" : {
+                "Topology" : {
+                  "nodeId" : 118,
+                  "unqualifiedName" : "T"
                 }
               }
             }
           },
-          "StateMachine": {
-            "map": {
-              "Q": {
-                "Component": {
-                  "nodeId": 81,
-                  "unqualifiedName": "Q"
+          "StateMachine" : {
+            "map" : {
+              "Q" : {
+                "Component" : {
+                  "nodeId" : 81,
+                  "unqualifiedName" : "Q"
                 }
               }
             }
           },
-          "Value": {
-            "map": {
-              "Q": {
-                "Component": {
-                  "nodeId": 81,
-                  "unqualifiedName": "Q"
+          "Value" : {
+            "map" : {
+              "Q" : {
+                "Component" : {
+                  "nodeId" : 81,
+                  "unqualifiedName" : "Q"
                 }
               }
             }
           },
-          "Port": {
-            "map": {
-              "P": {
-                "Port": {
-                  "nodeId": 69,
-                  "unqualifiedName": "P"
+          "Port" : {
+            "map" : {
+              "P" : {
+                "Port" : {
+                  "nodeId" : 69,
+                  "unqualifiedName" : "P"
                 }
               }
             }
           },
-          "Component": {
-            "map": {
-              "Q": {
-                "Component": {
-                  "nodeId": 81,
-                  "unqualifiedName": "Q"
+          "Component" : {
+            "map" : {
+              "Q" : {
+                "Component" : {
+                  "nodeId" : 81,
+                  "unqualifiedName" : "Q"
                 }
               }
             }
           },
-          "Type": {
-            "map": {
-              "Q": {
-                "Component": {
-                  "nodeId": 81,
-                  "unqualifiedName": "Q"
+          "Type" : {
+            "map" : {
+              "Q" : {
+                "Component" : {
+                  "nodeId" : 81,
+                  "unqualifiedName" : "Q"
                 }
               }
             }
           }
         }
       },
-      "81": {
-        "map": {}
+      "81" : {
+        "map" : {
+          
+        }
       }
     },
-    "topologyMap": {
-      "118": {
-        "aNode": {
-          "astNodeId": 118
+    "topologyMap" : {
+      "118" : {
+        "aNode" : {
+          "astNodeId" : 118
         },
-        "directImportMap": {},
-        "transitiveImportSet": [],
-        "instanceMap": [
+        "directImportMap" : {
+          
+        },
+        "transitiveImportSet" : [
+        ],
+        "instanceMap" : [
           [
             {
-              "aNode": {
-                "astNodeId": 88
+              "aNode" : {
+                "astNodeId" : 88
               },
-              "qualifiedName": {
-                "qualifier": [],
-                "base": "i"
+              "qualifiedName" : {
+                "qualifier" : [
+                ],
+                "base" : "i"
               },
-              "component": {
-                "astNodeId": 81
+              "component" : {
+                "astNodeId" : 81
               },
-              "baseId": 8448,
-              "maxId": 8447,
-              "file": "None",
-              "queueSize": {
-                "Some": 10
+              "baseId" : 8448,
+              "maxId" : 8447,
+              "file" : "None",
+              "queueSize" : {
+                "Some" : 10
               },
-              "stackSize": "None",
-              "priority": "None",
-              "cpu": "None",
-              "initSpecifierMap": {}
+              "stackSize" : "None",
+              "priority" : "None",
+              "cpu" : "None",
+              "initSpecifierMap" : {
+                
+              }
             },
             [
               {
-                "Public": {}
+                "Public" : {
+                  
+                }
               },
               {
-                "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-                "pos": "39.9",
-                "includingLoc": "None"
+                "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+                "pos" : "39.9",
+                "includingLoc" : "None"
               }
             ]
           ]
         ],
-        "patternMap": {},
-        "connectionMap": {},
-        "localConnectionMap": {},
-        "outputConnectionMap": [],
-        "inputConnectionMap": [],
-        "fromPortNumberMap": [],
-        "toPortNumberMap": [],
-        "unconnectedPortSet": [
+        "patternMap" : {
+          
+        },
+        "connectionMap" : {
+          
+        },
+        "localConnectionMap" : {
+          
+        },
+        "outputConnectionMap" : [
+        ],
+        "inputConnectionMap" : [
+        ],
+        "fromPortNumberMap" : [
+        ],
+        "toPortNumberMap" : [
+        ],
+        "unconnectedPortSet" : [
           {
-            "componentInstance": {
-              "aNode": {
-                "astNodeId": 88
+            "componentInstance" : {
+              "aNode" : {
+                "astNodeId" : 88
               },
-              "qualifiedName": {
-                "qualifier": [],
-                "base": "i"
+              "qualifiedName" : {
+                "qualifier" : [
+                ],
+                "base" : "i"
               },
-              "component": {
-                "astNodeId": 81
+              "component" : {
+                "astNodeId" : 81
               },
-              "baseId": 8448,
-              "maxId": 8447,
-              "file": "None",
-              "queueSize": {
-                "Some": 10
+              "baseId" : 8448,
+              "maxId" : 8447,
+              "file" : "None",
+              "queueSize" : {
+                "Some" : 10
               },
-              "stackSize": "None",
-              "priority": "None",
-              "cpu": "None",
-              "initSpecifierMap": {}
+              "stackSize" : "None",
+              "priority" : "None",
+              "cpu" : "None",
+              "initSpecifierMap" : {
+                
+              }
             },
-            "portInstance": {
-              "Special": {
-                "aNode": {
-                  "astNodeId": 80
+            "portInstance" : {
+              "Special" : {
+                "aNode" : {
+                  "astNodeId" : 80
                 },
-                "specifier": {
-                  "inputKind": {
-                    "Some": {
-                      "Async": {}
+                "specifier" : {
+                  "inputKind" : {
+                    "Some" : {
+                      "Async" : {
+                        
+                      }
                     }
                   },
-                  "kind": {
-                    "ProductRecv": {}
+                  "kind" : {
+                    "ProductRecv" : {
+                      
+                    }
                   },
-                  "name": "productRecvIn",
-                  "priority": "None",
-                  "queueFull": "None"
+                  "name" : "productRecvIn",
+                  "priority" : "None",
+                  "queueFull" : "None"
                 },
-                "symbol": {
-                  "Port": {
-                    "nodeId": 67,
-                    "unqualifiedName": "DpResponse"
+                "symbol" : {
+                  "Port" : {
+                    "nodeId" : 67,
+                    "unqualifiedName" : "DpResponse"
                   }
                 },
-                "priority": "None",
-                "queueFull": {
-                  "Some": {
-                    "Assert": {}
+                "priority" : "None",
+                "queueFull" : {
+                  "Some" : {
+                    "Assert" : {
+                      
+                    }
                   }
                 },
-                "importNodeIds": []
+                "importNodeIds" : [
+                ]
               }
             }
           }
         ]
       }
     },
-    "typeMap": {
-      "23": {
-        "Enum": {
-          "node": {
-            "astNodeId": 24
+    "typeMap" : {
+      "23" : {
+        "Enum" : {
+          "node" : {
+            "astNodeId" : 24
           },
-          "repType": {
-            "kind": {
-              "I32": {}
+          "repType" : {
+            "kind" : {
+              "I32" : {
+                
+              }
             }
           },
-          "default": "None"
+          "default" : "None"
         }
       },
-      "44": {
-        "AbsType": {
-          "node": {
-            "astNodeId": 25
+      "44" : {
+        "AbsType" : {
+          "node" : {
+            "astNodeId" : 25
           }
         }
       },
-      "50": {
-        "Enum": {
-          "node": {
-            "astNodeId": 54
+      "50" : {
+        "Enum" : {
+          "node" : {
+            "astNodeId" : 54
           },
-          "repType": {
-            "kind": {
-              "I32": {}
+          "repType" : {
+            "kind" : {
+              "I32" : {
+                
+              }
             }
           },
-          "default": "None"
+          "default" : "None"
         }
       },
-      "24": {
-        "Enum": {
-          "node": {
-            "astNodeId": 24
+      "24" : {
+        "Enum" : {
+          "node" : {
+            "astNodeId" : 24
           },
-          "repType": {
-            "kind": {
-              "I32": {}
+          "repType" : {
+            "kind" : {
+              "I32" : {
+                
+              }
             }
           },
-          "default": {
-            "Some": {
-              "value": ["A", 0],
-              "t": {
-                "node": {
-                  "astNodeId": 24
+          "default" : {
+            "Some" : {
+              "value" : [
+                "A",
+                0
+              ],
+              "t" : {
+                "node" : {
+                  "astNodeId" : 24
                 },
-                "repType": {
-                  "kind": {
-                    "I32": {}
+                "repType" : {
+                  "kind" : {
+                    "I32" : {
+                      
+                    }
                   }
                 },
-                "default": "None"
+                "default" : "None"
               }
             }
           }
         }
       },
-      "48": {
-        "AbsType": {
-          "node": {
-            "astNodeId": 25
+      "48" : {
+        "AbsType" : {
+          "node" : {
+            "astNodeId" : 25
           }
         }
       },
-      "54": {
-        "Enum": {
-          "node": {
-            "astNodeId": 54
+      "54" : {
+        "Enum" : {
+          "node" : {
+            "astNodeId" : 54
           },
-          "repType": {
-            "kind": {
-              "I32": {}
+          "repType" : {
+            "kind" : {
+              "I32" : {
+                
+              }
             }
           },
-          "default": {
-            "Some": {
-              "value": ["SUCCEED", 0],
-              "t": {
-                "node": {
-                  "astNodeId": 54
+          "default" : {
+            "Some" : {
+              "value" : [
+                "SUCCEED",
+                0
+              ],
+              "t" : {
+                "node" : {
+                  "astNodeId" : 54
                 },
-                "repType": {
-                  "kind": {
-                    "I32": {}
+                "repType" : {
+                  "kind" : {
+                    "I32" : {
+                      
+                    }
                   }
                 },
-                "default": "None"
+                "default" : "None"
               }
             }
           }
         }
       },
-      "32": {
-        "AbsType": {
-          "node": {
-            "astNodeId": 25
+      "32" : {
+        "AbsType" : {
+          "node" : {
+            "astNodeId" : 25
           }
         }
       },
-      "6": {
-        "Int": {
-          "PrimitiveInt": {
-            "kind": {
-              "U32": {}
-            }
-          }
-        }
-      },
-      "53": {
-        "Enum": {
-          "node": {
-            "astNodeId": 54
-          },
-          "repType": {
-            "kind": {
-              "I32": {}
-            }
-          },
-          "default": "None"
-        }
-      },
-      "20": {
-        "Enum": {
-          "node": {
-            "astNodeId": 24
-          },
-          "repType": {
-            "kind": {
-              "I32": {}
-            }
-          },
-          "default": "None"
-        }
-      },
-      "86": {
-        "Int": {
-          "Integer": {}
-        }
-      },
-      "63": {
-        "Enum": {
-          "node": {
-            "astNodeId": 54
-          },
-          "repType": {
-            "kind": {
-              "I32": {}
-            }
-          },
-          "default": {
-            "Some": {
-              "value": ["SUCCEED", 0],
-              "t": {
-                "node": {
-                  "astNodeId": 54
-                },
-                "repType": {
-                  "kind": {
-                    "I32": {}
-                  }
-                },
-                "default": "None"
+      "6" : {
+        "Int" : {
+          "PrimitiveInt" : {
+            "kind" : {
+              "U32" : {
+                
               }
             }
           }
         }
       },
-      "28": {
-        "Enum": {
-          "node": {
-            "astNodeId": 24
+      "53" : {
+        "Enum" : {
+          "node" : {
+            "astNodeId" : 54
           },
-          "repType": {
-            "kind": {
-              "I32": {}
+          "repType" : {
+            "kind" : {
+              "I32" : {
+                
+              }
             }
           },
-          "default": {
-            "Some": {
-              "value": ["A", 0],
-              "t": {
-                "node": {
-                  "astNodeId": 24
+          "default" : "None"
+        }
+      },
+      "20" : {
+        "Enum" : {
+          "node" : {
+            "astNodeId" : 24
+          },
+          "repType" : {
+            "kind" : {
+              "I32" : {
+                
+              }
+            }
+          },
+          "default" : "None"
+        }
+      },
+      "86" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
+        }
+      },
+      "63" : {
+        "Enum" : {
+          "node" : {
+            "astNodeId" : 54
+          },
+          "repType" : {
+            "kind" : {
+              "I32" : {
+                
+              }
+            }
+          },
+          "default" : {
+            "Some" : {
+              "value" : [
+                "SUCCEED",
+                0
+              ],
+              "t" : {
+                "node" : {
+                  "astNodeId" : 54
                 },
-                "repType": {
-                  "kind": {
-                    "I32": {}
+                "repType" : {
+                  "kind" : {
+                    "I32" : {
+                      
+                    }
                   }
                 },
-                "default": "None"
+                "default" : "None"
               }
             }
           }
         }
       },
-      "11": {
-        "Primitive": {
-          "Float": {
-            "kind": {
-              "F32": {}
+      "28" : {
+        "Enum" : {
+          "node" : {
+            "astNodeId" : 24
+          },
+          "repType" : {
+            "kind" : {
+              "I32" : {
+                
+              }
+            }
+          },
+          "default" : {
+            "Some" : {
+              "value" : [
+                "A",
+                0
+              ],
+              "t" : {
+                "node" : {
+                  "astNodeId" : 24
+                },
+                "repType" : {
+                  "kind" : {
+                    "I32" : {
+                      
+                    }
+                  }
+                },
+                "default" : "None"
+              }
             }
           }
         }
       },
-      "9": {
-        "Int": {
-          "PrimitiveInt": {
-            "kind": {
-              "I32": {}
+      "11" : {
+        "Primitive" : {
+          "Float" : {
+            "kind" : {
+              "F32" : {
+                
+              }
             }
           }
         }
       },
-      "59": {
-        "Int": {
-          "PrimitiveInt": {
-            "kind": {
-              "U32": {}
+      "9" : {
+        "Int" : {
+          "PrimitiveInt" : {
+            "kind" : {
+              "I32" : {
+                
+              }
             }
           }
         }
       },
-      "87": {
-        "Int": {
-          "Integer": {}
+      "59" : {
+        "Int" : {
+          "PrimitiveInt" : {
+            "kind" : {
+              "U32" : {
+                
+              }
+            }
+          }
         }
       },
-      "17": {
-        "String": {
-          "size": "None"
+      "87" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "25": {
-        "AbsType": {
-          "node": {
-            "astNodeId": 25
+      "17" : {
+        "String" : {
+          "size" : "None"
+        }
+      },
+      "25" : {
+        "AbsType" : {
+          "node" : {
+            "astNodeId" : 25
           }
         }
       }
     },
-    "useDefMap": {
-      "62": {
-        "Enum": {
-          "nodeId": 54,
-          "unqualifiedName": "Status"
+    "useDefMap" : {
+      "62" : {
+        "Enum" : {
+          "nodeId" : 54,
+          "unqualifiedName" : "Status"
         }
       },
-      "44": {
-        "AbsType": {
-          "nodeId": 25,
-          "unqualifiedName": "T"
+      "44" : {
+        "AbsType" : {
+          "nodeId" : 25,
+          "unqualifiedName" : "T"
         }
       },
-      "83": {
-        "Module": {
-          "nodeId": 82,
-          "unqualifiedName": "M"
+      "83" : {
+        "Module" : {
+          "nodeId" : 82,
+          "unqualifiedName" : "M"
         }
       },
-      "43": {
-        "AbsType": {
-          "nodeId": 25,
-          "unqualifiedName": "T"
+      "43" : {
+        "AbsType" : {
+          "nodeId" : 25,
+          "unqualifiedName" : "T"
         }
       },
-      "32": {
-        "AbsType": {
-          "nodeId": 25,
-          "unqualifiedName": "T"
+      "32" : {
+        "AbsType" : {
+          "nodeId" : 25,
+          "unqualifiedName" : "T"
         }
       },
-      "80": {
-        "Port": {
-          "nodeId": 67,
-          "unqualifiedName": "DpResponse"
+      "80" : {
+        "Port" : {
+          "nodeId" : 67,
+          "unqualifiedName" : "DpResponse"
         }
       },
-      "27": {
-        "Enum": {
-          "nodeId": 24,
-          "unqualifiedName": "E"
+      "27" : {
+        "Enum" : {
+          "nodeId" : 24,
+          "unqualifiedName" : "E"
         }
       },
-      "63": {
-        "Enum": {
-          "nodeId": 54,
-          "unqualifiedName": "Status"
+      "63" : {
+        "Enum" : {
+          "nodeId" : 54,
+          "unqualifiedName" : "Status"
         }
       },
-      "85": {
-        "Component": {
-          "nodeId": 81,
-          "unqualifiedName": "Q"
+      "85" : {
+        "Component" : {
+          "nodeId" : 81,
+          "unqualifiedName" : "Q"
         }
       },
-      "28": {
-        "Enum": {
-          "nodeId": 24,
-          "unqualifiedName": "E"
+      "28" : {
+        "Enum" : {
+          "nodeId" : 24,
+          "unqualifiedName" : "E"
         }
       },
-      "48": {
-        "AbsType": {
-          "nodeId": 25,
-          "unqualifiedName": "T"
+      "48" : {
+        "AbsType" : {
+          "nodeId" : 25,
+          "unqualifiedName" : "T"
         }
       },
-      "116": {
-        "ComponentInstance": {
-          "nodeId": 88,
-          "unqualifiedName": "i"
+      "116" : {
+        "ComponentInstance" : {
+          "nodeId" : 88,
+          "unqualifiedName" : "i"
         }
       },
-      "47": {
-        "AbsType": {
-          "nodeId": 25,
-          "unqualifiedName": "T"
+      "47" : {
+        "AbsType" : {
+          "nodeId" : 25,
+          "unqualifiedName" : "T"
         }
       },
-      "31": {
-        "AbsType": {
-          "nodeId": 25,
-          "unqualifiedName": "T"
+      "31" : {
+        "AbsType" : {
+          "nodeId" : 25,
+          "unqualifiedName" : "T"
         }
       }
     },
-    "valueMap": {
-      "23": {
-        "EnumConstant": {
-          "value": ["B", 1],
-          "t": {
-            "node": {
-              "astNodeId": 24
+    "valueMap" : {
+      "23" : {
+        "EnumConstant" : {
+          "value" : [
+            "B",
+            1
+          ],
+          "t" : {
+            "node" : {
+              "astNodeId" : 24
             },
-            "repType": {
-              "kind": {
-                "I32": {}
+            "repType" : {
+              "kind" : {
+                "I32" : {
+                  
+                }
               }
             },
-            "default": "None"
+            "default" : "None"
           }
         }
       },
-      "50": {
-        "EnumConstant": {
-          "value": ["SUCCEED", 0],
-          "t": {
-            "node": {
-              "astNodeId": 54
+      "50" : {
+        "EnumConstant" : {
+          "value" : [
+            "SUCCEED",
+            0
+          ],
+          "t" : {
+            "node" : {
+              "astNodeId" : 54
             },
-            "repType": {
-              "kind": {
-                "I32": {}
+            "repType" : {
+              "kind" : {
+                "I32" : {
+                  
+                }
               }
             },
-            "default": "None"
+            "default" : "None"
           }
         }
       },
-      "87": {
-        "Integer": {
-          "value": 10
+      "87" : {
+        "Integer" : {
+          "value" : 10
         }
       },
-      "53": {
-        "EnumConstant": {
-          "value": ["FAIL", 1],
-          "t": {
-            "node": {
-              "astNodeId": 54
+      "53" : {
+        "EnumConstant" : {
+          "value" : [
+            "FAIL",
+            1
+          ],
+          "t" : {
+            "node" : {
+              "astNodeId" : 54
             },
-            "repType": {
-              "kind": {
-                "I32": {}
+            "repType" : {
+              "kind" : {
+                "I32" : {
+                  
+                }
               }
             },
-            "default": "None"
+            "default" : "None"
           }
         }
       },
-      "20": {
-        "EnumConstant": {
-          "value": ["A", 0],
-          "t": {
-            "node": {
-              "astNodeId": 24
+      "20" : {
+        "EnumConstant" : {
+          "value" : [
+            "A",
+            0
+          ],
+          "t" : {
+            "node" : {
+              "astNodeId" : 24
             },
-            "repType": {
-              "kind": {
-                "I32": {}
+            "repType" : {
+              "kind" : {
+                "I32" : {
+                  
+                }
               }
             },
-            "default": "None"
+            "default" : "None"
           }
         }
       },
-      "86": {
-        "Integer": {
-          "value": 8448
+      "86" : {
+        "Integer" : {
+          "value" : 8448
         }
       }
     },
-    "stateMachineMap": {},
-    "dictionarySymbolSet": [],
-    "interfaceMap": {}
+    "stateMachineMap" : {
+      
+    },
+    "dictionarySymbolSet" : [
+    ],
+    "interfaceMap" : {
+      
+    }
   }
 }

--- a/tests/ports/ports_ast.json
+++ b/tests/ports/ports_ast.json
@@ -1,758 +1,860 @@
 {
-  "fppVersion": "[ fpp version ]",
-  "ast": [
+  "fppVersion" : "v3.1.0a10-46-g5b2da7ca1",
+  "ast" : [
     {
-      "members": [
+      "members" : [
         [
-          [],
+          [
+          ],
           {
-            "DefPort": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "P",
-                    "params": [],
-                    "returnType": "None"
-                  },
-                  "id": 0
-                }
-              }
-            }
-          },
-          []
-        ],
-        [
-          [],
-          {
-            "DefPort": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "P1",
-                    "params": [],
-                    "returnType": "None"
-                  },
-                  "id": 1
-                }
-              }
-            }
-          },
-          []
-        ],
-        [
-          [],
-          {
-            "DefPort": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "P2",
-                    "params": [
-                      [
-                        [],
-                        {
-                          "AstNode": {
-                            "data": {
-                              "kind": {
-                                "Value": {}
-                              },
-                              "name": "a",
-                              "typeName": {
-                                "AstNode": {
-                                  "data": {
-                                    "TypeNameInt": {
-                                      "name": {
-                                        "U32": {}
-                                      }
-                                    }
-                                  },
-                                  "id": 6
-                                }
-                              }
-                            },
-                            "id": 7
-                          }
-                        },
-                        []
-                      ]
+            "DefPort" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "P",
+                    "params" : [
                     ],
-                    "returnType": "None"
+                    "returnType" : "None"
                   },
-                  "id": 8
+                  "id" : 0
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          [],
+          [
+          ],
           {
-            "DefPort": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "P3",
-                    "params": [
-                      [
-                        [],
-                        {
-                          "AstNode": {
-                            "data": {
-                              "kind": {
-                                "Value": {}
-                              },
-                              "name": "a",
-                              "typeName": {
-                                "AstNode": {
-                                  "data": {
-                                    "TypeNameInt": {
-                                      "name": {
-                                        "I32": {}
-                                      }
-                                    }
-                                  },
-                                  "id": 9
-                                }
-                              }
-                            },
-                            "id": 10
-                          }
-                        },
-                        []
-                      ],
-                      [
-                        [],
-                        {
-                          "AstNode": {
-                            "data": {
-                              "kind": {
-                                "Value": {}
-                              },
-                              "name": "b",
-                              "typeName": {
-                                "AstNode": {
-                                  "data": {
-                                    "TypeNameFloat": {
-                                      "name": {
-                                        "F32": {}
-                                      }
-                                    }
-                                  },
-                                  "id": 11
-                                }
-                              }
-                            },
-                            "id": 12
-                          }
-                        },
-                        []
-                      ],
-                      [
-                        [],
-                        {
-                          "AstNode": {
-                            "data": {
-                              "kind": {
-                                "Value": {}
-                              },
-                              "name": "c",
-                              "typeName": {
-                                "AstNode": {
-                                  "data": {
-                                    "TypeNameString": {
-                                      "size": "None"
-                                    }
-                                  },
-                                  "id": 17
-                                }
-                              }
-                            },
-                            "id": 18
-                          }
-                        },
-                        []
-                      ]
+            "DefPort" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "P1",
+                    "params" : [
                     ],
-                    "returnType": "None"
+                    "returnType" : "None"
                   },
-                  "id": 19
+                  "id" : 1
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          [],
+          [
+          ],
           {
-            "DefEnum": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "E",
-                    "typeName": "None",
-                    "constants": [
+            "DefPort" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "P2",
+                    "params" : [
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "AstNode": {
-                            "data": {
-                              "name": "A",
-                              "value": "None"
-                            },
-                            "id": 20
-                          }
-                        },
-                        []
-                      ],
-                      [
-                        [],
-                        {
-                          "AstNode": {
-                            "data": {
-                              "name": "B",
-                              "value": "None"
-                            },
-                            "id": 23
-                          }
-                        },
-                        []
-                      ]
-                    ],
-                    "default": "None",
-                    "isDictionaryDef": false
-                  },
-                  "id": 24
-                }
-              }
-            }
-          },
-          []
-        ],
-        [
-          [],
-          {
-            "DefAbsType": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "T"
-                  },
-                  "id": 25
-                }
-              }
-            }
-          },
-          []
-        ],
-        [
-          [],
-          {
-            "DefPort": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "P4",
-                    "params": [
-                      [
-                        [],
-                        {
-                          "AstNode": {
-                            "data": {
-                              "kind": {
-                                "Value": {}
+                          "AstNode" : {
+                            "data" : {
+                              "kind" : {
+                                "Value" : {
+                                  
+                                }
                               },
-                              "name": "e",
-                              "typeName": {
-                                "AstNode": {
-                                  "data": {
-                                    "TypeNameQualIdent": {
-                                      "name": {
-                                        "AstNode": {
-                                          "data": {
-                                            "Unqualified": {
-                                              "name": "E"
-                                            }
-                                          },
-                                          "id": 27
+                              "name" : "a",
+                              "typeName" : {
+                                "AstNode" : {
+                                  "data" : {
+                                    "TypeNameInt" : {
+                                      "name" : {
+                                        "U32" : {
+                                          
                                         }
                                       }
                                     }
                                   },
-                                  "id": 28
+                                  "id" : 6
                                 }
                               }
                             },
-                            "id": 29
+                            "id" : 7
                           }
                         },
-                        []
-                      ],
-                      [
-                        [],
-                        {
-                          "AstNode": {
-                            "data": {
-                              "kind": {
-                                "Value": {}
-                              },
-                              "name": "t",
-                              "typeName": {
-                                "AstNode": {
-                                  "data": {
-                                    "TypeNameQualIdent": {
-                                      "name": {
-                                        "AstNode": {
-                                          "data": {
-                                            "Unqualified": {
-                                              "name": "T"
-                                            }
-                                          },
-                                          "id": 31
-                                        }
-                                      }
-                                    }
-                                  },
-                                  "id": 32
-                                }
-                              }
-                            },
-                            "id": 33
-                          }
-                        },
-                        []
-                      ],
-                      [
-                        [],
-                        {
-                          "AstNode": {
-                            "data": {
-                              "kind": {
-                                "Ref": {}
-                              },
-                              "name": "c",
-                              "typeName": {
-                                "AstNode": {
-                                  "data": {
-                                    "TypeNameQualIdent": {
-                                      "name": {
-                                        "AstNode": {
-                                          "data": {
-                                            "Unqualified": {
-                                              "name": "T"
-                                            }
-                                          },
-                                          "id": 43
-                                        }
-                                      }
-                                    }
-                                  },
-                                  "id": 44
-                                }
-                              }
-                            },
-                            "id": 45
-                          }
-                        },
-                        []
+                        [
+                        ]
                       ]
                     ],
-                    "returnType": {
-                      "Some": {
-                        "AstNode": {
-                          "data": {
-                            "TypeNameQualIdent": {
-                              "name": {
-                                "AstNode": {
-                                  "data": {
-                                    "Unqualified": {
-                                      "name": "T"
+                    "returnType" : "None"
+                  },
+                  "id" : 8
+                }
+              }
+            }
+          },
+          [
+          ]
+        ],
+        [
+          [
+          ],
+          {
+            "DefPort" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "P3",
+                    "params" : [
+                      [
+                        [
+                        ],
+                        {
+                          "AstNode" : {
+                            "data" : {
+                              "kind" : {
+                                "Value" : {
+                                  
+                                }
+                              },
+                              "name" : "a",
+                              "typeName" : {
+                                "AstNode" : {
+                                  "data" : {
+                                    "TypeNameInt" : {
+                                      "name" : {
+                                        "I32" : {
+                                          
+                                        }
+                                      }
                                     }
                                   },
-                                  "id": 47
+                                  "id" : 9
+                                }
+                              }
+                            },
+                            "id" : 10
+                          }
+                        },
+                        [
+                        ]
+                      ],
+                      [
+                        [
+                        ],
+                        {
+                          "AstNode" : {
+                            "data" : {
+                              "kind" : {
+                                "Value" : {
+                                  
+                                }
+                              },
+                              "name" : "b",
+                              "typeName" : {
+                                "AstNode" : {
+                                  "data" : {
+                                    "TypeNameFloat" : {
+                                      "name" : {
+                                        "F32" : {
+                                          
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "id" : 11
+                                }
+                              }
+                            },
+                            "id" : 12
+                          }
+                        },
+                        [
+                        ]
+                      ],
+                      [
+                        [
+                        ],
+                        {
+                          "AstNode" : {
+                            "data" : {
+                              "kind" : {
+                                "Value" : {
+                                  
+                                }
+                              },
+                              "name" : "c",
+                              "typeName" : {
+                                "AstNode" : {
+                                  "data" : {
+                                    "TypeNameString" : {
+                                      "size" : "None"
+                                    }
+                                  },
+                                  "id" : 17
+                                }
+                              }
+                            },
+                            "id" : 18
+                          }
+                        },
+                        [
+                        ]
+                      ]
+                    ],
+                    "returnType" : "None"
+                  },
+                  "id" : 19
+                }
+              }
+            }
+          },
+          [
+          ]
+        ],
+        [
+          [
+          ],
+          {
+            "DefEnum" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "E",
+                    "typeName" : "None",
+                    "constants" : [
+                      [
+                        [
+                        ],
+                        {
+                          "AstNode" : {
+                            "data" : {
+                              "name" : "A",
+                              "value" : "None"
+                            },
+                            "id" : 20
+                          }
+                        },
+                        [
+                        ]
+                      ],
+                      [
+                        [
+                        ],
+                        {
+                          "AstNode" : {
+                            "data" : {
+                              "name" : "B",
+                              "value" : "None"
+                            },
+                            "id" : 23
+                          }
+                        },
+                        [
+                        ]
+                      ]
+                    ],
+                    "default" : "None",
+                    "isDictionaryDef" : false
+                  },
+                  "id" : 24
+                }
+              }
+            }
+          },
+          [
+          ]
+        ],
+        [
+          [
+          ],
+          {
+            "DefAbsType" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "T"
+                  },
+                  "id" : 25
+                }
+              }
+            }
+          },
+          [
+          ]
+        ],
+        [
+          [
+          ],
+          {
+            "DefPort" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "P4",
+                    "params" : [
+                      [
+                        [
+                        ],
+                        {
+                          "AstNode" : {
+                            "data" : {
+                              "kind" : {
+                                "Value" : {
+                                  
+                                }
+                              },
+                              "name" : "e",
+                              "typeName" : {
+                                "AstNode" : {
+                                  "data" : {
+                                    "TypeNameQualIdent" : {
+                                      "name" : {
+                                        "AstNode" : {
+                                          "data" : {
+                                            "Unqualified" : {
+                                              "name" : "E"
+                                            }
+                                          },
+                                          "id" : 27
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "id" : 28
+                                }
+                              }
+                            },
+                            "id" : 29
+                          }
+                        },
+                        [
+                        ]
+                      ],
+                      [
+                        [
+                        ],
+                        {
+                          "AstNode" : {
+                            "data" : {
+                              "kind" : {
+                                "Value" : {
+                                  
+                                }
+                              },
+                              "name" : "t",
+                              "typeName" : {
+                                "AstNode" : {
+                                  "data" : {
+                                    "TypeNameQualIdent" : {
+                                      "name" : {
+                                        "AstNode" : {
+                                          "data" : {
+                                            "Unqualified" : {
+                                              "name" : "T"
+                                            }
+                                          },
+                                          "id" : 31
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "id" : 32
+                                }
+                              }
+                            },
+                            "id" : 33
+                          }
+                        },
+                        [
+                        ]
+                      ],
+                      [
+                        [
+                        ],
+                        {
+                          "AstNode" : {
+                            "data" : {
+                              "kind" : {
+                                "Ref" : {
+                                  
+                                }
+                              },
+                              "name" : "c",
+                              "typeName" : {
+                                "AstNode" : {
+                                  "data" : {
+                                    "TypeNameQualIdent" : {
+                                      "name" : {
+                                        "AstNode" : {
+                                          "data" : {
+                                            "Unqualified" : {
+                                              "name" : "T"
+                                            }
+                                          },
+                                          "id" : 43
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "id" : 44
+                                }
+                              }
+                            },
+                            "id" : 45
+                          }
+                        },
+                        [
+                        ]
+                      ]
+                    ],
+                    "returnType" : {
+                      "Some" : {
+                        "AstNode" : {
+                          "data" : {
+                            "TypeNameQualIdent" : {
+                              "name" : {
+                                "AstNode" : {
+                                  "data" : {
+                                    "Unqualified" : {
+                                      "name" : "T"
+                                    }
+                                  },
+                                  "id" : 47
                                 }
                               }
                             }
                           },
-                          "id": 48
+                          "id" : 48
                         }
                       }
                     }
                   },
-                  "id": 49
+                  "id" : 49
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          [],
+          [
+          ],
           {
-            "DefEnum": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "Status",
-                    "typeName": "None",
-                    "constants": [
+            "DefEnum" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "Status",
+                    "typeName" : "None",
+                    "constants" : [
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "AstNode": {
-                            "data": {
-                              "name": "SUCCEED",
-                              "value": "None"
+                          "AstNode" : {
+                            "data" : {
+                              "name" : "SUCCEED",
+                              "value" : "None"
                             },
-                            "id": 50
+                            "id" : 50
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "AstNode": {
-                            "data": {
-                              "name": "FAIL",
-                              "value": "None"
+                          "AstNode" : {
+                            "data" : {
+                              "name" : "FAIL",
+                              "value" : "None"
                             },
-                            "id": 53
+                            "id" : 53
                           }
                         },
-                        []
+                        [
+                        ]
                       ]
                     ],
-                    "default": "None",
-                    "isDictionaryDef": false
+                    "default" : "None",
+                    "isDictionaryDef" : false
                   },
-                  "id": 54
+                  "id" : 54
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          ["Pre annotation for port P5"],
+          [
+            "Pre annotation for port P5"
+          ],
           {
-            "DefPort": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "P5",
-                    "params": [
+            "DefPort" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "P5",
+                    "params" : [
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "AstNode": {
-                            "data": {
-                              "kind": {
-                                "Ref": {}
+                          "AstNode" : {
+                            "data" : {
+                              "kind" : {
+                                "Ref" : {
+                                  
+                                }
                               },
-                              "name": "result",
-                              "typeName": {
-                                "AstNode": {
-                                  "data": {
-                                    "TypeNameInt": {
-                                      "name": {
-                                        "U32": {}
+                              "name" : "result",
+                              "typeName" : {
+                                "AstNode" : {
+                                  "data" : {
+                                    "TypeNameInt" : {
+                                      "name" : {
+                                        "U32" : {
+                                          
+                                        }
                                       }
                                     }
                                   },
-                                  "id": 59
+                                  "id" : 59
                                 }
                               }
                             },
-                            "id": 60
+                            "id" : 60
                           }
                         },
-                        []
+                        [
+                        ]
                       ]
                     ],
-                    "returnType": {
-                      "Some": {
-                        "AstNode": {
-                          "data": {
-                            "TypeNameQualIdent": {
-                              "name": {
-                                "AstNode": {
-                                  "data": {
-                                    "Unqualified": {
-                                      "name": "Status"
+                    "returnType" : {
+                      "Some" : {
+                        "AstNode" : {
+                          "data" : {
+                            "TypeNameQualIdent" : {
+                              "name" : {
+                                "AstNode" : {
+                                  "data" : {
+                                    "Unqualified" : {
+                                      "name" : "Status"
                                     }
                                   },
-                                  "id": 62
+                                  "id" : 62
                                 }
                               }
                             }
                           },
-                          "id": 63
+                          "id" : 63
                         }
                       }
                     }
                   },
-                  "id": 64
+                  "id" : 64
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          [],
+          [
+          ],
           {
-            "DefModule": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "Fw",
-                    "members": [
+            "DefModule" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "Fw",
+                    "members" : [
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "DefPort": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "name": "DpResponse",
-                                  "params": [],
-                                  "returnType": "None"
+                          "DefPort" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "name" : "DpResponse",
+                                  "params" : [
+                                  ],
+                                  "returnType" : "None"
                                 },
-                                "id": 67
+                                "id" : 67
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ]
                     ]
                   },
-                  "id": 68
+                  "id" : 68
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          [],
+          [
+          ],
           {
-            "DefModule": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "M",
-                    "members": [
+            "DefModule" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "M",
+                    "members" : [
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "DefPort": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "name": "P",
-                                  "params": [],
-                                  "returnType": "None"
+                          "DefPort" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "name" : "P",
+                                  "params" : [
+                                  ],
+                                  "returnType" : "None"
                                 },
-                                "id": 69
+                                "id" : 69
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        ["Queued component"],
+                        [
+                          "Queued component"
+                        ],
                         {
-                          "DefComponent": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "kind": {
-                                    "Queued": {}
+                          "DefComponent" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "kind" : {
+                                    "Queued" : {
+                                      
+                                    }
                                   },
-                                  "name": "Q",
-                                  "members": [
+                                  "name" : "Q",
+                                  "members" : [
                                     [
-                                      ["Data product receive port"],
+                                      [
+                                        "Data product receive port"
+                                      ],
                                       {
-                                        "SpecPortInstance": {
-                                          "node": {
-                                            "AstNode": {
-                                              "data": {
-                                                "Special": {
-                                                  "inputKind": {
-                                                    "Some": {
-                                                      "Async": {}
+                                        "SpecPortInstance" : {
+                                          "node" : {
+                                            "AstNode" : {
+                                              "data" : {
+                                                "Special" : {
+                                                  "inputKind" : {
+                                                    "Some" : {
+                                                      "Async" : {
+                                                        
+                                                      }
                                                     }
                                                   },
-                                                  "kind": {
-                                                    "ProductRecv": {}
+                                                  "kind" : {
+                                                    "ProductRecv" : {
+                                                      
+                                                    }
                                                   },
-                                                  "name": "productRecvIn",
-                                                  "priority": "None",
-                                                  "queueFull": "None"
+                                                  "name" : "productRecvIn",
+                                                  "priority" : "None",
+                                                  "queueFull" : "None"
                                                 }
                                               },
-                                              "id": 80
+                                              "id" : 80
                                             }
                                           }
                                         }
                                       },
-                                      []
+                                      [
+                                      ]
                                     ]
                                   ]
                                 },
-                                "id": 81
+                                "id" : 81
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ]
                     ]
                   },
-                  "id": 82
+                  "id" : 82
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          [],
+          [
+          ],
           {
-            "DefComponentInstance": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "i",
-                    "component": {
-                      "AstNode": {
-                        "data": {
-                          "Qualified": {
-                            "qualifier": {
-                              "AstNode": {
-                                "data": {
-                                  "Unqualified": {
-                                    "name": "M"
+            "DefComponentInstance" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "i",
+                    "component" : {
+                      "AstNode" : {
+                        "data" : {
+                          "Qualified" : {
+                            "qualifier" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "Unqualified" : {
+                                    "name" : "M"
                                   }
                                 },
-                                "id": 83
+                                "id" : 83
                               }
                             },
-                            "name": {
-                              "AstNode": {
-                                "data": "Q",
-                                "id": 84
+                            "name" : {
+                              "AstNode" : {
+                                "data" : "Q",
+                                "id" : 84
                               }
                             }
                           }
                         },
-                        "id": 85
+                        "id" : 85
                       }
                     },
-                    "baseId": {
-                      "AstNode": {
-                        "data": {
-                          "ExprLiteralInt": {
-                            "value": "0x2100"
+                    "baseId" : {
+                      "AstNode" : {
+                        "data" : {
+                          "ExprLiteralInt" : {
+                            "value" : "0x2100"
                           }
                         },
-                        "id": 86
+                        "id" : 86
                       }
                     },
-                    "implType": "None",
-                    "file": "None",
-                    "queueSize": {
-                      "Some": {
-                        "AstNode": {
-                          "data": {
-                            "ExprLiteralInt": {
-                              "value": "10"
+                    "implType" : "None",
+                    "file" : "None",
+                    "queueSize" : {
+                      "Some" : {
+                        "AstNode" : {
+                          "data" : {
+                            "ExprLiteralInt" : {
+                              "value" : "10"
                             }
                           },
-                          "id": 87
+                          "id" : 87
                         }
                       }
                     },
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecs": []
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecs" : [
+                    ]
                   },
-                  "id": 88
+                  "id" : 88
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          [],
+          [
+          ],
           {
-            "DefModule": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "M",
-                    "members": [
+            "DefModule" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "M",
+                    "members" : [
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "DefTopology": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "name": "T",
-                                  "members": [
+                          "DefTopology" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "name" : "T",
+                                  "members" : [
                                     [
-                                      [],
+                                      [
+                                      ],
                                       {
-                                        "SpecCompInstance": {
-                                          "node": {
-                                            "AstNode": {
-                                              "data": {
-                                                "visibility": {
-                                                  "Public": {}
+                                        "SpecCompInstance" : {
+                                          "node" : {
+                                            "AstNode" : {
+                                              "data" : {
+                                                "visibility" : {
+                                                  "Public" : {
+                                                    
+                                                  }
                                                 },
-                                                "instance": {
-                                                  "AstNode": {
-                                                    "data": {
-                                                      "Unqualified": {
-                                                        "name": "i"
+                                                "instance" : {
+                                                  "AstNode" : {
+                                                    "data" : {
+                                                      "Unqualified" : {
+                                                        "name" : "i"
                                                       }
                                                     },
-                                                    "id": 116
+                                                    "id" : 116
                                                   }
                                                 }
                                               },
-                                              "id": 117
+                                              "id" : 117
                                             }
                                           }
                                         }
                                       },
-                                      []
+                                      [
+                                      ]
                                     ]
                                   ]
                                 },
-                                "id": 118
+                                "id" : 118
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ]
                     ]
                   },
-                  "id": 119
+                  "id" : 119
                 }
               }
             }
           },
-          []
+          [
+          ]
         ]
       ]
     }

--- a/tests/ports/ports_ast.json
+++ b/tests/ports/ports_ast.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion" : "v3.1.0a10-46-g5b2da7ca1",
+  "fppVersion" : "v3.1.0a10-54-g11243e778",
   "ast" : [
     {
       "members" : [

--- a/tests/ports/ports_locations.json
+++ b/tests/ports/ports_locations.json
@@ -1,605 +1,605 @@
 {
-  "fppVersion": "[ fpp version ]",
-  "locationMap": {
-    "0": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "1.1",
-      "includingLoc": "None"
-    },
-    "1": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "3.1",
-      "includingLoc": "None"
-    },
-    "2": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "4.12",
-      "includingLoc": "None"
-    },
-    "3": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "4.9",
-      "includingLoc": "None"
-    },
-    "4": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "4.12",
-      "includingLoc": "None"
-    },
-    "5": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "4.9",
-      "includingLoc": "None"
-    },
-    "6": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "4.12",
-      "includingLoc": "None"
-    },
-    "7": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "4.9",
-      "includingLoc": "None"
-    },
-    "8": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "4.1",
-      "includingLoc": "None"
-    },
-    "9": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "5.12",
-      "includingLoc": "None"
-    },
-    "10": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "5.9",
-      "includingLoc": "None"
-    },
-    "11": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "5.20",
-      "includingLoc": "None"
-    },
-    "12": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "5.17",
-      "includingLoc": "None"
-    },
-    "13": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "5.28",
-      "includingLoc": "None"
-    },
-    "14": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "5.25",
-      "includingLoc": "None"
-    },
-    "15": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "5.28",
-      "includingLoc": "None"
-    },
-    "16": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "5.25",
-      "includingLoc": "None"
-    },
-    "17": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "5.28",
-      "includingLoc": "None"
-    },
-    "18": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "5.25",
-      "includingLoc": "None"
-    },
-    "19": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "5.1",
-      "includingLoc": "None"
-    },
-    "20": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "7.10",
-      "includingLoc": "None"
-    },
-    "21": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "7.13",
-      "includingLoc": "None"
-    },
-    "22": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "7.13",
-      "includingLoc": "None"
-    },
-    "23": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "7.13",
-      "includingLoc": "None"
-    },
-    "24": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "7.1",
-      "includingLoc": "None"
-    },
-    "25": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "8.1",
-      "includingLoc": "None"
-    },
-    "26": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "9.12",
-      "includingLoc": "None"
-    },
-    "27": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "9.12",
-      "includingLoc": "None"
-    },
-    "28": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "9.12",
-      "includingLoc": "None"
-    },
-    "29": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "9.9",
-      "includingLoc": "None"
-    },
-    "30": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "9.18",
-      "includingLoc": "None"
-    },
-    "31": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "9.18",
-      "includingLoc": "None"
-    },
-    "32": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "9.18",
-      "includingLoc": "None"
-    },
-    "33": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "9.15",
-      "includingLoc": "None"
-    },
-    "34": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "9.28",
-      "includingLoc": "None"
-    },
-    "35": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "9.28",
-      "includingLoc": "None"
-    },
-    "36": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "9.28",
-      "includingLoc": "None"
-    },
-    "37": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "9.21",
-      "includingLoc": "None"
-    },
-    "38": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "9.28",
-      "includingLoc": "None"
-    },
-    "39": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "9.28",
-      "includingLoc": "None"
-    },
-    "40": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "9.28",
-      "includingLoc": "None"
-    },
-    "41": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "9.21",
-      "includingLoc": "None"
-    },
-    "42": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "9.28",
-      "includingLoc": "None"
-    },
-    "43": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "9.28",
-      "includingLoc": "None"
-    },
-    "44": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "9.28",
-      "includingLoc": "None"
-    },
-    "45": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "9.21",
-      "includingLoc": "None"
-    },
-    "46": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "9.34",
-      "includingLoc": "None"
-    },
-    "47": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "9.34",
-      "includingLoc": "None"
-    },
-    "48": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "9.34",
-      "includingLoc": "None"
-    },
-    "49": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "9.1",
-      "includingLoc": "None"
-    },
-    "50": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "11.15",
-      "includingLoc": "None"
-    },
-    "51": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "11.24",
-      "includingLoc": "None"
-    },
-    "52": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "11.24",
-      "includingLoc": "None"
-    },
-    "53": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "11.24",
-      "includingLoc": "None"
-    },
-    "54": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "11.1",
-      "includingLoc": "None"
-    },
-    "55": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "13.21",
-      "includingLoc": "None"
-    },
-    "56": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "13.9",
-      "includingLoc": "None"
-    },
-    "57": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "13.21",
-      "includingLoc": "None"
-    },
-    "58": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "13.9",
-      "includingLoc": "None"
-    },
-    "59": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "13.21",
-      "includingLoc": "None"
-    },
-    "60": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "13.9",
-      "includingLoc": "None"
-    },
-    "61": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "13.29",
-      "includingLoc": "None"
-    },
-    "62": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "13.29",
-      "includingLoc": "None"
-    },
-    "63": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "13.29",
-      "includingLoc": "None"
-    },
-    "64": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "13.1",
-      "includingLoc": "None"
-    },
-    "65": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "17.5",
-      "includingLoc": "None"
-    },
-    "66": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "17.5",
-      "includingLoc": "None"
-    },
-    "67": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "17.5",
-      "includingLoc": "None"
-    },
-    "68": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "16.1",
-      "includingLoc": "None"
-    },
-    "69": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "21.3",
-      "includingLoc": "None"
-    },
-    "70": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "27.5",
-      "includingLoc": "None"
-    },
-    "71": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "27.5",
-      "includingLoc": "None"
-    },
-    "72": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "27.5",
-      "includingLoc": "None"
-    },
-    "73": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "24.3",
-      "includingLoc": "None"
-    },
-    "74": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "27.5",
-      "includingLoc": "None"
-    },
-    "75": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "27.5",
-      "includingLoc": "None"
-    },
-    "76": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "27.5",
-      "includingLoc": "None"
-    },
-    "77": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "24.3",
-      "includingLoc": "None"
-    },
-    "78": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "27.5",
-      "includingLoc": "None"
-    },
-    "79": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "27.5",
-      "includingLoc": "None"
-    },
-    "80": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "27.5",
-      "includingLoc": "None"
-    },
-    "81": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "24.3",
-      "includingLoc": "None"
-    },
-    "82": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "20.1",
-      "includingLoc": "None"
-    },
-    "83": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "33.13",
-      "includingLoc": "None"
-    },
-    "84": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "33.15",
-      "includingLoc": "None"
-    },
-    "85": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "33.13",
-      "includingLoc": "None"
-    },
-    "86": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "33.25",
-      "includingLoc": "None"
-    },
-    "87": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "34.16",
-      "includingLoc": "None"
-    },
-    "88": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "33.1",
-      "includingLoc": "None"
-    },
-    "89": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "39.18",
-      "includingLoc": "None"
-    },
-    "90": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "39.18",
-      "includingLoc": "None"
-    },
-    "91": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "39.9",
-      "includingLoc": "None"
-    },
-    "92": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "39.18",
-      "includingLoc": "None"
-    },
-    "93": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "39.18",
-      "includingLoc": "None"
-    },
-    "94": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "39.9",
-      "includingLoc": "None"
-    },
-    "95": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "39.18",
-      "includingLoc": "None"
-    },
-    "96": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "39.18",
-      "includingLoc": "None"
-    },
-    "97": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "39.9",
-      "includingLoc": "None"
-    },
-    "98": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "38.5",
-      "includingLoc": "None"
-    },
-    "99": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "39.18",
-      "includingLoc": "None"
-    },
-    "100": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "39.18",
-      "includingLoc": "None"
-    },
-    "101": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "39.9",
-      "includingLoc": "None"
-    },
-    "102": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "39.18",
-      "includingLoc": "None"
-    },
-    "103": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "39.18",
-      "includingLoc": "None"
-    },
-    "104": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "39.9",
-      "includingLoc": "None"
-    },
-    "105": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "39.18",
-      "includingLoc": "None"
-    },
-    "106": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "39.18",
-      "includingLoc": "None"
-    },
-    "107": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "39.9",
-      "includingLoc": "None"
-    },
-    "108": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "38.5",
-      "includingLoc": "None"
-    },
-    "109": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "39.18",
-      "includingLoc": "None"
-    },
-    "110": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "39.18",
-      "includingLoc": "None"
-    },
-    "111": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "39.9",
-      "includingLoc": "None"
-    },
-    "112": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "39.18",
-      "includingLoc": "None"
-    },
-    "113": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "39.18",
-      "includingLoc": "None"
-    },
-    "114": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "39.9",
-      "includingLoc": "None"
-    },
-    "115": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "39.18",
-      "includingLoc": "None"
-    },
-    "116": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "39.18",
-      "includingLoc": "None"
-    },
-    "117": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "39.9",
-      "includingLoc": "None"
-    },
-    "118": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "38.5",
-      "includingLoc": "None"
-    },
-    "119": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
-      "pos": "37.1",
-      "includingLoc": "None"
+  "fppVersion" : "v3.1.0a10-46-g5b2da7ca1",
+  "locationMap" : {
+    "0" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "1.1",
+      "includingLoc" : "None"
+    },
+    "1" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "3.1",
+      "includingLoc" : "None"
+    },
+    "2" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "4.12",
+      "includingLoc" : "None"
+    },
+    "3" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "4.9",
+      "includingLoc" : "None"
+    },
+    "4" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "4.12",
+      "includingLoc" : "None"
+    },
+    "5" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "4.9",
+      "includingLoc" : "None"
+    },
+    "6" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "4.12",
+      "includingLoc" : "None"
+    },
+    "7" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "4.9",
+      "includingLoc" : "None"
+    },
+    "8" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "4.1",
+      "includingLoc" : "None"
+    },
+    "9" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "5.12",
+      "includingLoc" : "None"
+    },
+    "10" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "5.9",
+      "includingLoc" : "None"
+    },
+    "11" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "5.20",
+      "includingLoc" : "None"
+    },
+    "12" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "5.17",
+      "includingLoc" : "None"
+    },
+    "13" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "5.28",
+      "includingLoc" : "None"
+    },
+    "14" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "5.25",
+      "includingLoc" : "None"
+    },
+    "15" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "5.28",
+      "includingLoc" : "None"
+    },
+    "16" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "5.25",
+      "includingLoc" : "None"
+    },
+    "17" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "5.28",
+      "includingLoc" : "None"
+    },
+    "18" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "5.25",
+      "includingLoc" : "None"
+    },
+    "19" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "5.1",
+      "includingLoc" : "None"
+    },
+    "20" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "7.10",
+      "includingLoc" : "None"
+    },
+    "21" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "7.13",
+      "includingLoc" : "None"
+    },
+    "22" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "7.13",
+      "includingLoc" : "None"
+    },
+    "23" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "7.13",
+      "includingLoc" : "None"
+    },
+    "24" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "7.1",
+      "includingLoc" : "None"
+    },
+    "25" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "8.1",
+      "includingLoc" : "None"
+    },
+    "26" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "9.12",
+      "includingLoc" : "None"
+    },
+    "27" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "9.12",
+      "includingLoc" : "None"
+    },
+    "28" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "9.12",
+      "includingLoc" : "None"
+    },
+    "29" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "9.9",
+      "includingLoc" : "None"
+    },
+    "30" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "9.18",
+      "includingLoc" : "None"
+    },
+    "31" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "9.18",
+      "includingLoc" : "None"
+    },
+    "32" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "9.18",
+      "includingLoc" : "None"
+    },
+    "33" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "9.15",
+      "includingLoc" : "None"
+    },
+    "34" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "9.28",
+      "includingLoc" : "None"
+    },
+    "35" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "9.28",
+      "includingLoc" : "None"
+    },
+    "36" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "9.28",
+      "includingLoc" : "None"
+    },
+    "37" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "9.21",
+      "includingLoc" : "None"
+    },
+    "38" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "9.28",
+      "includingLoc" : "None"
+    },
+    "39" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "9.28",
+      "includingLoc" : "None"
+    },
+    "40" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "9.28",
+      "includingLoc" : "None"
+    },
+    "41" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "9.21",
+      "includingLoc" : "None"
+    },
+    "42" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "9.28",
+      "includingLoc" : "None"
+    },
+    "43" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "9.28",
+      "includingLoc" : "None"
+    },
+    "44" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "9.28",
+      "includingLoc" : "None"
+    },
+    "45" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "9.21",
+      "includingLoc" : "None"
+    },
+    "46" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "9.34",
+      "includingLoc" : "None"
+    },
+    "47" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "9.34",
+      "includingLoc" : "None"
+    },
+    "48" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "9.34",
+      "includingLoc" : "None"
+    },
+    "49" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "9.1",
+      "includingLoc" : "None"
+    },
+    "50" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "11.15",
+      "includingLoc" : "None"
+    },
+    "51" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "11.24",
+      "includingLoc" : "None"
+    },
+    "52" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "11.24",
+      "includingLoc" : "None"
+    },
+    "53" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "11.24",
+      "includingLoc" : "None"
+    },
+    "54" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "11.1",
+      "includingLoc" : "None"
+    },
+    "55" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "13.21",
+      "includingLoc" : "None"
+    },
+    "56" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "13.9",
+      "includingLoc" : "None"
+    },
+    "57" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "13.21",
+      "includingLoc" : "None"
+    },
+    "58" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "13.9",
+      "includingLoc" : "None"
+    },
+    "59" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "13.21",
+      "includingLoc" : "None"
+    },
+    "60" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "13.9",
+      "includingLoc" : "None"
+    },
+    "61" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "13.29",
+      "includingLoc" : "None"
+    },
+    "62" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "13.29",
+      "includingLoc" : "None"
+    },
+    "63" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "13.29",
+      "includingLoc" : "None"
+    },
+    "64" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "13.1",
+      "includingLoc" : "None"
+    },
+    "65" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "17.5",
+      "includingLoc" : "None"
+    },
+    "66" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "17.5",
+      "includingLoc" : "None"
+    },
+    "67" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "17.5",
+      "includingLoc" : "None"
+    },
+    "68" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "16.1",
+      "includingLoc" : "None"
+    },
+    "69" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "21.3",
+      "includingLoc" : "None"
+    },
+    "70" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "27.5",
+      "includingLoc" : "None"
+    },
+    "71" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "27.5",
+      "includingLoc" : "None"
+    },
+    "72" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "27.5",
+      "includingLoc" : "None"
+    },
+    "73" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "24.3",
+      "includingLoc" : "None"
+    },
+    "74" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "27.5",
+      "includingLoc" : "None"
+    },
+    "75" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "27.5",
+      "includingLoc" : "None"
+    },
+    "76" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "27.5",
+      "includingLoc" : "None"
+    },
+    "77" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "24.3",
+      "includingLoc" : "None"
+    },
+    "78" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "27.5",
+      "includingLoc" : "None"
+    },
+    "79" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "27.5",
+      "includingLoc" : "None"
+    },
+    "80" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "27.5",
+      "includingLoc" : "None"
+    },
+    "81" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "24.3",
+      "includingLoc" : "None"
+    },
+    "82" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "20.1",
+      "includingLoc" : "None"
+    },
+    "83" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "33.13",
+      "includingLoc" : "None"
+    },
+    "84" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "33.15",
+      "includingLoc" : "None"
+    },
+    "85" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "33.13",
+      "includingLoc" : "None"
+    },
+    "86" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "33.25",
+      "includingLoc" : "None"
+    },
+    "87" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "34.16",
+      "includingLoc" : "None"
+    },
+    "88" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "33.1",
+      "includingLoc" : "None"
+    },
+    "89" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "39.18",
+      "includingLoc" : "None"
+    },
+    "90" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "39.18",
+      "includingLoc" : "None"
+    },
+    "91" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "39.9",
+      "includingLoc" : "None"
+    },
+    "92" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "39.18",
+      "includingLoc" : "None"
+    },
+    "93" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "39.18",
+      "includingLoc" : "None"
+    },
+    "94" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "39.9",
+      "includingLoc" : "None"
+    },
+    "95" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "39.18",
+      "includingLoc" : "None"
+    },
+    "96" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "39.18",
+      "includingLoc" : "None"
+    },
+    "97" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "39.9",
+      "includingLoc" : "None"
+    },
+    "98" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "38.5",
+      "includingLoc" : "None"
+    },
+    "99" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "39.18",
+      "includingLoc" : "None"
+    },
+    "100" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "39.18",
+      "includingLoc" : "None"
+    },
+    "101" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "39.9",
+      "includingLoc" : "None"
+    },
+    "102" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "39.18",
+      "includingLoc" : "None"
+    },
+    "103" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "39.18",
+      "includingLoc" : "None"
+    },
+    "104" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "39.9",
+      "includingLoc" : "None"
+    },
+    "105" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "39.18",
+      "includingLoc" : "None"
+    },
+    "106" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "39.18",
+      "includingLoc" : "None"
+    },
+    "107" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "39.9",
+      "includingLoc" : "None"
+    },
+    "108" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "38.5",
+      "includingLoc" : "None"
+    },
+    "109" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "39.18",
+      "includingLoc" : "None"
+    },
+    "110" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "39.18",
+      "includingLoc" : "None"
+    },
+    "111" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "39.9",
+      "includingLoc" : "None"
+    },
+    "112" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "39.18",
+      "includingLoc" : "None"
+    },
+    "113" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "39.18",
+      "includingLoc" : "None"
+    },
+    "114" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "39.9",
+      "includingLoc" : "None"
+    },
+    "115" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "39.18",
+      "includingLoc" : "None"
+    },
+    "116" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "39.18",
+      "includingLoc" : "None"
+    },
+    "117" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "39.9",
+      "includingLoc" : "None"
+    },
+    "118" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "38.5",
+      "includingLoc" : "None"
+    },
+    "119" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",
+      "pos" : "37.1",
+      "includingLoc" : "None"
     }
   }
 }

--- a/tests/ports/ports_locations.json
+++ b/tests/ports/ports_locations.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion" : "v3.1.0a10-46-g5b2da7ca1",
+  "fppVersion" : "v3.1.0a10-54-g11243e778",
   "locationMap" : {
     "0" : {
       "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",

--- a/tests/queued_component/queued_component_analysis.json
+++ b/tests/queued_component/queued_component_analysis.json
@@ -1,551 +1,640 @@
 {
-  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
-  "analysis": {
-    "componentInstanceMap": {
-      "79": {
-        "aNode": {
-          "astNodeId": 79
+  "fppVersion" : "v3.1.0a10-54-g11243e778",
+  "analysis" : {
+    "componentInstanceMap" : {
+      "79" : {
+        "aNode" : {
+          "astNodeId" : 79
         },
-        "qualifiedName": {
-          "qualifier": ["FSW"],
-          "base": "engineTemp"
+        "qualifiedName" : {
+          "qualifier" : [
+            "FSW"
+          ],
+          "base" : "engineTemp"
         },
-        "component": {
-          "astNodeId": 60
+        "component" : {
+          "astNodeId" : 60
         },
-        "baseId": 256,
-        "maxId": 257,
-        "file": "None",
-        "queueSize": {
-          "Some": 10
+        "baseId" : 256,
+        "maxId" : 257,
+        "file" : "None",
+        "queueSize" : {
+          "Some" : 10
         },
-        "stackSize": "None",
-        "priority": "None",
-        "cpu": "None",
-        "initSpecifierMap": {}
+        "stackSize" : "None",
+        "priority" : "None",
+        "cpu" : "None",
+        "initSpecifierMap" : {
+          
+        }
       }
     },
-    "componentMap": {
-      "60": {
-        "aNode": {
-          "astNodeId": 60
+    "componentMap" : {
+      "60" : {
+        "aNode" : {
+          "astNodeId" : 60
         },
-        "portMap": {
-          "schedIn": {
-            "General": {
-              "aNode": {
-                "astNodeId": 46
+        "portMap" : {
+          "schedIn" : {
+            "General" : {
+              "aNode" : {
+                "astNodeId" : 46
               },
-              "specifier": {
-                "kind": {
-                  "SyncInput": {}
-                },
-                "name": "schedIn",
-                "size": "None",
-                "port": {
-                  "Some": {
-                    "astNodeId": 45
+              "specifier" : {
+                "kind" : {
+                  "SyncInput" : {
+                    
                   }
                 },
-                "priority": "None",
-                "queueFull": "None"
+                "name" : "schedIn",
+                "size" : "None",
+                "port" : {
+                  "Some" : {
+                    "astNodeId" : 45
+                  }
+                },
+                "priority" : "None",
+                "queueFull" : "None"
               },
-              "kind": "SyncInput",
-              "size": 1,
-              "ty": {
-                "DefPort": {
-                  "symbol": {
-                    "Port": {
-                      "nodeId": 83,
-                      "unqualifiedName": "Sched"
+              "kind" : "SyncInput",
+              "size" : 1,
+              "ty" : {
+                "DefPort" : {
+                  "symbol" : {
+                    "Port" : {
+                      "nodeId" : 83,
+                      "unqualifiedName" : "Sched"
                     }
                   }
                 }
               },
-              "importNodeIds": []
+              "importNodeIds" : [
+              ]
             }
           },
-          "calibrationIn": {
-            "General": {
-              "aNode": {
-                "astNodeId": 49
+          "calibrationIn" : {
+            "General" : {
+              "aNode" : {
+                "astNodeId" : 49
               },
-              "specifier": {
-                "kind": {
-                  "AsyncInput": {}
-                },
-                "name": "calibrationIn",
-                "size": "None",
-                "port": {
-                  "Some": {
-                    "astNodeId": 48
+              "specifier" : {
+                "kind" : {
+                  "AsyncInput" : {
+                    
                   }
                 },
-                "priority": "None",
-                "queueFull": "None"
+                "name" : "calibrationIn",
+                "size" : "None",
+                "port" : {
+                  "Some" : {
+                    "astNodeId" : 48
+                  }
+                },
+                "priority" : "None",
+                "queueFull" : "None"
               },
-              "kind": "AsyncInput",
-              "size": 1,
-              "ty": {
-                "DefPort": {
-                  "symbol": {
-                    "Port": {
-                      "nodeId": 6,
-                      "unqualifiedName": "Calibration"
+              "kind" : "AsyncInput",
+              "size" : 1,
+              "ty" : {
+                "DefPort" : {
+                  "symbol" : {
+                    "Port" : {
+                      "nodeId" : 6,
+                      "unqualifiedName" : "Calibration"
                     }
                   }
                 }
               },
-              "importNodeIds": []
+              "importNodeIds" : [
+              ]
             }
           },
-          "tlmOut": {
-            "Special": {
-              "aNode": {
-                "astNodeId": 50
+          "tlmOut" : {
+            "Special" : {
+              "aNode" : {
+                "astNodeId" : 50
               },
-              "specifier": {
-                "inputKind": "None",
-                "kind": {
-                  "Telemetry": {}
+              "specifier" : {
+                "inputKind" : "None",
+                "kind" : {
+                  "Telemetry" : {
+                    
+                  }
                 },
-                "name": "tlmOut",
-                "priority": "None",
-                "queueFull": "None"
+                "name" : "tlmOut",
+                "priority" : "None",
+                "queueFull" : "None"
               },
-              "symbol": {
-                "Port": {
-                  "nodeId": 85,
-                  "unqualifiedName": "Tlm"
+              "symbol" : {
+                "Port" : {
+                  "nodeId" : 85,
+                  "unqualifiedName" : "Tlm"
                 }
               },
-              "priority": "None",
-              "queueFull": "None",
-              "importNodeIds": []
+              "priority" : "None",
+              "queueFull" : "None",
+              "importNodeIds" : [
+              ]
             }
           },
-          "timeGetOut": {
-            "Special": {
-              "aNode": {
-                "astNodeId": 51
+          "timeGetOut" : {
+            "Special" : {
+              "aNode" : {
+                "astNodeId" : 51
               },
-              "specifier": {
-                "inputKind": "None",
-                "kind": {
-                  "TimeGet": {}
+              "specifier" : {
+                "inputKind" : "None",
+                "kind" : {
+                  "TimeGet" : {
+                    
+                  }
                 },
-                "name": "timeGetOut",
-                "priority": "None",
-                "queueFull": "None"
+                "name" : "timeGetOut",
+                "priority" : "None",
+                "queueFull" : "None"
               },
-              "symbol": {
-                "Port": {
-                  "nodeId": 88,
-                  "unqualifiedName": "Time"
+              "symbol" : {
+                "Port" : {
+                  "nodeId" : 88,
+                  "unqualifiedName" : "Time"
                 }
               },
-              "priority": "None",
-              "queueFull": "None",
-              "importNodeIds": []
+              "priority" : "None",
+              "queueFull" : "None",
+              "importNodeIds" : [
+              ]
             }
           }
         },
-        "specialPortMap": {
-          "telemetry": {
-            "aNode": {
-              "astNodeId": 50
+        "specialPortMap" : {
+          "telemetry" : {
+            "aNode" : {
+              "astNodeId" : 50
             },
-            "specifier": {
-              "inputKind": "None",
-              "kind": {
-                "Telemetry": {}
+            "specifier" : {
+              "inputKind" : "None",
+              "kind" : {
+                "Telemetry" : {
+                  
+                }
               },
-              "name": "tlmOut",
-              "priority": "None",
-              "queueFull": "None"
+              "name" : "tlmOut",
+              "priority" : "None",
+              "queueFull" : "None"
             },
-            "symbol": {
-              "Port": {
-                "nodeId": 85,
-                "unqualifiedName": "Tlm"
+            "symbol" : {
+              "Port" : {
+                "nodeId" : 85,
+                "unqualifiedName" : "Tlm"
               }
             },
-            "priority": "None",
-            "queueFull": "None",
-            "importNodeIds": []
+            "priority" : "None",
+            "queueFull" : "None",
+            "importNodeIds" : [
+            ]
           },
-          "time get": {
-            "aNode": {
-              "astNodeId": 51
+          "time get" : {
+            "aNode" : {
+              "astNodeId" : 51
             },
-            "specifier": {
-              "inputKind": "None",
-              "kind": {
-                "TimeGet": {}
+            "specifier" : {
+              "inputKind" : "None",
+              "kind" : {
+                "TimeGet" : {
+                  
+                }
               },
-              "name": "timeGetOut",
-              "priority": "None",
-              "queueFull": "None"
+              "name" : "timeGetOut",
+              "priority" : "None",
+              "queueFull" : "None"
             },
-            "symbol": {
-              "Port": {
-                "nodeId": 88,
-                "unqualifiedName": "Time"
+            "symbol" : {
+              "Port" : {
+                "nodeId" : 88,
+                "unqualifiedName" : "Time"
               }
             },
-            "priority": "None",
-            "queueFull": "None",
-            "importNodeIds": []
+            "priority" : "None",
+            "queueFull" : "None",
+            "importNodeIds" : [
+            ]
           }
         },
-        "commandMap": {},
-        "defaultOpcode": 0,
-        "tlmChannelMap": {
-          "0": {
-            "aNode": {
-              "astNodeId": 53
+        "commandMap" : {
+          
+        },
+        "defaultOpcode" : 0,
+        "tlmChannelMap" : {
+          "0" : {
+            "aNode" : {
+              "astNodeId" : 53
             },
-            "channelType": {
-              "Primitive": {
-                "Float": {
-                  "kind": {
-                    "F32": {}
+            "channelType" : {
+              "Primitive" : {
+                "Float" : {
+                  "kind" : {
+                    "F32" : {
+                      
+                    }
                   }
                 }
               }
             },
-            "update": {
-              "Always": {}
+            "update" : {
+              "Always" : {
+                
+              }
             },
-            "format": "None",
-            "lowLimits": {},
-            "highLimits": {}
+            "format" : "None",
+            "lowLimits" : {
+              
+            },
+            "highLimits" : {
+              
+            }
           },
-          "1": {
-            "aNode": {
-              "astNodeId": 59
+          "1" : {
+            "aNode" : {
+              "astNodeId" : 59
             },
-            "channelType": {
-              "Primitive": {
-                "Float": {
-                  "kind": {
-                    "F32": {}
+            "channelType" : {
+              "Primitive" : {
+                "Float" : {
+                  "kind" : {
+                    "F32" : {
+                      
+                    }
                   }
                 }
               }
             },
-            "update": {
-              "Always": {}
+            "update" : {
+              "Always" : {
+                
+              }
             },
-            "format": "None",
-            "lowLimits": {},
-            "highLimits": {}
+            "format" : "None",
+            "lowLimits" : {
+              
+            },
+            "highLimits" : {
+              
+            }
           }
         },
-        "tlmChannelNameMap": {
-          "ImpulseTemp": {
-            "aNode": {
-              "astNodeId": 53
+        "tlmChannelNameMap" : {
+          "ImpulseTemp" : {
+            "aNode" : {
+              "astNodeId" : 53
             },
-            "channelType": {
-              "Primitive": {
-                "Float": {
-                  "kind": {
-                    "F32": {}
+            "channelType" : {
+              "Primitive" : {
+                "Float" : {
+                  "kind" : {
+                    "F32" : {
+                      
+                    }
                   }
                 }
               }
             },
-            "update": {
-              "Always": {}
+            "update" : {
+              "Always" : {
+                
+              }
             },
-            "format": "None",
-            "lowLimits": {},
-            "highLimits": {}
+            "format" : "None",
+            "lowLimits" : {
+              
+            },
+            "highLimits" : {
+              
+            }
           },
-          "WarpTemp": {
-            "aNode": {
-              "astNodeId": 59
+          "WarpTemp" : {
+            "aNode" : {
+              "astNodeId" : 59
             },
-            "channelType": {
-              "Primitive": {
-                "Float": {
-                  "kind": {
-                    "F32": {}
+            "channelType" : {
+              "Primitive" : {
+                "Float" : {
+                  "kind" : {
+                    "F32" : {
+                      
+                    }
                   }
                 }
               }
             },
-            "update": {
-              "Always": {}
+            "update" : {
+              "Always" : {
+                
+              }
             },
-            "format": "None",
-            "lowLimits": {},
-            "highLimits": {}
+            "format" : "None",
+            "lowLimits" : {
+              
+            },
+            "highLimits" : {
+              
+            }
           }
         },
-        "defaultTlmChannelId": 2,
-        "eventMap": {},
-        "defaultEventId": 0,
-        "paramMap": {},
-        "specPortMatchingList": [],
-        "stateMachineInstanceMap": {},
-        "portMatchingList": [],
-        "defaultParamId": 0,
-        "containerMap": {},
-        "defaultContainerId": 0,
-        "recordMap": {},
-        "defaultRecordId": 0
+        "defaultTlmChannelId" : 2,
+        "eventMap" : {
+          
+        },
+        "defaultEventId" : 0,
+        "paramMap" : {
+          
+        },
+        "specPortMatchingList" : [
+        ],
+        "stateMachineInstanceMap" : {
+          
+        },
+        "portMatchingList" : [
+        ],
+        "defaultParamId" : 0,
+        "containerMap" : {
+          
+        },
+        "defaultContainerId" : 0,
+        "recordMap" : {
+          
+        },
+        "defaultRecordId" : 0
       }
     },
-    "includedFileSet": [],
-    "inputFileSet": [
+    "includedFileSet" : [
+    ],
+    "inputFileSet" : [
       "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp"
     ],
-    "locationSpecifierMap": [],
-    "parentSymbolMap": {
-      "88": {
-        "Module": {
-          "nodeId": 89,
-          "unqualifiedName": "Fw"
+    "locationSpecifierMap" : [
+    ],
+    "parentSymbolMap" : {
+      "88" : {
+        "Module" : {
+          "nodeId" : 89,
+          "unqualifiedName" : "Fw"
         }
       },
-      "83": {
-        "Module": {
-          "nodeId": 84,
-          "unqualifiedName": "Svc"
+      "83" : {
+        "Module" : {
+          "nodeId" : 84,
+          "unqualifiedName" : "Svc"
         }
       },
-      "79": {
-        "Module": {
-          "nodeId": 80,
-          "unqualifiedName": "FSW"
+      "79" : {
+        "Module" : {
+          "nodeId" : 80,
+          "unqualifiedName" : "FSW"
         }
       },
-      "6": {
-        "Module": {
-          "nodeId": 61,
-          "unqualifiedName": "Sensors"
+      "6" : {
+        "Module" : {
+          "nodeId" : 61,
+          "unqualifiedName" : "Sensors"
         }
       },
-      "60": {
-        "Module": {
-          "nodeId": 61,
-          "unqualifiedName": "Sensors"
+      "60" : {
+        "Module" : {
+          "nodeId" : 61,
+          "unqualifiedName" : "Sensors"
         }
       },
-      "85": {
-        "Module": {
-          "nodeId": 89,
-          "unqualifiedName": "Fw"
+      "85" : {
+        "Module" : {
+          "nodeId" : 89,
+          "unqualifiedName" : "Fw"
         }
       }
     },
-    "symbolScopeMap": {
-      "89": {
-        "map": {
-          "Port": {
-            "map": {
-              "Tlm": {
-                "Port": {
-                  "nodeId": 85,
-                  "unqualifiedName": "Tlm"
+    "symbolScopeMap" : {
+      "89" : {
+        "map" : {
+          "Port" : {
+            "map" : {
+              "Tlm" : {
+                "Port" : {
+                  "nodeId" : 85,
+                  "unqualifiedName" : "Tlm"
                 }
               },
-              "Time": {
-                "Port": {
-                  "nodeId": 88,
-                  "unqualifiedName": "Time"
+              "Time" : {
+                "Port" : {
+                  "nodeId" : 88,
+                  "unqualifiedName" : "Time"
                 }
               }
             }
           }
         }
       },
-      "84": {
-        "map": {
-          "Port": {
-            "map": {
-              "Sched": {
-                "Port": {
-                  "nodeId": 83,
-                  "unqualifiedName": "Sched"
+      "84" : {
+        "map" : {
+          "Port" : {
+            "map" : {
+              "Sched" : {
+                "Port" : {
+                  "nodeId" : 83,
+                  "unqualifiedName" : "Sched"
                 }
               }
             }
           }
         }
       },
-      "61": {
-        "map": {
-          "StateMachine": {
-            "map": {
-              "EngineTemp": {
-                "Component": {
-                  "nodeId": 60,
-                  "unqualifiedName": "EngineTemp"
+      "61" : {
+        "map" : {
+          "StateMachine" : {
+            "map" : {
+              "EngineTemp" : {
+                "Component" : {
+                  "nodeId" : 60,
+                  "unqualifiedName" : "EngineTemp"
                 }
               }
             }
           },
-          "Value": {
-            "map": {
-              "EngineTemp": {
-                "Component": {
-                  "nodeId": 60,
-                  "unqualifiedName": "EngineTemp"
+          "Value" : {
+            "map" : {
+              "EngineTemp" : {
+                "Component" : {
+                  "nodeId" : 60,
+                  "unqualifiedName" : "EngineTemp"
                 }
               }
             }
           },
-          "Port": {
-            "map": {
-              "Calibration": {
-                "Port": {
-                  "nodeId": 6,
-                  "unqualifiedName": "Calibration"
+          "Port" : {
+            "map" : {
+              "Calibration" : {
+                "Port" : {
+                  "nodeId" : 6,
+                  "unqualifiedName" : "Calibration"
                 }
               }
             }
           },
-          "Component": {
-            "map": {
-              "EngineTemp": {
-                "Component": {
-                  "nodeId": 60,
-                  "unqualifiedName": "EngineTemp"
+          "Component" : {
+            "map" : {
+              "EngineTemp" : {
+                "Component" : {
+                  "nodeId" : 60,
+                  "unqualifiedName" : "EngineTemp"
                 }
               }
             }
           },
-          "Type": {
-            "map": {
-              "EngineTemp": {
-                "Component": {
-                  "nodeId": 60,
-                  "unqualifiedName": "EngineTemp"
+          "Type" : {
+            "map" : {
+              "EngineTemp" : {
+                "Component" : {
+                  "nodeId" : 60,
+                  "unqualifiedName" : "EngineTemp"
                 }
               }
             }
           }
         }
       },
-      "80": {
-        "map": {
-          "ComponentInstance": {
-            "map": {
-              "engineTemp": {
-                "ComponentInstance": {
-                  "nodeId": 79,
-                  "unqualifiedName": "engineTemp"
+      "80" : {
+        "map" : {
+          "ComponentInstance" : {
+            "map" : {
+              "engineTemp" : {
+                "ComponentInstance" : {
+                  "nodeId" : 79,
+                  "unqualifiedName" : "engineTemp"
                 }
               }
             }
           }
         }
       },
-      "60": {
-        "map": {}
+      "60" : {
+        "map" : {
+          
+        }
       }
     },
-    "topologyMap": {},
-    "typeMap": {
-      "78": {
-        "Int": {
-          "Integer": {}
+    "topologyMap" : {
+      
+    },
+    "typeMap" : {
+      "78" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "58": {
-        "Primitive": {
-          "Float": {
-            "kind": {
-              "F32": {}
+      "58" : {
+        "Primitive" : {
+          "Float" : {
+            "kind" : {
+              "F32" : {
+                
+              }
             }
           }
         }
       },
-      "52": {
-        "Primitive": {
-          "Float": {
-            "kind": {
-              "F32": {}
+      "52" : {
+        "Primitive" : {
+          "Float" : {
+            "kind" : {
+              "F32" : {
+                
+              }
             }
           }
         }
       },
-      "4": {
-        "Primitive": {
-          "Float": {
-            "kind": {
-              "F32": {}
+      "4" : {
+        "Primitive" : {
+          "Float" : {
+            "kind" : {
+              "F32" : {
+                
+              }
             }
           }
         }
       },
-      "77": {
-        "Int": {
-          "Integer": {}
+      "77" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       }
     },
-    "useDefMap": {
-      "45": {
-        "Port": {
-          "nodeId": 83,
-          "unqualifiedName": "Sched"
+    "useDefMap" : {
+      "45" : {
+        "Port" : {
+          "nodeId" : 83,
+          "unqualifiedName" : "Sched"
         }
       },
-      "51": {
-        "Port": {
-          "nodeId": 88,
-          "unqualifiedName": "Time"
+      "51" : {
+        "Port" : {
+          "nodeId" : 88,
+          "unqualifiedName" : "Time"
         }
       },
-      "50": {
-        "Port": {
-          "nodeId": 85,
-          "unqualifiedName": "Tlm"
+      "50" : {
+        "Port" : {
+          "nodeId" : 85,
+          "unqualifiedName" : "Tlm"
         }
       },
-      "43": {
-        "Module": {
-          "nodeId": 84,
-          "unqualifiedName": "Svc"
+      "43" : {
+        "Module" : {
+          "nodeId" : 84,
+          "unqualifiedName" : "Svc"
         }
       },
-      "74": {
-        "Module": {
-          "nodeId": 61,
-          "unqualifiedName": "Sensors"
+      "74" : {
+        "Module" : {
+          "nodeId" : 61,
+          "unqualifiedName" : "Sensors"
         }
       },
-      "48": {
-        "Port": {
-          "nodeId": 6,
-          "unqualifiedName": "Calibration"
+      "48" : {
+        "Port" : {
+          "nodeId" : 6,
+          "unqualifiedName" : "Calibration"
         }
       },
-      "76": {
-        "Component": {
-          "nodeId": 60,
-          "unqualifiedName": "EngineTemp"
+      "76" : {
+        "Component" : {
+          "nodeId" : 60,
+          "unqualifiedName" : "EngineTemp"
         }
       }
     },
-    "valueMap": {
-      "77": {
-        "Integer": {
-          "value": 256
+    "valueMap" : {
+      "77" : {
+        "Integer" : {
+          "value" : 256
         }
       },
-      "78": {
-        "Integer": {
-          "value": 10
+      "78" : {
+        "Integer" : {
+          "value" : 10
         }
       }
     },
-    "stateMachineMap": {},
-    "dictionarySymbolSet": [],
-    "interfaceMap": {}
+    "stateMachineMap" : {
+      
+    },
+    "dictionarySymbolSet" : [
+    ],
+    "interfaceMap" : {
+      
+    }
   }
 }

--- a/tests/queued_component/queued_component_analysis.json
+++ b/tests/queued_component/queued_component_analysis.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion": "[ fpp version ]",
+  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
   "analysis": {
     "componentInstanceMap": {
       "79": {

--- a/tests/queued_component/queued_component_ast.json
+++ b/tests/queued_component/queued_component_ast.json
@@ -1,470 +1,539 @@
 {
-  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
-  "ast": [
+  "fppVersion" : "v3.1.0a10-54-g11243e778",
+  "ast" : [
     {
-      "members": [
+      "members" : [
         [
-          [],
+          [
+          ],
           {
-            "DefModule": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "Sensors",
-                    "members": [
+            "DefModule" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "Sensors",
+                    "members" : [
                       [
-                        ["A port for calibration input"],
+                        [
+                          "A port for calibration input"
+                        ],
                         {
-                          "DefPort": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "name": "Calibration",
-                                  "params": [
+                          "DefPort" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "name" : "Calibration",
+                                  "params" : [
                                     [
-                                      [],
+                                      [
+                                      ],
                                       {
-                                        "AstNode": {
-                                          "data": {
-                                            "kind": {
-                                              "Value": {}
+                                        "AstNode" : {
+                                          "data" : {
+                                            "kind" : {
+                                              "Value" : {
+                                                
+                                              }
                                             },
-                                            "name": "cal",
-                                            "typeName": {
-                                              "AstNode": {
-                                                "data": {
-                                                  "TypeNameFloat": {
-                                                    "name": {
-                                                      "F32": {}
+                                            "name" : "cal",
+                                            "typeName" : {
+                                              "AstNode" : {
+                                                "data" : {
+                                                  "TypeNameFloat" : {
+                                                    "name" : {
+                                                      "F32" : {
+                                                        
+                                                      }
                                                     }
                                                   }
                                                 },
-                                                "id": 4
+                                                "id" : 4
                                               }
                                             }
                                           },
-                                          "id": 5
+                                          "id" : 5
                                         }
                                       },
-                                      []
+                                      [
+                                      ]
                                     ]
                                   ],
-                                  "returnType": "None"
+                                  "returnType" : "None"
                                 },
-                                "id": 6
+                                "id" : 6
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        ["A component for sensing engine temperature"],
+                        [
+                          "A component for sensing engine temperature"
+                        ],
                         {
-                          "DefComponent": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "kind": {
-                                    "Queued": {}
+                          "DefComponent" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "kind" : {
+                                    "Queued" : {
+                                      
+                                    }
                                   },
-                                  "name": "EngineTemp",
-                                  "members": [
+                                  "name" : "EngineTemp",
+                                  "members" : [
                                     [
-                                      ["Schedule input port"],
+                                      [
+                                        "Schedule input port"
+                                      ],
                                       {
-                                        "SpecPortInstance": {
-                                          "node": {
-                                            "AstNode": {
-                                              "data": {
-                                                "General": {
-                                                  "kind": {
-                                                    "SyncInput": {}
+                                        "SpecPortInstance" : {
+                                          "node" : {
+                                            "AstNode" : {
+                                              "data" : {
+                                                "General" : {
+                                                  "kind" : {
+                                                    "SyncInput" : {
+                                                      
+                                                    }
                                                   },
-                                                  "name": "schedIn",
-                                                  "size": "None",
-                                                  "port": {
-                                                    "Some": {
-                                                      "AstNode": {
-                                                        "data": {
-                                                          "Qualified": {
-                                                            "qualifier": {
-                                                              "AstNode": {
-                                                                "data": {
-                                                                  "Unqualified": {
-                                                                    "name": "Svc"
+                                                  "name" : "schedIn",
+                                                  "size" : "None",
+                                                  "port" : {
+                                                    "Some" : {
+                                                      "AstNode" : {
+                                                        "data" : {
+                                                          "Qualified" : {
+                                                            "qualifier" : {
+                                                              "AstNode" : {
+                                                                "data" : {
+                                                                  "Unqualified" : {
+                                                                    "name" : "Svc"
                                                                   }
                                                                 },
-                                                                "id": 43
+                                                                "id" : 43
                                                               }
                                                             },
-                                                            "name": {
-                                                              "AstNode": {
-                                                                "data": "Sched",
-                                                                "id": 44
+                                                            "name" : {
+                                                              "AstNode" : {
+                                                                "data" : "Sched",
+                                                                "id" : 44
                                                               }
                                                             }
                                                           }
                                                         },
-                                                        "id": 45
+                                                        "id" : 45
                                                       }
                                                     }
                                                   },
-                                                  "priority": "None",
-                                                  "queueFull": "None"
+                                                  "priority" : "None",
+                                                  "queueFull" : "None"
                                                 }
                                               },
-                                              "id": 46
+                                              "id" : 46
                                             }
                                           }
                                         }
                                       },
-                                      []
+                                      [
+                                      ]
                                     ],
                                     [
-                                      ["Calibration input"],
+                                      [
+                                        "Calibration input"
+                                      ],
                                       {
-                                        "SpecPortInstance": {
-                                          "node": {
-                                            "AstNode": {
-                                              "data": {
-                                                "General": {
-                                                  "kind": {
-                                                    "AsyncInput": {}
+                                        "SpecPortInstance" : {
+                                          "node" : {
+                                            "AstNode" : {
+                                              "data" : {
+                                                "General" : {
+                                                  "kind" : {
+                                                    "AsyncInput" : {
+                                                      
+                                                    }
                                                   },
-                                                  "name": "calibrationIn",
-                                                  "size": "None",
-                                                  "port": {
-                                                    "Some": {
-                                                      "AstNode": {
-                                                        "data": {
-                                                          "Unqualified": {
-                                                            "name": "Calibration"
+                                                  "name" : "calibrationIn",
+                                                  "size" : "None",
+                                                  "port" : {
+                                                    "Some" : {
+                                                      "AstNode" : {
+                                                        "data" : {
+                                                          "Unqualified" : {
+                                                            "name" : "Calibration"
                                                           }
                                                         },
-                                                        "id": 48
+                                                        "id" : 48
                                                       }
                                                     }
                                                   },
-                                                  "priority": "None",
-                                                  "queueFull": "None"
+                                                  "priority" : "None",
+                                                  "queueFull" : "None"
                                                 }
                                               },
-                                              "id": 49
+                                              "id" : 49
                                             }
                                           }
                                         }
                                       },
-                                      []
+                                      [
+                                      ]
                                     ],
                                     [
-                                      ["Telemetry port"],
+                                      [
+                                        "Telemetry port"
+                                      ],
                                       {
-                                        "SpecPortInstance": {
-                                          "node": {
-                                            "AstNode": {
-                                              "data": {
-                                                "Special": {
-                                                  "inputKind": "None",
-                                                  "kind": {
-                                                    "Telemetry": {}
+                                        "SpecPortInstance" : {
+                                          "node" : {
+                                            "AstNode" : {
+                                              "data" : {
+                                                "Special" : {
+                                                  "inputKind" : "None",
+                                                  "kind" : {
+                                                    "Telemetry" : {
+                                                      
+                                                    }
                                                   },
-                                                  "name": "tlmOut",
-                                                  "priority": "None",
-                                                  "queueFull": "None"
+                                                  "name" : "tlmOut",
+                                                  "priority" : "None",
+                                                  "queueFull" : "None"
                                                 }
                                               },
-                                              "id": 50
+                                              "id" : 50
                                             }
                                           }
                                         }
                                       },
-                                      []
+                                      [
+                                      ]
                                     ],
                                     [
-                                      ["Time get port"],
+                                      [
+                                        "Time get port"
+                                      ],
                                       {
-                                        "SpecPortInstance": {
-                                          "node": {
-                                            "AstNode": {
-                                              "data": {
-                                                "Special": {
-                                                  "inputKind": "None",
-                                                  "kind": {
-                                                    "TimeGet": {}
+                                        "SpecPortInstance" : {
+                                          "node" : {
+                                            "AstNode" : {
+                                              "data" : {
+                                                "Special" : {
+                                                  "inputKind" : "None",
+                                                  "kind" : {
+                                                    "TimeGet" : {
+                                                      
+                                                    }
                                                   },
-                                                  "name": "timeGetOut",
-                                                  "priority": "None",
-                                                  "queueFull": "None"
+                                                  "name" : "timeGetOut",
+                                                  "priority" : "None",
+                                                  "queueFull" : "None"
                                                 }
                                               },
-                                              "id": 51
+                                              "id" : 51
                                             }
                                           }
                                         }
                                       },
-                                      []
+                                      [
+                                      ]
                                     ],
                                     [
-                                      ["Impulse engine temperature"],
+                                      [
+                                        "Impulse engine temperature"
+                                      ],
                                       {
-                                        "SpecTlmChannel": {
-                                          "node": {
-                                            "AstNode": {
-                                              "data": {
-                                                "name": "ImpulseTemp",
-                                                "typeName": {
-                                                  "AstNode": {
-                                                    "data": {
-                                                      "TypeNameFloat": {
-                                                        "name": {
-                                                          "F32": {}
+                                        "SpecTlmChannel" : {
+                                          "node" : {
+                                            "AstNode" : {
+                                              "data" : {
+                                                "name" : "ImpulseTemp",
+                                                "typeName" : {
+                                                  "AstNode" : {
+                                                    "data" : {
+                                                      "TypeNameFloat" : {
+                                                        "name" : {
+                                                          "F32" : {
+                                                            
+                                                          }
                                                         }
                                                       }
                                                     },
-                                                    "id": 52
+                                                    "id" : 52
                                                   }
                                                 },
-                                                "id": "None",
-                                                "update": "None",
-                                                "format": "None",
-                                                "low": [],
-                                                "high": []
+                                                "id" : "None",
+                                                "update" : "None",
+                                                "format" : "None",
+                                                "low" : [
+                                                ],
+                                                "high" : [
+                                                ]
                                               },
-                                              "id": 53
+                                              "id" : 53
                                             }
                                           }
                                         }
                                       },
-                                      []
+                                      [
+                                      ]
                                     ],
                                     [
-                                      ["Warp core temperature"],
+                                      [
+                                        "Warp core temperature"
+                                      ],
                                       {
-                                        "SpecTlmChannel": {
-                                          "node": {
-                                            "AstNode": {
-                                              "data": {
-                                                "name": "WarpTemp",
-                                                "typeName": {
-                                                  "AstNode": {
-                                                    "data": {
-                                                      "TypeNameFloat": {
-                                                        "name": {
-                                                          "F32": {}
+                                        "SpecTlmChannel" : {
+                                          "node" : {
+                                            "AstNode" : {
+                                              "data" : {
+                                                "name" : "WarpTemp",
+                                                "typeName" : {
+                                                  "AstNode" : {
+                                                    "data" : {
+                                                      "TypeNameFloat" : {
+                                                        "name" : {
+                                                          "F32" : {
+                                                            
+                                                          }
                                                         }
                                                       }
                                                     },
-                                                    "id": 58
+                                                    "id" : 58
                                                   }
                                                 },
-                                                "id": "None",
-                                                "update": "None",
-                                                "format": "None",
-                                                "low": [],
-                                                "high": []
+                                                "id" : "None",
+                                                "update" : "None",
+                                                "format" : "None",
+                                                "low" : [
+                                                ],
+                                                "high" : [
+                                                ]
                                               },
-                                              "id": 59
+                                              "id" : 59
                                             }
                                           }
                                         }
                                       },
-                                      []
+                                      [
+                                      ]
                                     ]
                                   ]
                                 },
-                                "id": 60
+                                "id" : 60
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ]
                     ]
                   },
-                  "id": 61
+                  "id" : 61
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          [],
+          [
+          ],
           {
-            "DefModule": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "FSW",
-                    "members": [
+            "DefModule" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "FSW",
+                    "members" : [
                       [
-                        ["Engine temperature sensor"],
+                        [
+                          "Engine temperature sensor"
+                        ],
                         {
-                          "DefComponentInstance": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "name": "engineTemp",
-                                  "component": {
-                                    "AstNode": {
-                                      "data": {
-                                        "Qualified": {
-                                          "qualifier": {
-                                            "AstNode": {
-                                              "data": {
-                                                "Unqualified": {
-                                                  "name": "Sensors"
+                          "DefComponentInstance" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "name" : "engineTemp",
+                                  "component" : {
+                                    "AstNode" : {
+                                      "data" : {
+                                        "Qualified" : {
+                                          "qualifier" : {
+                                            "AstNode" : {
+                                              "data" : {
+                                                "Unqualified" : {
+                                                  "name" : "Sensors"
                                                 }
                                               },
-                                              "id": 74
+                                              "id" : 74
                                             }
                                           },
-                                          "name": {
-                                            "AstNode": {
-                                              "data": "EngineTemp",
-                                              "id": 75
+                                          "name" : {
+                                            "AstNode" : {
+                                              "data" : "EngineTemp",
+                                              "id" : 75
                                             }
                                           }
                                         }
                                       },
-                                      "id": 76
+                                      "id" : 76
                                     }
                                   },
-                                  "baseId": {
-                                    "AstNode": {
-                                      "data": {
-                                        "ExprLiteralInt": {
-                                          "value": "0x100"
+                                  "baseId" : {
+                                    "AstNode" : {
+                                      "data" : {
+                                        "ExprLiteralInt" : {
+                                          "value" : "0x100"
                                         }
                                       },
-                                      "id": 77
+                                      "id" : 77
                                     }
                                   },
-                                  "implType": "None",
-                                  "file": "None",
-                                  "queueSize": {
-                                    "Some": {
-                                      "AstNode": {
-                                        "data": {
-                                          "ExprLiteralInt": {
-                                            "value": "10"
+                                  "implType" : "None",
+                                  "file" : "None",
+                                  "queueSize" : {
+                                    "Some" : {
+                                      "AstNode" : {
+                                        "data" : {
+                                          "ExprLiteralInt" : {
+                                            "value" : "10"
                                           }
                                         },
-                                        "id": 78
+                                        "id" : 78
                                       }
                                     }
                                   },
-                                  "stackSize": "None",
-                                  "priority": "None",
-                                  "cpu": "None",
-                                  "initSpecs": []
+                                  "stackSize" : "None",
+                                  "priority" : "None",
+                                  "cpu" : "None",
+                                  "initSpecs" : [
+                                  ]
                                 },
-                                "id": 79
+                                "id" : 79
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ]
                     ]
                   },
-                  "id": 80
+                  "id" : 80
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          [],
+          [
+          ],
           {
-            "DefModule": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "Svc",
-                    "members": [
+            "DefModule" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "Svc",
+                    "members" : [
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "DefPort": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "name": "Sched",
-                                  "params": [],
-                                  "returnType": "None"
+                          "DefPort" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "name" : "Sched",
+                                  "params" : [
+                                  ],
+                                  "returnType" : "None"
                                 },
-                                "id": 83
+                                "id" : 83
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ]
                     ]
                   },
-                  "id": 84
+                  "id" : 84
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          [],
+          [
+          ],
           {
-            "DefModule": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "Fw",
-                    "members": [
+            "DefModule" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "Fw",
+                    "members" : [
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "DefPort": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "name": "Tlm",
-                                  "params": [],
-                                  "returnType": "None"
+                          "DefPort" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "name" : "Tlm",
+                                  "params" : [
+                                  ],
+                                  "returnType" : "None"
                                 },
-                                "id": 85
+                                "id" : 85
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "DefPort": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "name": "Time",
-                                  "params": [],
-                                  "returnType": "None"
+                          "DefPort" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "name" : "Time",
+                                  "params" : [
+                                  ],
+                                  "returnType" : "None"
                                 },
-                                "id": 88
+                                "id" : 88
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ]
                     ]
                   },
-                  "id": 89
+                  "id" : 89
                 }
               }
             }
           },
-          []
+          [
+          ]
         ]
       ]
     }

--- a/tests/queued_component/queued_component_ast.json
+++ b/tests/queued_component/queued_component_ast.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion": "[ fpp version ]",
+  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
   "ast": [
     {
       "members": [

--- a/tests/queued_component/queued_component_locations.json
+++ b/tests/queued_component/queued_component_locations.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion": "[ fpp version ]",
+  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
   "locationMap": {
     "0": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",

--- a/tests/queued_component/queued_component_locations.json
+++ b/tests/queued_component/queued_component_locations.json
@@ -1,455 +1,455 @@
 {
-  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
-  "locationMap": {
-    "0": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
-      "pos": "4.25",
-      "includingLoc": "None"
-    },
-    "1": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
-      "pos": "4.20",
-      "includingLoc": "None"
-    },
-    "2": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
-      "pos": "4.25",
-      "includingLoc": "None"
-    },
-    "3": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
-      "pos": "4.20",
-      "includingLoc": "None"
-    },
-    "4": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
-      "pos": "4.25",
-      "includingLoc": "None"
-    },
-    "5": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
-      "pos": "4.20",
-      "includingLoc": "None"
-    },
-    "6": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
-      "pos": "4.3",
-      "includingLoc": "None"
-    },
-    "7": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
-      "pos": "10.30",
-      "includingLoc": "None"
-    },
-    "8": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
-      "pos": "10.34",
-      "includingLoc": "None"
-    },
-    "9": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
-      "pos": "10.30",
-      "includingLoc": "None"
-    },
-    "10": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
-      "pos": "10.5",
-      "includingLoc": "None"
-    },
-    "11": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
-      "pos": "13.37",
-      "includingLoc": "None"
-    },
-    "12": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
-      "pos": "13.37",
-      "includingLoc": "None"
-    },
-    "13": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
-      "pos": "13.5",
-      "includingLoc": "None"
-    },
-    "14": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
-      "pos": "16.5",
-      "includingLoc": "None"
-    },
-    "15": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
-      "pos": "19.5",
-      "includingLoc": "None"
-    },
-    "16": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
-      "pos": "22.28",
-      "includingLoc": "None"
-    },
-    "17": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
-      "pos": "22.5",
-      "includingLoc": "None"
-    },
-    "18": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
-      "pos": "25.25",
-      "includingLoc": "None"
-    },
-    "19": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
-      "pos": "25.5",
-      "includingLoc": "None"
-    },
-    "20": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
-      "pos": "25.25",
-      "includingLoc": "None"
-    },
-    "21": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
-      "pos": "25.5",
-      "includingLoc": "None"
-    },
-    "22": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
-      "pos": "25.25",
-      "includingLoc": "None"
-    },
-    "23": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
-      "pos": "25.5",
-      "includingLoc": "None"
-    },
-    "24": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
-      "pos": "7.3",
-      "includingLoc": "None"
-    },
-    "25": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
-      "pos": "10.30",
-      "includingLoc": "None"
-    },
-    "26": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
-      "pos": "10.34",
-      "includingLoc": "None"
-    },
-    "27": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
-      "pos": "10.30",
-      "includingLoc": "None"
-    },
-    "28": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
-      "pos": "10.5",
-      "includingLoc": "None"
-    },
-    "29": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
-      "pos": "13.37",
-      "includingLoc": "None"
-    },
-    "30": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
-      "pos": "13.37",
-      "includingLoc": "None"
-    },
-    "31": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
-      "pos": "13.5",
-      "includingLoc": "None"
-    },
-    "32": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
-      "pos": "16.5",
-      "includingLoc": "None"
-    },
-    "33": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
-      "pos": "19.5",
-      "includingLoc": "None"
-    },
-    "34": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
-      "pos": "22.28",
-      "includingLoc": "None"
-    },
-    "35": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
-      "pos": "22.5",
-      "includingLoc": "None"
-    },
-    "36": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
-      "pos": "25.25",
-      "includingLoc": "None"
-    },
-    "37": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
-      "pos": "25.5",
-      "includingLoc": "None"
-    },
-    "38": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
-      "pos": "25.25",
-      "includingLoc": "None"
-    },
-    "39": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
-      "pos": "25.5",
-      "includingLoc": "None"
-    },
-    "40": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
-      "pos": "25.25",
-      "includingLoc": "None"
-    },
-    "41": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
-      "pos": "25.5",
-      "includingLoc": "None"
-    },
-    "42": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
-      "pos": "7.3",
-      "includingLoc": "None"
-    },
-    "43": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
-      "pos": "10.30",
-      "includingLoc": "None"
-    },
-    "44": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
-      "pos": "10.34",
-      "includingLoc": "None"
-    },
-    "45": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
-      "pos": "10.30",
-      "includingLoc": "None"
-    },
-    "46": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
-      "pos": "10.5",
-      "includingLoc": "None"
-    },
-    "47": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
-      "pos": "13.37",
-      "includingLoc": "None"
-    },
-    "48": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
-      "pos": "13.37",
-      "includingLoc": "None"
-    },
-    "49": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
-      "pos": "13.5",
-      "includingLoc": "None"
-    },
-    "50": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
-      "pos": "16.5",
-      "includingLoc": "None"
-    },
-    "51": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
-      "pos": "19.5",
-      "includingLoc": "None"
-    },
-    "52": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
-      "pos": "22.28",
-      "includingLoc": "None"
-    },
-    "53": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
-      "pos": "22.5",
-      "includingLoc": "None"
-    },
-    "54": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
-      "pos": "25.25",
-      "includingLoc": "None"
-    },
-    "55": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
-      "pos": "25.5",
-      "includingLoc": "None"
-    },
-    "56": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
-      "pos": "25.25",
-      "includingLoc": "None"
-    },
-    "57": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
-      "pos": "25.5",
-      "includingLoc": "None"
-    },
-    "58": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
-      "pos": "25.25",
-      "includingLoc": "None"
-    },
-    "59": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
-      "pos": "25.5",
-      "includingLoc": "None"
-    },
-    "60": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
-      "pos": "7.3",
-      "includingLoc": "None"
-    },
-    "61": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
-      "pos": "1.1",
-      "includingLoc": "None"
-    },
-    "62": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
-      "pos": "34.24",
-      "includingLoc": "None"
-    },
-    "63": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
-      "pos": "34.32",
-      "includingLoc": "None"
-    },
-    "64": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
-      "pos": "34.24",
-      "includingLoc": "None"
-    },
-    "65": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
-      "pos": "34.51",
-      "includingLoc": "None"
-    },
-    "66": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
-      "pos": "35.16",
-      "includingLoc": "None"
-    },
-    "67": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
-      "pos": "34.3",
-      "includingLoc": "None"
-    },
-    "68": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
-      "pos": "34.24",
-      "includingLoc": "None"
-    },
-    "69": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
-      "pos": "34.32",
-      "includingLoc": "None"
-    },
-    "70": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
-      "pos": "34.24",
-      "includingLoc": "None"
-    },
-    "71": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
-      "pos": "34.51",
-      "includingLoc": "None"
-    },
-    "72": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
-      "pos": "35.16",
-      "includingLoc": "None"
-    },
-    "73": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
-      "pos": "34.3",
-      "includingLoc": "None"
-    },
-    "74": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
-      "pos": "34.24",
-      "includingLoc": "None"
-    },
-    "75": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
-      "pos": "34.32",
-      "includingLoc": "None"
-    },
-    "76": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
-      "pos": "34.24",
-      "includingLoc": "None"
-    },
-    "77": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
-      "pos": "34.51",
-      "includingLoc": "None"
-    },
-    "78": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
-      "pos": "35.16",
-      "includingLoc": "None"
-    },
-    "79": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
-      "pos": "34.3",
-      "includingLoc": "None"
-    },
-    "80": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
-      "pos": "31.1",
-      "includingLoc": "None"
-    },
-    "81": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
-      "pos": "40.3",
-      "includingLoc": "None"
-    },
-    "82": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
-      "pos": "40.3",
-      "includingLoc": "None"
-    },
-    "83": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
-      "pos": "40.3",
-      "includingLoc": "None"
-    },
-    "84": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
-      "pos": "39.1",
-      "includingLoc": "None"
-    },
-    "85": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
-      "pos": "44.3",
-      "includingLoc": "None"
-    },
-    "86": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
-      "pos": "45.3",
-      "includingLoc": "None"
-    },
-    "87": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
-      "pos": "45.3",
-      "includingLoc": "None"
-    },
-    "88": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
-      "pos": "45.3",
-      "includingLoc": "None"
-    },
-    "89": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
-      "pos": "43.1",
-      "includingLoc": "None"
+  "fppVersion" : "v3.1.0a10-54-g11243e778",
+  "locationMap" : {
+    "0" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
+      "pos" : "4.25",
+      "includingLoc" : "None"
+    },
+    "1" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
+      "pos" : "4.20",
+      "includingLoc" : "None"
+    },
+    "2" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
+      "pos" : "4.25",
+      "includingLoc" : "None"
+    },
+    "3" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
+      "pos" : "4.20",
+      "includingLoc" : "None"
+    },
+    "4" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
+      "pos" : "4.25",
+      "includingLoc" : "None"
+    },
+    "5" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
+      "pos" : "4.20",
+      "includingLoc" : "None"
+    },
+    "6" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
+      "pos" : "4.3",
+      "includingLoc" : "None"
+    },
+    "7" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
+      "pos" : "10.30",
+      "includingLoc" : "None"
+    },
+    "8" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
+      "pos" : "10.34",
+      "includingLoc" : "None"
+    },
+    "9" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
+      "pos" : "10.30",
+      "includingLoc" : "None"
+    },
+    "10" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
+      "pos" : "10.5",
+      "includingLoc" : "None"
+    },
+    "11" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
+      "pos" : "13.37",
+      "includingLoc" : "None"
+    },
+    "12" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
+      "pos" : "13.37",
+      "includingLoc" : "None"
+    },
+    "13" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
+      "pos" : "13.5",
+      "includingLoc" : "None"
+    },
+    "14" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
+      "pos" : "16.5",
+      "includingLoc" : "None"
+    },
+    "15" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
+      "pos" : "19.5",
+      "includingLoc" : "None"
+    },
+    "16" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
+      "pos" : "22.28",
+      "includingLoc" : "None"
+    },
+    "17" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
+      "pos" : "22.5",
+      "includingLoc" : "None"
+    },
+    "18" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
+      "pos" : "25.25",
+      "includingLoc" : "None"
+    },
+    "19" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
+      "pos" : "25.5",
+      "includingLoc" : "None"
+    },
+    "20" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
+      "pos" : "25.25",
+      "includingLoc" : "None"
+    },
+    "21" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
+      "pos" : "25.5",
+      "includingLoc" : "None"
+    },
+    "22" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
+      "pos" : "25.25",
+      "includingLoc" : "None"
+    },
+    "23" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
+      "pos" : "25.5",
+      "includingLoc" : "None"
+    },
+    "24" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
+      "pos" : "7.3",
+      "includingLoc" : "None"
+    },
+    "25" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
+      "pos" : "10.30",
+      "includingLoc" : "None"
+    },
+    "26" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
+      "pos" : "10.34",
+      "includingLoc" : "None"
+    },
+    "27" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
+      "pos" : "10.30",
+      "includingLoc" : "None"
+    },
+    "28" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
+      "pos" : "10.5",
+      "includingLoc" : "None"
+    },
+    "29" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
+      "pos" : "13.37",
+      "includingLoc" : "None"
+    },
+    "30" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
+      "pos" : "13.37",
+      "includingLoc" : "None"
+    },
+    "31" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
+      "pos" : "13.5",
+      "includingLoc" : "None"
+    },
+    "32" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
+      "pos" : "16.5",
+      "includingLoc" : "None"
+    },
+    "33" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
+      "pos" : "19.5",
+      "includingLoc" : "None"
+    },
+    "34" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
+      "pos" : "22.28",
+      "includingLoc" : "None"
+    },
+    "35" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
+      "pos" : "22.5",
+      "includingLoc" : "None"
+    },
+    "36" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
+      "pos" : "25.25",
+      "includingLoc" : "None"
+    },
+    "37" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
+      "pos" : "25.5",
+      "includingLoc" : "None"
+    },
+    "38" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
+      "pos" : "25.25",
+      "includingLoc" : "None"
+    },
+    "39" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
+      "pos" : "25.5",
+      "includingLoc" : "None"
+    },
+    "40" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
+      "pos" : "25.25",
+      "includingLoc" : "None"
+    },
+    "41" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
+      "pos" : "25.5",
+      "includingLoc" : "None"
+    },
+    "42" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
+      "pos" : "7.3",
+      "includingLoc" : "None"
+    },
+    "43" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
+      "pos" : "10.30",
+      "includingLoc" : "None"
+    },
+    "44" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
+      "pos" : "10.34",
+      "includingLoc" : "None"
+    },
+    "45" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
+      "pos" : "10.30",
+      "includingLoc" : "None"
+    },
+    "46" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
+      "pos" : "10.5",
+      "includingLoc" : "None"
+    },
+    "47" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
+      "pos" : "13.37",
+      "includingLoc" : "None"
+    },
+    "48" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
+      "pos" : "13.37",
+      "includingLoc" : "None"
+    },
+    "49" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
+      "pos" : "13.5",
+      "includingLoc" : "None"
+    },
+    "50" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
+      "pos" : "16.5",
+      "includingLoc" : "None"
+    },
+    "51" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
+      "pos" : "19.5",
+      "includingLoc" : "None"
+    },
+    "52" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
+      "pos" : "22.28",
+      "includingLoc" : "None"
+    },
+    "53" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
+      "pos" : "22.5",
+      "includingLoc" : "None"
+    },
+    "54" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
+      "pos" : "25.25",
+      "includingLoc" : "None"
+    },
+    "55" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
+      "pos" : "25.5",
+      "includingLoc" : "None"
+    },
+    "56" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
+      "pos" : "25.25",
+      "includingLoc" : "None"
+    },
+    "57" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
+      "pos" : "25.5",
+      "includingLoc" : "None"
+    },
+    "58" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
+      "pos" : "25.25",
+      "includingLoc" : "None"
+    },
+    "59" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
+      "pos" : "25.5",
+      "includingLoc" : "None"
+    },
+    "60" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
+      "pos" : "7.3",
+      "includingLoc" : "None"
+    },
+    "61" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
+      "pos" : "1.1",
+      "includingLoc" : "None"
+    },
+    "62" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
+      "pos" : "34.24",
+      "includingLoc" : "None"
+    },
+    "63" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
+      "pos" : "34.32",
+      "includingLoc" : "None"
+    },
+    "64" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
+      "pos" : "34.24",
+      "includingLoc" : "None"
+    },
+    "65" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
+      "pos" : "34.51",
+      "includingLoc" : "None"
+    },
+    "66" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
+      "pos" : "35.16",
+      "includingLoc" : "None"
+    },
+    "67" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
+      "pos" : "34.3",
+      "includingLoc" : "None"
+    },
+    "68" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
+      "pos" : "34.24",
+      "includingLoc" : "None"
+    },
+    "69" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
+      "pos" : "34.32",
+      "includingLoc" : "None"
+    },
+    "70" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
+      "pos" : "34.24",
+      "includingLoc" : "None"
+    },
+    "71" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
+      "pos" : "34.51",
+      "includingLoc" : "None"
+    },
+    "72" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
+      "pos" : "35.16",
+      "includingLoc" : "None"
+    },
+    "73" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
+      "pos" : "34.3",
+      "includingLoc" : "None"
+    },
+    "74" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
+      "pos" : "34.24",
+      "includingLoc" : "None"
+    },
+    "75" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
+      "pos" : "34.32",
+      "includingLoc" : "None"
+    },
+    "76" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
+      "pos" : "34.24",
+      "includingLoc" : "None"
+    },
+    "77" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
+      "pos" : "34.51",
+      "includingLoc" : "None"
+    },
+    "78" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
+      "pos" : "35.16",
+      "includingLoc" : "None"
+    },
+    "79" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
+      "pos" : "34.3",
+      "includingLoc" : "None"
+    },
+    "80" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
+      "pos" : "31.1",
+      "includingLoc" : "None"
+    },
+    "81" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
+      "pos" : "40.3",
+      "includingLoc" : "None"
+    },
+    "82" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
+      "pos" : "40.3",
+      "includingLoc" : "None"
+    },
+    "83" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
+      "pos" : "40.3",
+      "includingLoc" : "None"
+    },
+    "84" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
+      "pos" : "39.1",
+      "includingLoc" : "None"
+    },
+    "85" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
+      "pos" : "44.3",
+      "includingLoc" : "None"
+    },
+    "86" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
+      "pos" : "45.3",
+      "includingLoc" : "None"
+    },
+    "87" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
+      "pos" : "45.3",
+      "includingLoc" : "None"
+    },
+    "88" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
+      "pos" : "45.3",
+      "includingLoc" : "None"
+    },
+    "89" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",
+      "pos" : "43.1",
+      "includingLoc" : "None"
     }
   }
 }

--- a/tests/special_ports/special_ports_analysis.json
+++ b/tests/special_ports/special_ports_analysis.json
@@ -1,767 +1,936 @@
 {
-  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
-  "analysis": {
-    "componentInstanceMap": {},
-    "componentMap": {
-      "5": {
-        "aNode": {
-          "astNodeId": 5
+  "fppVersion" : "v3.1.0a10-54-g11243e778",
+  "analysis" : {
+    "componentInstanceMap" : {
+      
+    },
+    "componentMap" : {
+      "5" : {
+        "aNode" : {
+          "astNodeId" : 5
         },
-        "portMap": {
-          "cmdIn": {
-            "Special": {
-              "aNode": {
-                "astNodeId": 0
+        "portMap" : {
+          "cmdIn" : {
+            "Special" : {
+              "aNode" : {
+                "astNodeId" : 0
               },
-              "specifier": {
-                "inputKind": "None",
-                "kind": {
-                  "CommandRecv": {}
+              "specifier" : {
+                "inputKind" : "None",
+                "kind" : {
+                  "CommandRecv" : {
+                    
+                  }
                 },
-                "name": "cmdIn",
-                "priority": "None",
-                "queueFull": "None"
+                "name" : "cmdIn",
+                "priority" : "None",
+                "queueFull" : "None"
               },
-              "symbol": {
-                "Port": {
-                  "nodeId": 24,
-                  "unqualifiedName": "Cmd"
+              "symbol" : {
+                "Port" : {
+                  "nodeId" : 24,
+                  "unqualifiedName" : "Cmd"
                 }
               },
-              "priority": "None",
-              "queueFull": "None",
-              "importNodeIds": []
+              "priority" : "None",
+              "queueFull" : "None",
+              "importNodeIds" : [
+              ]
             }
           },
-          "cmdRegOut": {
-            "Special": {
-              "aNode": {
-                "astNodeId": 1
+          "cmdRegOut" : {
+            "Special" : {
+              "aNode" : {
+                "astNodeId" : 1
               },
-              "specifier": {
-                "inputKind": "None",
-                "kind": {
-                  "CommandReg": {}
+              "specifier" : {
+                "inputKind" : "None",
+                "kind" : {
+                  "CommandReg" : {
+                    
+                  }
                 },
-                "name": "cmdRegOut",
-                "priority": "None",
-                "queueFull": "None"
+                "name" : "cmdRegOut",
+                "priority" : "None",
+                "queueFull" : "None"
               },
-              "symbol": {
-                "Port": {
-                  "nodeId": 25,
-                  "unqualifiedName": "CmdReg"
+              "symbol" : {
+                "Port" : {
+                  "nodeId" : 25,
+                  "unqualifiedName" : "CmdReg"
                 }
               },
-              "priority": "None",
-              "queueFull": "None",
-              "importNodeIds": []
+              "priority" : "None",
+              "queueFull" : "None",
+              "importNodeIds" : [
+              ]
             }
           },
-          "cmdResponseOut": {
-            "Special": {
-              "aNode": {
-                "astNodeId": 4
+          "cmdResponseOut" : {
+            "Special" : {
+              "aNode" : {
+                "astNodeId" : 4
               },
-              "specifier": {
-                "inputKind": "None",
-                "kind": {
-                  "CommandResp": {}
+              "specifier" : {
+                "inputKind" : "None",
+                "kind" : {
+                  "CommandResp" : {
+                    
+                  }
                 },
-                "name": "cmdResponseOut",
-                "priority": "None",
-                "queueFull": "None"
+                "name" : "cmdResponseOut",
+                "priority" : "None",
+                "queueFull" : "None"
               },
-              "symbol": {
-                "Port": {
-                  "nodeId": 26,
-                  "unqualifiedName": "CmdResponse"
+              "symbol" : {
+                "Port" : {
+                  "nodeId" : 26,
+                  "unqualifiedName" : "CmdResponse"
                 }
               },
-              "priority": "None",
-              "queueFull": "None",
-              "importNodeIds": []
+              "priority" : "None",
+              "queueFull" : "None",
+              "importNodeIds" : [
+              ]
             }
           }
         },
-        "specialPortMap": {
-          "command recv": {
-            "aNode": {
-              "astNodeId": 0
+        "specialPortMap" : {
+          "command recv" : {
+            "aNode" : {
+              "astNodeId" : 0
             },
-            "specifier": {
-              "inputKind": "None",
-              "kind": {
-                "CommandRecv": {}
+            "specifier" : {
+              "inputKind" : "None",
+              "kind" : {
+                "CommandRecv" : {
+                  
+                }
               },
-              "name": "cmdIn",
-              "priority": "None",
-              "queueFull": "None"
+              "name" : "cmdIn",
+              "priority" : "None",
+              "queueFull" : "None"
             },
-            "symbol": {
-              "Port": {
-                "nodeId": 24,
-                "unqualifiedName": "Cmd"
+            "symbol" : {
+              "Port" : {
+                "nodeId" : 24,
+                "unqualifiedName" : "Cmd"
               }
             },
-            "priority": "None",
-            "queueFull": "None",
-            "importNodeIds": []
+            "priority" : "None",
+            "queueFull" : "None",
+            "importNodeIds" : [
+            ]
           },
-          "command reg": {
-            "aNode": {
-              "astNodeId": 1
+          "command reg" : {
+            "aNode" : {
+              "astNodeId" : 1
             },
-            "specifier": {
-              "inputKind": "None",
-              "kind": {
-                "CommandReg": {}
+            "specifier" : {
+              "inputKind" : "None",
+              "kind" : {
+                "CommandReg" : {
+                  
+                }
               },
-              "name": "cmdRegOut",
-              "priority": "None",
-              "queueFull": "None"
+              "name" : "cmdRegOut",
+              "priority" : "None",
+              "queueFull" : "None"
             },
-            "symbol": {
-              "Port": {
-                "nodeId": 25,
-                "unqualifiedName": "CmdReg"
+            "symbol" : {
+              "Port" : {
+                "nodeId" : 25,
+                "unqualifiedName" : "CmdReg"
               }
             },
-            "priority": "None",
-            "queueFull": "None",
-            "importNodeIds": []
+            "priority" : "None",
+            "queueFull" : "None",
+            "importNodeIds" : [
+            ]
           },
-          "command resp": {
-            "aNode": {
-              "astNodeId": 4
+          "command resp" : {
+            "aNode" : {
+              "astNodeId" : 4
             },
-            "specifier": {
-              "inputKind": "None",
-              "kind": {
-                "CommandResp": {}
+            "specifier" : {
+              "inputKind" : "None",
+              "kind" : {
+                "CommandResp" : {
+                  
+                }
               },
-              "name": "cmdResponseOut",
-              "priority": "None",
-              "queueFull": "None"
+              "name" : "cmdResponseOut",
+              "priority" : "None",
+              "queueFull" : "None"
             },
-            "symbol": {
-              "Port": {
-                "nodeId": 26,
-                "unqualifiedName": "CmdResponse"
+            "symbol" : {
+              "Port" : {
+                "nodeId" : 26,
+                "unqualifiedName" : "CmdResponse"
               }
             },
-            "priority": "None",
-            "queueFull": "None",
-            "importNodeIds": []
+            "priority" : "None",
+            "queueFull" : "None",
+            "importNodeIds" : [
+            ]
           }
         },
-        "commandMap": {},
-        "defaultOpcode": 0,
-        "tlmChannelMap": {},
-        "tlmChannelNameMap": {},
-        "defaultTlmChannelId": 0,
-        "eventMap": {},
-        "defaultEventId": 0,
-        "paramMap": {},
-        "specPortMatchingList": [],
-        "stateMachineInstanceMap": {},
-        "portMatchingList": [],
-        "defaultParamId": 0,
-        "containerMap": {},
-        "defaultContainerId": 0,
-        "recordMap": {},
-        "defaultRecordId": 0
+        "commandMap" : {
+          
+        },
+        "defaultOpcode" : 0,
+        "tlmChannelMap" : {
+          
+        },
+        "tlmChannelNameMap" : {
+          
+        },
+        "defaultTlmChannelId" : 0,
+        "eventMap" : {
+          
+        },
+        "defaultEventId" : 0,
+        "paramMap" : {
+          
+        },
+        "specPortMatchingList" : [
+        ],
+        "stateMachineInstanceMap" : {
+          
+        },
+        "portMatchingList" : [
+        ],
+        "defaultParamId" : 0,
+        "containerMap" : {
+          
+        },
+        "defaultContainerId" : 0,
+        "recordMap" : {
+          
+        },
+        "defaultRecordId" : 0
       },
-      "10": {
-        "aNode": {
-          "astNodeId": 10
+      "10" : {
+        "aNode" : {
+          "astNodeId" : 10
         },
-        "portMap": {
-          "eventOut": {
-            "Special": {
-              "aNode": {
-                "astNodeId": 6
+        "portMap" : {
+          "eventOut" : {
+            "Special" : {
+              "aNode" : {
+                "astNodeId" : 6
               },
-              "specifier": {
-                "inputKind": "None",
-                "kind": {
-                  "Event": {}
+              "specifier" : {
+                "inputKind" : "None",
+                "kind" : {
+                  "Event" : {
+                    
+                  }
                 },
-                "name": "eventOut",
-                "priority": "None",
-                "queueFull": "None"
+                "name" : "eventOut",
+                "priority" : "None",
+                "queueFull" : "None"
               },
-              "symbol": {
-                "Port": {
-                  "nodeId": 27,
-                  "unqualifiedName": "Log"
+              "symbol" : {
+                "Port" : {
+                  "nodeId" : 27,
+                  "unqualifiedName" : "Log"
                 }
               },
-              "priority": "None",
-              "queueFull": "None",
-              "importNodeIds": []
+              "priority" : "None",
+              "queueFull" : "None",
+              "importNodeIds" : [
+              ]
             }
           },
-          "textEventOut": {
-            "Special": {
-              "aNode": {
-                "astNodeId": 9
+          "textEventOut" : {
+            "Special" : {
+              "aNode" : {
+                "astNodeId" : 9
               },
-              "specifier": {
-                "inputKind": "None",
-                "kind": {
-                  "TextEvent": {}
+              "specifier" : {
+                "inputKind" : "None",
+                "kind" : {
+                  "TextEvent" : {
+                    
+                  }
                 },
-                "name": "textEventOut",
-                "priority": "None",
-                "queueFull": "None"
+                "name" : "textEventOut",
+                "priority" : "None",
+                "queueFull" : "None"
               },
-              "symbol": {
-                "Port": {
-                  "nodeId": 28,
-                  "unqualifiedName": "LogText"
+              "symbol" : {
+                "Port" : {
+                  "nodeId" : 28,
+                  "unqualifiedName" : "LogText"
                 }
               },
-              "priority": "None",
-              "queueFull": "None",
-              "importNodeIds": []
+              "priority" : "None",
+              "queueFull" : "None",
+              "importNodeIds" : [
+              ]
             }
           }
         },
-        "specialPortMap": {
-          "event": {
-            "aNode": {
-              "astNodeId": 6
+        "specialPortMap" : {
+          "event" : {
+            "aNode" : {
+              "astNodeId" : 6
             },
-            "specifier": {
-              "inputKind": "None",
-              "kind": {
-                "Event": {}
+            "specifier" : {
+              "inputKind" : "None",
+              "kind" : {
+                "Event" : {
+                  
+                }
               },
-              "name": "eventOut",
-              "priority": "None",
-              "queueFull": "None"
+              "name" : "eventOut",
+              "priority" : "None",
+              "queueFull" : "None"
             },
-            "symbol": {
-              "Port": {
-                "nodeId": 27,
-                "unqualifiedName": "Log"
+            "symbol" : {
+              "Port" : {
+                "nodeId" : 27,
+                "unqualifiedName" : "Log"
               }
             },
-            "priority": "None",
-            "queueFull": "None",
-            "importNodeIds": []
+            "priority" : "None",
+            "queueFull" : "None",
+            "importNodeIds" : [
+            ]
           },
-          "text event": {
-            "aNode": {
-              "astNodeId": 9
+          "text event" : {
+            "aNode" : {
+              "astNodeId" : 9
             },
-            "specifier": {
-              "inputKind": "None",
-              "kind": {
-                "TextEvent": {}
+            "specifier" : {
+              "inputKind" : "None",
+              "kind" : {
+                "TextEvent" : {
+                  
+                }
               },
-              "name": "textEventOut",
-              "priority": "None",
-              "queueFull": "None"
+              "name" : "textEventOut",
+              "priority" : "None",
+              "queueFull" : "None"
             },
-            "symbol": {
-              "Port": {
-                "nodeId": 28,
-                "unqualifiedName": "LogText"
+            "symbol" : {
+              "Port" : {
+                "nodeId" : 28,
+                "unqualifiedName" : "LogText"
               }
             },
-            "priority": "None",
-            "queueFull": "None",
-            "importNodeIds": []
+            "priority" : "None",
+            "queueFull" : "None",
+            "importNodeIds" : [
+            ]
           }
         },
-        "commandMap": {},
-        "defaultOpcode": 0,
-        "tlmChannelMap": {},
-        "tlmChannelNameMap": {},
-        "defaultTlmChannelId": 0,
-        "eventMap": {},
-        "defaultEventId": 0,
-        "paramMap": {},
-        "specPortMatchingList": [],
-        "stateMachineInstanceMap": {},
-        "portMatchingList": [],
-        "defaultParamId": 0,
-        "containerMap": {},
-        "defaultContainerId": 0,
-        "recordMap": {},
-        "defaultRecordId": 0
+        "commandMap" : {
+          
+        },
+        "defaultOpcode" : 0,
+        "tlmChannelMap" : {
+          
+        },
+        "tlmChannelNameMap" : {
+          
+        },
+        "defaultTlmChannelId" : 0,
+        "eventMap" : {
+          
+        },
+        "defaultEventId" : 0,
+        "paramMap" : {
+          
+        },
+        "specPortMatchingList" : [
+        ],
+        "stateMachineInstanceMap" : {
+          
+        },
+        "portMatchingList" : [
+        ],
+        "defaultParamId" : 0,
+        "containerMap" : {
+          
+        },
+        "defaultContainerId" : 0,
+        "recordMap" : {
+          
+        },
+        "defaultRecordId" : 0
       },
-      "14": {
-        "aNode": {
-          "astNodeId": 14
+      "14" : {
+        "aNode" : {
+          "astNodeId" : 14
         },
-        "portMap": {
-          "tlmOut": {
-            "Special": {
-              "aNode": {
-                "astNodeId": 13
+        "portMap" : {
+          "tlmOut" : {
+            "Special" : {
+              "aNode" : {
+                "astNodeId" : 13
               },
-              "specifier": {
-                "inputKind": "None",
-                "kind": {
-                  "Telemetry": {}
+              "specifier" : {
+                "inputKind" : "None",
+                "kind" : {
+                  "Telemetry" : {
+                    
+                  }
                 },
-                "name": "tlmOut",
-                "priority": "None",
-                "queueFull": "None"
+                "name" : "tlmOut",
+                "priority" : "None",
+                "queueFull" : "None"
               },
-              "symbol": {
-                "Port": {
-                  "nodeId": 29,
-                  "unqualifiedName": "Tlm"
+              "symbol" : {
+                "Port" : {
+                  "nodeId" : 29,
+                  "unqualifiedName" : "Tlm"
                 }
               },
-              "priority": "None",
-              "queueFull": "None",
-              "importNodeIds": []
+              "priority" : "None",
+              "queueFull" : "None",
+              "importNodeIds" : [
+              ]
             }
           }
         },
-        "specialPortMap": {
-          "telemetry": {
-            "aNode": {
-              "astNodeId": 13
+        "specialPortMap" : {
+          "telemetry" : {
+            "aNode" : {
+              "astNodeId" : 13
             },
-            "specifier": {
-              "inputKind": "None",
-              "kind": {
-                "Telemetry": {}
-              },
-              "name": "tlmOut",
-              "priority": "None",
-              "queueFull": "None"
-            },
-            "symbol": {
-              "Port": {
-                "nodeId": 29,
-                "unqualifiedName": "Tlm"
-              }
-            },
-            "priority": "None",
-            "queueFull": "None",
-            "importNodeIds": []
-          }
-        },
-        "commandMap": {},
-        "defaultOpcode": 0,
-        "tlmChannelMap": {},
-        "tlmChannelNameMap": {},
-        "defaultTlmChannelId": 0,
-        "eventMap": {},
-        "defaultEventId": 0,
-        "paramMap": {},
-        "specPortMatchingList": [],
-        "stateMachineInstanceMap": {},
-        "portMatchingList": [],
-        "defaultParamId": 0,
-        "containerMap": {},
-        "defaultContainerId": 0,
-        "recordMap": {},
-        "defaultRecordId": 0
-      },
-      "19": {
-        "aNode": {
-          "astNodeId": 19
-        },
-        "portMap": {
-          "prmGetOut": {
-            "Special": {
-              "aNode": {
-                "astNodeId": 15
-              },
-              "specifier": {
-                "inputKind": "None",
-                "kind": {
-                  "ParamGet": {}
-                },
-                "name": "prmGetOut",
-                "priority": "None",
-                "queueFull": "None"
-              },
-              "symbol": {
-                "Port": {
-                  "nodeId": 30,
-                  "unqualifiedName": "PrmGet"
+            "specifier" : {
+              "inputKind" : "None",
+              "kind" : {
+                "Telemetry" : {
+                  
                 }
               },
-              "priority": "None",
-              "queueFull": "None",
-              "importNodeIds": []
+              "name" : "tlmOut",
+              "priority" : "None",
+              "queueFull" : "None"
+            },
+            "symbol" : {
+              "Port" : {
+                "nodeId" : 29,
+                "unqualifiedName" : "Tlm"
+              }
+            },
+            "priority" : "None",
+            "queueFull" : "None",
+            "importNodeIds" : [
+            ]
+          }
+        },
+        "commandMap" : {
+          
+        },
+        "defaultOpcode" : 0,
+        "tlmChannelMap" : {
+          
+        },
+        "tlmChannelNameMap" : {
+          
+        },
+        "defaultTlmChannelId" : 0,
+        "eventMap" : {
+          
+        },
+        "defaultEventId" : 0,
+        "paramMap" : {
+          
+        },
+        "specPortMatchingList" : [
+        ],
+        "stateMachineInstanceMap" : {
+          
+        },
+        "portMatchingList" : [
+        ],
+        "defaultParamId" : 0,
+        "containerMap" : {
+          
+        },
+        "defaultContainerId" : 0,
+        "recordMap" : {
+          
+        },
+        "defaultRecordId" : 0
+      },
+      "19" : {
+        "aNode" : {
+          "astNodeId" : 19
+        },
+        "portMap" : {
+          "prmGetOut" : {
+            "Special" : {
+              "aNode" : {
+                "astNodeId" : 15
+              },
+              "specifier" : {
+                "inputKind" : "None",
+                "kind" : {
+                  "ParamGet" : {
+                    
+                  }
+                },
+                "name" : "prmGetOut",
+                "priority" : "None",
+                "queueFull" : "None"
+              },
+              "symbol" : {
+                "Port" : {
+                  "nodeId" : 30,
+                  "unqualifiedName" : "PrmGet"
+                }
+              },
+              "priority" : "None",
+              "queueFull" : "None",
+              "importNodeIds" : [
+              ]
             }
           },
-          "prmSetOut": {
-            "Special": {
-              "aNode": {
-                "astNodeId": 18
+          "prmSetOut" : {
+            "Special" : {
+              "aNode" : {
+                "astNodeId" : 18
               },
-              "specifier": {
-                "inputKind": "None",
-                "kind": {
-                  "ParamSet": {}
+              "specifier" : {
+                "inputKind" : "None",
+                "kind" : {
+                  "ParamSet" : {
+                    
+                  }
                 },
-                "name": "prmSetOut",
-                "priority": "None",
-                "queueFull": "None"
+                "name" : "prmSetOut",
+                "priority" : "None",
+                "queueFull" : "None"
               },
-              "symbol": {
-                "Port": {
-                  "nodeId": 31,
-                  "unqualifiedName": "PrmSet"
+              "symbol" : {
+                "Port" : {
+                  "nodeId" : 31,
+                  "unqualifiedName" : "PrmSet"
                 }
               },
-              "priority": "None",
-              "queueFull": "None",
-              "importNodeIds": []
+              "priority" : "None",
+              "queueFull" : "None",
+              "importNodeIds" : [
+              ]
             }
           }
         },
-        "specialPortMap": {
-          "param get": {
-            "aNode": {
-              "astNodeId": 15
+        "specialPortMap" : {
+          "param get" : {
+            "aNode" : {
+              "astNodeId" : 15
             },
-            "specifier": {
-              "inputKind": "None",
-              "kind": {
-                "ParamGet": {}
+            "specifier" : {
+              "inputKind" : "None",
+              "kind" : {
+                "ParamGet" : {
+                  
+                }
               },
-              "name": "prmGetOut",
-              "priority": "None",
-              "queueFull": "None"
+              "name" : "prmGetOut",
+              "priority" : "None",
+              "queueFull" : "None"
             },
-            "symbol": {
-              "Port": {
-                "nodeId": 30,
-                "unqualifiedName": "PrmGet"
+            "symbol" : {
+              "Port" : {
+                "nodeId" : 30,
+                "unqualifiedName" : "PrmGet"
               }
             },
-            "priority": "None",
-            "queueFull": "None",
-            "importNodeIds": []
+            "priority" : "None",
+            "queueFull" : "None",
+            "importNodeIds" : [
+            ]
           },
-          "param set": {
-            "aNode": {
-              "astNodeId": 18
+          "param set" : {
+            "aNode" : {
+              "astNodeId" : 18
             },
-            "specifier": {
-              "inputKind": "None",
-              "kind": {
-                "ParamSet": {}
-              },
-              "name": "prmSetOut",
-              "priority": "None",
-              "queueFull": "None"
-            },
-            "symbol": {
-              "Port": {
-                "nodeId": 31,
-                "unqualifiedName": "PrmSet"
-              }
-            },
-            "priority": "None",
-            "queueFull": "None",
-            "importNodeIds": []
-          }
-        },
-        "commandMap": {},
-        "defaultOpcode": 0,
-        "tlmChannelMap": {},
-        "tlmChannelNameMap": {},
-        "defaultTlmChannelId": 0,
-        "eventMap": {},
-        "defaultEventId": 0,
-        "paramMap": {},
-        "specPortMatchingList": [],
-        "stateMachineInstanceMap": {},
-        "portMatchingList": [],
-        "defaultParamId": 0,
-        "containerMap": {},
-        "defaultContainerId": 0,
-        "recordMap": {},
-        "defaultRecordId": 0
-      },
-      "23": {
-        "aNode": {
-          "astNodeId": 23
-        },
-        "portMap": {
-          "timeGetOut": {
-            "Special": {
-              "aNode": {
-                "astNodeId": 22
-              },
-              "specifier": {
-                "inputKind": "None",
-                "kind": {
-                  "TimeGet": {}
-                },
-                "name": "timeGetOut",
-                "priority": "None",
-                "queueFull": "None"
-              },
-              "symbol": {
-                "Port": {
-                  "nodeId": 34,
-                  "unqualifiedName": "Time"
+            "specifier" : {
+              "inputKind" : "None",
+              "kind" : {
+                "ParamSet" : {
+                  
                 }
               },
-              "priority": "None",
-              "queueFull": "None",
-              "importNodeIds": []
+              "name" : "prmSetOut",
+              "priority" : "None",
+              "queueFull" : "None"
+            },
+            "symbol" : {
+              "Port" : {
+                "nodeId" : 31,
+                "unqualifiedName" : "PrmSet"
+              }
+            },
+            "priority" : "None",
+            "queueFull" : "None",
+            "importNodeIds" : [
+            ]
+          }
+        },
+        "commandMap" : {
+          
+        },
+        "defaultOpcode" : 0,
+        "tlmChannelMap" : {
+          
+        },
+        "tlmChannelNameMap" : {
+          
+        },
+        "defaultTlmChannelId" : 0,
+        "eventMap" : {
+          
+        },
+        "defaultEventId" : 0,
+        "paramMap" : {
+          
+        },
+        "specPortMatchingList" : [
+        ],
+        "stateMachineInstanceMap" : {
+          
+        },
+        "portMatchingList" : [
+        ],
+        "defaultParamId" : 0,
+        "containerMap" : {
+          
+        },
+        "defaultContainerId" : 0,
+        "recordMap" : {
+          
+        },
+        "defaultRecordId" : 0
+      },
+      "23" : {
+        "aNode" : {
+          "astNodeId" : 23
+        },
+        "portMap" : {
+          "timeGetOut" : {
+            "Special" : {
+              "aNode" : {
+                "astNodeId" : 22
+              },
+              "specifier" : {
+                "inputKind" : "None",
+                "kind" : {
+                  "TimeGet" : {
+                    
+                  }
+                },
+                "name" : "timeGetOut",
+                "priority" : "None",
+                "queueFull" : "None"
+              },
+              "symbol" : {
+                "Port" : {
+                  "nodeId" : 34,
+                  "unqualifiedName" : "Time"
+                }
+              },
+              "priority" : "None",
+              "queueFull" : "None",
+              "importNodeIds" : [
+              ]
             }
           }
         },
-        "specialPortMap": {
-          "time get": {
-            "aNode": {
-              "astNodeId": 22
+        "specialPortMap" : {
+          "time get" : {
+            "aNode" : {
+              "astNodeId" : 22
             },
-            "specifier": {
-              "inputKind": "None",
-              "kind": {
-                "TimeGet": {}
+            "specifier" : {
+              "inputKind" : "None",
+              "kind" : {
+                "TimeGet" : {
+                  
+                }
               },
-              "name": "timeGetOut",
-              "priority": "None",
-              "queueFull": "None"
+              "name" : "timeGetOut",
+              "priority" : "None",
+              "queueFull" : "None"
             },
-            "symbol": {
-              "Port": {
-                "nodeId": 34,
-                "unqualifiedName": "Time"
+            "symbol" : {
+              "Port" : {
+                "nodeId" : 34,
+                "unqualifiedName" : "Time"
               }
             },
-            "priority": "None",
-            "queueFull": "None",
-            "importNodeIds": []
+            "priority" : "None",
+            "queueFull" : "None",
+            "importNodeIds" : [
+            ]
           }
         },
-        "commandMap": {},
-        "defaultOpcode": 0,
-        "tlmChannelMap": {},
-        "tlmChannelNameMap": {},
-        "defaultTlmChannelId": 0,
-        "eventMap": {},
-        "defaultEventId": 0,
-        "paramMap": {},
-        "specPortMatchingList": [],
-        "stateMachineInstanceMap": {},
-        "portMatchingList": [],
-        "defaultParamId": 0,
-        "containerMap": {},
-        "defaultContainerId": 0,
-        "recordMap": {},
-        "defaultRecordId": 0
+        "commandMap" : {
+          
+        },
+        "defaultOpcode" : 0,
+        "tlmChannelMap" : {
+          
+        },
+        "tlmChannelNameMap" : {
+          
+        },
+        "defaultTlmChannelId" : 0,
+        "eventMap" : {
+          
+        },
+        "defaultEventId" : 0,
+        "paramMap" : {
+          
+        },
+        "specPortMatchingList" : [
+        ],
+        "stateMachineInstanceMap" : {
+          
+        },
+        "portMatchingList" : [
+        ],
+        "defaultParamId" : 0,
+        "containerMap" : {
+          
+        },
+        "defaultContainerId" : 0,
+        "recordMap" : {
+          
+        },
+        "defaultRecordId" : 0
       }
     },
-    "includedFileSet": [],
-    "inputFileSet": [
+    "includedFileSet" : [
+    ],
+    "inputFileSet" : [
       "[ local path prefix ]/compiler/tools/fpp-to-json/test/specialPorts.fpp"
     ],
-    "locationSpecifierMap": [],
-    "parentSymbolMap": {
-      "34": {
-        "Module": {
-          "nodeId": 35,
-          "unqualifiedName": "Fw"
+    "locationSpecifierMap" : [
+    ],
+    "parentSymbolMap" : {
+      "34" : {
+        "Module" : {
+          "nodeId" : 35,
+          "unqualifiedName" : "Fw"
         }
       },
-      "26": {
-        "Module": {
-          "nodeId": 35,
-          "unqualifiedName": "Fw"
+      "26" : {
+        "Module" : {
+          "nodeId" : 35,
+          "unqualifiedName" : "Fw"
         }
       },
-      "24": {
-        "Module": {
-          "nodeId": 35,
-          "unqualifiedName": "Fw"
+      "24" : {
+        "Module" : {
+          "nodeId" : 35,
+          "unqualifiedName" : "Fw"
         }
       },
-      "25": {
-        "Module": {
-          "nodeId": 35,
-          "unqualifiedName": "Fw"
+      "25" : {
+        "Module" : {
+          "nodeId" : 35,
+          "unqualifiedName" : "Fw"
         }
       },
-      "31": {
-        "Module": {
-          "nodeId": 35,
-          "unqualifiedName": "Fw"
+      "31" : {
+        "Module" : {
+          "nodeId" : 35,
+          "unqualifiedName" : "Fw"
         }
       },
-      "27": {
-        "Module": {
-          "nodeId": 35,
-          "unqualifiedName": "Fw"
+      "27" : {
+        "Module" : {
+          "nodeId" : 35,
+          "unqualifiedName" : "Fw"
         }
       },
-      "30": {
-        "Module": {
-          "nodeId": 35,
-          "unqualifiedName": "Fw"
+      "30" : {
+        "Module" : {
+          "nodeId" : 35,
+          "unqualifiedName" : "Fw"
         }
       },
-      "29": {
-        "Module": {
-          "nodeId": 35,
-          "unqualifiedName": "Fw"
+      "29" : {
+        "Module" : {
+          "nodeId" : 35,
+          "unqualifiedName" : "Fw"
         }
       },
-      "28": {
-        "Module": {
-          "nodeId": 35,
-          "unqualifiedName": "Fw"
+      "28" : {
+        "Module" : {
+          "nodeId" : 35,
+          "unqualifiedName" : "Fw"
         }
       }
     },
-    "symbolScopeMap": {
-      "35": {
-        "map": {
-          "Port": {
-            "map": {
-              "CmdReg": {
-                "Port": {
-                  "nodeId": 25,
-                  "unqualifiedName": "CmdReg"
+    "symbolScopeMap" : {
+      "35" : {
+        "map" : {
+          "Port" : {
+            "map" : {
+              "CmdReg" : {
+                "Port" : {
+                  "nodeId" : 25,
+                  "unqualifiedName" : "CmdReg"
                 }
               },
-              "Tlm": {
-                "Port": {
-                  "nodeId": 29,
-                  "unqualifiedName": "Tlm"
+              "Tlm" : {
+                "Port" : {
+                  "nodeId" : 29,
+                  "unqualifiedName" : "Tlm"
                 }
               },
-              "PrmGet": {
-                "Port": {
-                  "nodeId": 30,
-                  "unqualifiedName": "PrmGet"
+              "PrmGet" : {
+                "Port" : {
+                  "nodeId" : 30,
+                  "unqualifiedName" : "PrmGet"
                 }
               },
-              "PrmSet": {
-                "Port": {
-                  "nodeId": 31,
-                  "unqualifiedName": "PrmSet"
+              "PrmSet" : {
+                "Port" : {
+                  "nodeId" : 31,
+                  "unqualifiedName" : "PrmSet"
                 }
               },
-              "LogText": {
-                "Port": {
-                  "nodeId": 28,
-                  "unqualifiedName": "LogText"
+              "LogText" : {
+                "Port" : {
+                  "nodeId" : 28,
+                  "unqualifiedName" : "LogText"
                 }
               },
-              "Cmd": {
-                "Port": {
-                  "nodeId": 24,
-                  "unqualifiedName": "Cmd"
+              "Cmd" : {
+                "Port" : {
+                  "nodeId" : 24,
+                  "unqualifiedName" : "Cmd"
                 }
               },
-              "Log": {
-                "Port": {
-                  "nodeId": 27,
-                  "unqualifiedName": "Log"
+              "Log" : {
+                "Port" : {
+                  "nodeId" : 27,
+                  "unqualifiedName" : "Log"
                 }
               },
-              "CmdResponse": {
-                "Port": {
-                  "nodeId": 26,
-                  "unqualifiedName": "CmdResponse"
+              "CmdResponse" : {
+                "Port" : {
+                  "nodeId" : 26,
+                  "unqualifiedName" : "CmdResponse"
                 }
               },
-              "Time": {
-                "Port": {
-                  "nodeId": 34,
-                  "unqualifiedName": "Time"
+              "Time" : {
+                "Port" : {
+                  "nodeId" : 34,
+                  "unqualifiedName" : "Time"
                 }
               }
             }
           }
         }
       },
-      "5": {
-        "map": {}
-      },
-      "10": {
-        "map": {}
-      },
-      "14": {
-        "map": {}
-      },
-      "19": {
-        "map": {}
-      },
-      "23": {
-        "map": {}
-      }
-    },
-    "topologyMap": {},
-    "typeMap": {},
-    "useDefMap": {
-      "4": {
-        "Port": {
-          "nodeId": 26,
-          "unqualifiedName": "CmdResponse"
+      "5" : {
+        "map" : {
+          
         }
       },
-      "22": {
-        "Port": {
-          "nodeId": 34,
-          "unqualifiedName": "Time"
+      "10" : {
+        "map" : {
+          
         }
       },
-      "13": {
-        "Port": {
-          "nodeId": 29,
-          "unqualifiedName": "Tlm"
+      "14" : {
+        "map" : {
+          
         }
       },
-      "0": {
-        "Port": {
-          "nodeId": 24,
-          "unqualifiedName": "Cmd"
+      "19" : {
+        "map" : {
+          
         }
       },
-      "18": {
-        "Port": {
-          "nodeId": 31,
-          "unqualifiedName": "PrmSet"
-        }
-      },
-      "15": {
-        "Port": {
-          "nodeId": 30,
-          "unqualifiedName": "PrmGet"
-        }
-      },
-      "9": {
-        "Port": {
-          "nodeId": 28,
-          "unqualifiedName": "LogText"
-        }
-      },
-      "6": {
-        "Port": {
-          "nodeId": 27,
-          "unqualifiedName": "Log"
-        }
-      },
-      "1": {
-        "Port": {
-          "nodeId": 25,
-          "unqualifiedName": "CmdReg"
+      "23" : {
+        "map" : {
+          
         }
       }
     },
-    "valueMap": {},
-    "stateMachineMap": {},
-    "dictionarySymbolSet": [],
-    "interfaceMap": {}
+    "topologyMap" : {
+      
+    },
+    "typeMap" : {
+      
+    },
+    "useDefMap" : {
+      "4" : {
+        "Port" : {
+          "nodeId" : 26,
+          "unqualifiedName" : "CmdResponse"
+        }
+      },
+      "22" : {
+        "Port" : {
+          "nodeId" : 34,
+          "unqualifiedName" : "Time"
+        }
+      },
+      "13" : {
+        "Port" : {
+          "nodeId" : 29,
+          "unqualifiedName" : "Tlm"
+        }
+      },
+      "0" : {
+        "Port" : {
+          "nodeId" : 24,
+          "unqualifiedName" : "Cmd"
+        }
+      },
+      "18" : {
+        "Port" : {
+          "nodeId" : 31,
+          "unqualifiedName" : "PrmSet"
+        }
+      },
+      "15" : {
+        "Port" : {
+          "nodeId" : 30,
+          "unqualifiedName" : "PrmGet"
+        }
+      },
+      "9" : {
+        "Port" : {
+          "nodeId" : 28,
+          "unqualifiedName" : "LogText"
+        }
+      },
+      "6" : {
+        "Port" : {
+          "nodeId" : 27,
+          "unqualifiedName" : "Log"
+        }
+      },
+      "1" : {
+        "Port" : {
+          "nodeId" : 25,
+          "unqualifiedName" : "CmdReg"
+        }
+      }
+    },
+    "valueMap" : {
+      
+    },
+    "stateMachineMap" : {
+      
+    },
+    "dictionarySymbolSet" : [
+    ],
+    "interfaceMap" : {
+      
+    }
   }
 }

--- a/tests/special_ports/special_ports_analysis.json
+++ b/tests/special_ports/special_ports_analysis.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion": "[ fpp version ]",
+  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
   "analysis": {
     "componentInstanceMap": {},
     "componentMap": {

--- a/tests/special_ports/special_ports_ast.json
+++ b/tests/special_ports/special_ports_ast.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion": "[ fpp version ]",
+  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
   "ast": [
     {
       "members": [

--- a/tests/special_ports/special_ports_ast.json
+++ b/tests/special_ports/special_ports_ast.json
@@ -1,508 +1,607 @@
 {
-  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
-  "ast": [
+  "fppVersion" : "v3.1.0a10-54-g11243e778",
+  "ast" : [
     {
-      "members": [
+      "members" : [
         [
-          ["A component for illustrating command ports"],
+          [
+            "A component for illustrating command ports"
+          ],
           {
-            "DefComponent": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "kind": {
-                      "Passive": {}
+            "DefComponent" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "kind" : {
+                      "Passive" : {
+                        
+                      }
                     },
-                    "name": "CommandPorts",
-                    "members": [
+                    "name" : "CommandPorts",
+                    "members" : [
                       [
-                        ["A port for receiving commands"],
+                        [
+                          "A port for receiving commands"
+                        ],
                         {
-                          "SpecPortInstance": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "Special": {
-                                    "inputKind": "None",
-                                    "kind": {
-                                      "CommandRecv": {}
+                          "SpecPortInstance" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "Special" : {
+                                    "inputKind" : "None",
+                                    "kind" : {
+                                      "CommandRecv" : {
+                                        
+                                      }
                                     },
-                                    "name": "cmdIn",
-                                    "priority": "None",
-                                    "queueFull": "None"
+                                    "name" : "cmdIn",
+                                    "priority" : "None",
+                                    "queueFull" : "None"
                                   }
                                 },
-                                "id": 0
+                                "id" : 0
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        ["A port for sending command registration requests"],
+                        [
+                          "A port for sending command registration requests"
+                        ],
                         {
-                          "SpecPortInstance": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "Special": {
-                                    "inputKind": "None",
-                                    "kind": {
-                                      "CommandReg": {}
+                          "SpecPortInstance" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "Special" : {
+                                    "inputKind" : "None",
+                                    "kind" : {
+                                      "CommandReg" : {
+                                        
+                                      }
                                     },
-                                    "name": "cmdRegOut",
-                                    "priority": "None",
-                                    "queueFull": "None"
+                                    "name" : "cmdRegOut",
+                                    "priority" : "None",
+                                    "queueFull" : "None"
                                   }
                                 },
-                                "id": 1
+                                "id" : 1
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        ["A port for sending command responses"],
+                        [
+                          "A port for sending command responses"
+                        ],
                         {
-                          "SpecPortInstance": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "Special": {
-                                    "inputKind": "None",
-                                    "kind": {
-                                      "CommandResp": {}
+                          "SpecPortInstance" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "Special" : {
+                                    "inputKind" : "None",
+                                    "kind" : {
+                                      "CommandResp" : {
+                                        
+                                      }
                                     },
-                                    "name": "cmdResponseOut",
-                                    "priority": "None",
-                                    "queueFull": "None"
+                                    "name" : "cmdResponseOut",
+                                    "priority" : "None",
+                                    "queueFull" : "None"
                                   }
                                 },
-                                "id": 4
+                                "id" : 4
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ]
                     ]
                   },
-                  "id": 5
+                  "id" : 5
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          ["A component for illustrating event ports"],
+          [
+            "A component for illustrating event ports"
+          ],
           {
-            "DefComponent": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "kind": {
-                      "Passive": {}
+            "DefComponent" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "kind" : {
+                      "Passive" : {
+                        
+                      }
                     },
-                    "name": "EventPorts",
-                    "members": [
+                    "name" : "EventPorts",
+                    "members" : [
                       [
-                        ["A port for emitting events"],
+                        [
+                          "A port for emitting events"
+                        ],
                         {
-                          "SpecPortInstance": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "Special": {
-                                    "inputKind": "None",
-                                    "kind": {
-                                      "Event": {}
+                          "SpecPortInstance" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "Special" : {
+                                    "inputKind" : "None",
+                                    "kind" : {
+                                      "Event" : {
+                                        
+                                      }
                                     },
-                                    "name": "eventOut",
-                                    "priority": "None",
-                                    "queueFull": "None"
+                                    "name" : "eventOut",
+                                    "priority" : "None",
+                                    "queueFull" : "None"
                                   }
                                 },
-                                "id": 6
+                                "id" : 6
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        ["A port for emitting text events"],
+                        [
+                          "A port for emitting text events"
+                        ],
                         {
-                          "SpecPortInstance": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "Special": {
-                                    "inputKind": "None",
-                                    "kind": {
-                                      "TextEvent": {}
+                          "SpecPortInstance" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "Special" : {
+                                    "inputKind" : "None",
+                                    "kind" : {
+                                      "TextEvent" : {
+                                        
+                                      }
                                     },
-                                    "name": "textEventOut",
-                                    "priority": "None",
-                                    "queueFull": "None"
+                                    "name" : "textEventOut",
+                                    "priority" : "None",
+                                    "queueFull" : "None"
                                   }
                                 },
-                                "id": 9
+                                "id" : 9
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ]
                     ]
                   },
-                  "id": 10
+                  "id" : 10
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          ["A component for illustrating telemetry ports"],
+          [
+            "A component for illustrating telemetry ports"
+          ],
           {
-            "DefComponent": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "kind": {
-                      "Passive": {}
+            "DefComponent" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "kind" : {
+                      "Passive" : {
+                        
+                      }
                     },
-                    "name": "TelemetryPorts",
-                    "members": [
+                    "name" : "TelemetryPorts",
+                    "members" : [
                       [
-                        ["A port for emitting telemetry"],
+                        [
+                          "A port for emitting telemetry"
+                        ],
                         {
-                          "SpecPortInstance": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "Special": {
-                                    "inputKind": "None",
-                                    "kind": {
-                                      "Telemetry": {}
+                          "SpecPortInstance" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "Special" : {
+                                    "inputKind" : "None",
+                                    "kind" : {
+                                      "Telemetry" : {
+                                        
+                                      }
                                     },
-                                    "name": "tlmOut",
-                                    "priority": "None",
-                                    "queueFull": "None"
+                                    "name" : "tlmOut",
+                                    "priority" : "None",
+                                    "queueFull" : "None"
                                   }
                                 },
-                                "id": 13
+                                "id" : 13
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ]
                     ]
                   },
-                  "id": 14
+                  "id" : 14
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          ["A component for illustrating parameter ports"],
+          [
+            "A component for illustrating parameter ports"
+          ],
           {
-            "DefComponent": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "kind": {
-                      "Passive": {}
+            "DefComponent" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "kind" : {
+                      "Passive" : {
+                        
+                      }
                     },
-                    "name": "ParamPorts",
-                    "members": [
+                    "name" : "ParamPorts",
+                    "members" : [
                       [
-                        ["A port for getting parameter values"],
+                        [
+                          "A port for getting parameter values"
+                        ],
                         {
-                          "SpecPortInstance": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "Special": {
-                                    "inputKind": "None",
-                                    "kind": {
-                                      "ParamGet": {}
+                          "SpecPortInstance" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "Special" : {
+                                    "inputKind" : "None",
+                                    "kind" : {
+                                      "ParamGet" : {
+                                        
+                                      }
                                     },
-                                    "name": "prmGetOut",
-                                    "priority": "None",
-                                    "queueFull": "None"
+                                    "name" : "prmGetOut",
+                                    "priority" : "None",
+                                    "queueFull" : "None"
                                   }
                                 },
-                                "id": 15
+                                "id" : 15
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        ["A port for setting parameter values"],
+                        [
+                          "A port for setting parameter values"
+                        ],
                         {
-                          "SpecPortInstance": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "Special": {
-                                    "inputKind": "None",
-                                    "kind": {
-                                      "ParamSet": {}
+                          "SpecPortInstance" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "Special" : {
+                                    "inputKind" : "None",
+                                    "kind" : {
+                                      "ParamSet" : {
+                                        
+                                      }
                                     },
-                                    "name": "prmSetOut",
-                                    "priority": "None",
-                                    "queueFull": "None"
+                                    "name" : "prmSetOut",
+                                    "priority" : "None",
+                                    "queueFull" : "None"
                                   }
                                 },
-                                "id": 18
+                                "id" : 18
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ]
                     ]
                   },
-                  "id": 19
+                  "id" : 19
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          ["A component for illustrating time get ports"],
+          [
+            "A component for illustrating time get ports"
+          ],
           {
-            "DefComponent": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "kind": {
-                      "Passive": {}
+            "DefComponent" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "kind" : {
+                      "Passive" : {
+                        
+                      }
                     },
-                    "name": "TimeGetPorts",
-                    "members": [
+                    "name" : "TimeGetPorts",
+                    "members" : [
                       [
-                        ["A port for getting the time"],
+                        [
+                          "A port for getting the time"
+                        ],
                         {
-                          "SpecPortInstance": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "Special": {
-                                    "inputKind": "None",
-                                    "kind": {
-                                      "TimeGet": {}
+                          "SpecPortInstance" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "Special" : {
+                                    "inputKind" : "None",
+                                    "kind" : {
+                                      "TimeGet" : {
+                                        
+                                      }
                                     },
-                                    "name": "timeGetOut",
-                                    "priority": "None",
-                                    "queueFull": "None"
+                                    "name" : "timeGetOut",
+                                    "priority" : "None",
+                                    "queueFull" : "None"
                                   }
                                 },
-                                "id": 22
+                                "id" : 22
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ]
                     ]
                   },
-                  "id": 23
+                  "id" : 23
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          [],
+          [
+          ],
           {
-            "DefModule": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "Fw",
-                    "members": [
+            "DefModule" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "Fw",
+                    "members" : [
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "DefPort": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "name": "Cmd",
-                                  "params": [],
-                                  "returnType": "None"
+                          "DefPort" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "name" : "Cmd",
+                                  "params" : [
+                                  ],
+                                  "returnType" : "None"
                                 },
-                                "id": 24
+                                "id" : 24
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "DefPort": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "name": "CmdReg",
-                                  "params": [],
-                                  "returnType": "None"
+                          "DefPort" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "name" : "CmdReg",
+                                  "params" : [
+                                  ],
+                                  "returnType" : "None"
                                 },
-                                "id": 25
+                                "id" : 25
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "DefPort": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "name": "CmdResponse",
-                                  "params": [],
-                                  "returnType": "None"
+                          "DefPort" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "name" : "CmdResponse",
+                                  "params" : [
+                                  ],
+                                  "returnType" : "None"
                                 },
-                                "id": 26
+                                "id" : 26
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "DefPort": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "name": "Log",
-                                  "params": [],
-                                  "returnType": "None"
+                          "DefPort" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "name" : "Log",
+                                  "params" : [
+                                  ],
+                                  "returnType" : "None"
                                 },
-                                "id": 27
+                                "id" : 27
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "DefPort": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "name": "LogText",
-                                  "params": [],
-                                  "returnType": "None"
+                          "DefPort" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "name" : "LogText",
+                                  "params" : [
+                                  ],
+                                  "returnType" : "None"
                                 },
-                                "id": 28
+                                "id" : 28
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "DefPort": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "name": "Tlm",
-                                  "params": [],
-                                  "returnType": "None"
+                          "DefPort" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "name" : "Tlm",
+                                  "params" : [
+                                  ],
+                                  "returnType" : "None"
                                 },
-                                "id": 29
+                                "id" : 29
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "DefPort": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "name": "PrmGet",
-                                  "params": [],
-                                  "returnType": "None"
+                          "DefPort" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "name" : "PrmGet",
+                                  "params" : [
+                                  ],
+                                  "returnType" : "None"
                                 },
-                                "id": 30
+                                "id" : 30
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "DefPort": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "name": "PrmSet",
-                                  "params": [],
-                                  "returnType": "None"
+                          "DefPort" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "name" : "PrmSet",
+                                  "params" : [
+                                  ],
+                                  "returnType" : "None"
                                 },
-                                "id": 31
+                                "id" : 31
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "DefPort": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "name": "Time",
-                                  "params": [],
-                                  "returnType": "None"
+                          "DefPort" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "name" : "Time",
+                                  "params" : [
+                                  ],
+                                  "returnType" : "None"
                                 },
-                                "id": 34
+                                "id" : 34
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ]
                     ]
                   },
-                  "id": 35
+                  "id" : 35
                 }
               }
             }
           },
-          []
+          [
+          ]
         ]
       ]
     }

--- a/tests/special_ports/special_ports_locations.json
+++ b/tests/special_ports/special_ports_locations.json
@@ -1,185 +1,185 @@
 {
-  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
-  "locationMap": {
-    "0": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/specialPorts.fpp",
-      "pos": "5.3",
-      "includingLoc": "None"
+  "fppVersion" : "v3.1.0a10-54-g11243e778",
+  "locationMap" : {
+    "0" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/specialPorts.fpp",
+      "pos" : "5.3",
+      "includingLoc" : "None"
     },
-    "1": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/specialPorts.fpp",
-      "pos": "8.3",
-      "includingLoc": "None"
+    "1" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/specialPorts.fpp",
+      "pos" : "8.3",
+      "includingLoc" : "None"
     },
-    "2": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/specialPorts.fpp",
-      "pos": "11.3",
-      "includingLoc": "None"
+    "2" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/specialPorts.fpp",
+      "pos" : "11.3",
+      "includingLoc" : "None"
     },
-    "3": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/specialPorts.fpp",
-      "pos": "11.3",
-      "includingLoc": "None"
+    "3" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/specialPorts.fpp",
+      "pos" : "11.3",
+      "includingLoc" : "None"
     },
-    "4": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/specialPorts.fpp",
-      "pos": "11.3",
-      "includingLoc": "None"
+    "4" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/specialPorts.fpp",
+      "pos" : "11.3",
+      "includingLoc" : "None"
     },
-    "5": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/specialPorts.fpp",
-      "pos": "2.1",
-      "includingLoc": "None"
+    "5" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/specialPorts.fpp",
+      "pos" : "2.1",
+      "includingLoc" : "None"
     },
-    "6": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/specialPorts.fpp",
-      "pos": "19.3",
-      "includingLoc": "None"
+    "6" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/specialPorts.fpp",
+      "pos" : "19.3",
+      "includingLoc" : "None"
     },
-    "7": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/specialPorts.fpp",
-      "pos": "22.3",
-      "includingLoc": "None"
+    "7" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/specialPorts.fpp",
+      "pos" : "22.3",
+      "includingLoc" : "None"
     },
-    "8": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/specialPorts.fpp",
-      "pos": "22.3",
-      "includingLoc": "None"
+    "8" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/specialPorts.fpp",
+      "pos" : "22.3",
+      "includingLoc" : "None"
     },
-    "9": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/specialPorts.fpp",
-      "pos": "22.3",
-      "includingLoc": "None"
+    "9" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/specialPorts.fpp",
+      "pos" : "22.3",
+      "includingLoc" : "None"
     },
-    "10": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/specialPorts.fpp",
-      "pos": "16.1",
-      "includingLoc": "None"
+    "10" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/specialPorts.fpp",
+      "pos" : "16.1",
+      "includingLoc" : "None"
     },
-    "11": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/specialPorts.fpp",
-      "pos": "30.3",
-      "includingLoc": "None"
+    "11" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/specialPorts.fpp",
+      "pos" : "30.3",
+      "includingLoc" : "None"
     },
-    "12": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/specialPorts.fpp",
-      "pos": "30.3",
-      "includingLoc": "None"
+    "12" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/specialPorts.fpp",
+      "pos" : "30.3",
+      "includingLoc" : "None"
     },
-    "13": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/specialPorts.fpp",
-      "pos": "30.3",
-      "includingLoc": "None"
+    "13" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/specialPorts.fpp",
+      "pos" : "30.3",
+      "includingLoc" : "None"
     },
-    "14": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/specialPorts.fpp",
-      "pos": "27.1",
-      "includingLoc": "None"
+    "14" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/specialPorts.fpp",
+      "pos" : "27.1",
+      "includingLoc" : "None"
     },
-    "15": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/specialPorts.fpp",
-      "pos": "38.3",
-      "includingLoc": "None"
+    "15" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/specialPorts.fpp",
+      "pos" : "38.3",
+      "includingLoc" : "None"
     },
-    "16": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/specialPorts.fpp",
-      "pos": "41.3",
-      "includingLoc": "None"
+    "16" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/specialPorts.fpp",
+      "pos" : "41.3",
+      "includingLoc" : "None"
     },
-    "17": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/specialPorts.fpp",
-      "pos": "41.3",
-      "includingLoc": "None"
+    "17" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/specialPorts.fpp",
+      "pos" : "41.3",
+      "includingLoc" : "None"
     },
-    "18": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/specialPorts.fpp",
-      "pos": "41.3",
-      "includingLoc": "None"
+    "18" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/specialPorts.fpp",
+      "pos" : "41.3",
+      "includingLoc" : "None"
     },
-    "19": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/specialPorts.fpp",
-      "pos": "35.1",
-      "includingLoc": "None"
+    "19" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/specialPorts.fpp",
+      "pos" : "35.1",
+      "includingLoc" : "None"
     },
-    "20": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/specialPorts.fpp",
-      "pos": "49.3",
-      "includingLoc": "None"
+    "20" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/specialPorts.fpp",
+      "pos" : "49.3",
+      "includingLoc" : "None"
     },
-    "21": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/specialPorts.fpp",
-      "pos": "49.3",
-      "includingLoc": "None"
+    "21" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/specialPorts.fpp",
+      "pos" : "49.3",
+      "includingLoc" : "None"
     },
-    "22": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/specialPorts.fpp",
-      "pos": "49.3",
-      "includingLoc": "None"
+    "22" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/specialPorts.fpp",
+      "pos" : "49.3",
+      "includingLoc" : "None"
     },
-    "23": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/specialPorts.fpp",
-      "pos": "46.1",
-      "includingLoc": "None"
+    "23" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/specialPorts.fpp",
+      "pos" : "46.1",
+      "includingLoc" : "None"
     },
-    "24": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/specialPorts.fpp",
-      "pos": "54.3",
-      "includingLoc": "None"
+    "24" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/specialPorts.fpp",
+      "pos" : "54.3",
+      "includingLoc" : "None"
     },
-    "25": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/specialPorts.fpp",
-      "pos": "55.3",
-      "includingLoc": "None"
+    "25" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/specialPorts.fpp",
+      "pos" : "55.3",
+      "includingLoc" : "None"
     },
-    "26": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/specialPorts.fpp",
-      "pos": "56.3",
-      "includingLoc": "None"
+    "26" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/specialPorts.fpp",
+      "pos" : "56.3",
+      "includingLoc" : "None"
     },
-    "27": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/specialPorts.fpp",
-      "pos": "57.3",
-      "includingLoc": "None"
+    "27" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/specialPorts.fpp",
+      "pos" : "57.3",
+      "includingLoc" : "None"
     },
-    "28": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/specialPorts.fpp",
-      "pos": "58.3",
-      "includingLoc": "None"
+    "28" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/specialPorts.fpp",
+      "pos" : "58.3",
+      "includingLoc" : "None"
     },
-    "29": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/specialPorts.fpp",
-      "pos": "59.3",
-      "includingLoc": "None"
+    "29" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/specialPorts.fpp",
+      "pos" : "59.3",
+      "includingLoc" : "None"
     },
-    "30": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/specialPorts.fpp",
-      "pos": "60.3",
-      "includingLoc": "None"
+    "30" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/specialPorts.fpp",
+      "pos" : "60.3",
+      "includingLoc" : "None"
     },
-    "31": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/specialPorts.fpp",
-      "pos": "61.3",
-      "includingLoc": "None"
+    "31" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/specialPorts.fpp",
+      "pos" : "61.3",
+      "includingLoc" : "None"
     },
-    "32": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/specialPorts.fpp",
-      "pos": "62.3",
-      "includingLoc": "None"
+    "32" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/specialPorts.fpp",
+      "pos" : "62.3",
+      "includingLoc" : "None"
     },
-    "33": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/specialPorts.fpp",
-      "pos": "62.3",
-      "includingLoc": "None"
+    "33" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/specialPorts.fpp",
+      "pos" : "62.3",
+      "includingLoc" : "None"
     },
-    "34": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/specialPorts.fpp",
-      "pos": "62.3",
-      "includingLoc": "None"
+    "34" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/specialPorts.fpp",
+      "pos" : "62.3",
+      "includingLoc" : "None"
     },
-    "35": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/specialPorts.fpp",
-      "pos": "53.1",
-      "includingLoc": "None"
+    "35" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/specialPorts.fpp",
+      "pos" : "53.1",
+      "includingLoc" : "None"
     }
   }
 }

--- a/tests/special_ports/special_ports_locations.json
+++ b/tests/special_ports/special_ports_locations.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion": "[ fpp version ]",
+  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
   "locationMap": {
     "0": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/specialPorts.fpp",

--- a/tests/state_machine/state_machine_analysis.json
+++ b/tests/state_machine/state_machine_analysis.json
@@ -1,79 +1,105 @@
 {
-  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
-  "analysis": {
-    "componentInstanceMap": {},
-    "componentMap": {},
-    "includedFileSet": [],
-    "inputFileSet": [
+  "fppVersion" : "v3.1.0a10-54-g11243e778",
+  "analysis" : {
+    "componentInstanceMap" : {
+      
+    },
+    "componentMap" : {
+      
+    },
+    "includedFileSet" : [
+    ],
+    "inputFileSet" : [
       "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp"
     ],
-    "locationSpecifierMap": [],
-    "parentSymbolMap": {},
-    "symbolScopeMap": {},
-    "topologyMap": {},
-    "typeMap": {
-      "3": {
-        "Int": {
-          "PrimitiveInt": {
-            "kind": {
-              "U32": {}
+    "locationSpecifierMap" : [
+    ],
+    "parentSymbolMap" : {
+      
+    },
+    "symbolScopeMap" : {
+      
+    },
+    "topologyMap" : {
+      
+    },
+    "typeMap" : {
+      "3" : {
+        "Int" : {
+          "PrimitiveInt" : {
+            "kind" : {
+              "U32" : {
+                
+              }
             }
           }
         }
       },
-      "6": {
-        "Int": {
-          "PrimitiveInt": {
-            "kind": {
-              "U32": {}
+      "6" : {
+        "Int" : {
+          "PrimitiveInt" : {
+            "kind" : {
+              "U32" : {
+                
+              }
             }
           }
         }
       },
-      "8": {
-        "Int": {
-          "PrimitiveInt": {
-            "kind": {
-              "U32": {}
+      "8" : {
+        "Int" : {
+          "PrimitiveInt" : {
+            "kind" : {
+              "U32" : {
+                
+              }
             }
           }
         }
       }
     },
-    "useDefMap": {},
-    "valueMap": {},
-    "stateMachineMap": {
-      "233": {
-        "aNode": {
-          "astNodeId": 233
+    "useDefMap" : {
+      
+    },
+    "valueMap" : {
+      
+    },
+    "stateMachineMap" : {
+      "233" : {
+        "aNode" : {
+          "astNodeId" : 233
         },
-        "sma": {
-          "symbol": {
-            "node": {
-              "astNodeId": 233
+        "sma" : {
+          "symbol" : {
+            "node" : {
+              "astNodeId" : 233
             }
           },
-          "symbolScopeMap": {
-            "28": {
-              "map": {}
+          "symbolScopeMap" : {
+            "28" : {
+              "map" : {
+                
+              }
             },
-            "190": {
-              "map": {}
+            "190" : {
+              "map" : {
+                
+              }
             },
-            "232": {
-              "map": {
-                "State": {
-                  "map": {
-                    "C": {
-                      "Choice": {
-                        "nodeId": 189,
-                        "unqualifiedName": "C"
+            "232" : {
+              "map" : {
+                "State" : {
+                  "map" : {
+                    "C" : {
+                      "Choice" : {
+                        "nodeId" : 189,
+                        "unqualifiedName" : "C"
                       }
                     },
-                    "S3": {
-                      "State": {
-                        "nodeId": 190,
-                        "unqualifiedName": "S3"
+                    "S3" : {
+                      "State" : {
+                        "nodeId" : 190,
+                        "unqualifiedName" : "S3"
                       }
                     }
                   }
@@ -81,263 +107,264 @@
               }
             }
           },
-          "useDefMap": {
-            "216": {
-              "Guard": {
-                "nodeId": 5,
-                "unqualifiedName": "g1"
+          "useDefMap" : {
+            "216" : {
+              "Guard" : {
+                "nodeId" : 5,
+                "unqualifiedName" : "g1"
               }
             },
-            "201": {
-              "State": {
-                "nodeId": 28,
-                "unqualifiedName": "S1"
+            "201" : {
+              "State" : {
+                "nodeId" : 28,
+                "unqualifiedName" : "S1"
               }
             },
-            "174": {
-              "State": {
-                "nodeId": 190,
-                "unqualifiedName": "S3"
+            "174" : {
+              "State" : {
+                "nodeId" : 190,
+                "unqualifiedName" : "S3"
               }
             },
-            "192": {
-              "Guard": {
-                "nodeId": 5,
-                "unqualifiedName": "g1"
+            "192" : {
+              "Guard" : {
+                "nodeId" : 5,
+                "unqualifiedName" : "g1"
               }
             },
-            "199": {
-              "Guard": {
-                "nodeId": 5,
-                "unqualifiedName": "g1"
+            "199" : {
+              "Guard" : {
+                "nodeId" : 5,
+                "unqualifiedName" : "g1"
               }
             },
-            "228": {
-              "Signal": {
-                "nodeId": 14,
-                "unqualifiedName": "s6"
+            "228" : {
+              "Signal" : {
+                "nodeId" : 14,
+                "unqualifiedName" : "s6"
               }
             },
-            "185": {
-              "State": {
-                "nodeId": 232,
-                "unqualifiedName": "S2"
+            "185" : {
+              "State" : {
+                "nodeId" : 232,
+                "unqualifiedName" : "S2"
               }
             },
-            "184": {
-              "Action": {
-                "nodeId": 2,
-                "unqualifiedName": "a3"
+            "184" : {
+              "Action" : {
+                "nodeId" : 2,
+                "unqualifiedName" : "a3"
               }
             },
-            "195": {
-              "Choice": {
-                "nodeId": 189,
-                "unqualifiedName": "C"
+            "195" : {
+              "Choice" : {
+                "nodeId" : 189,
+                "unqualifiedName" : "C"
               }
             },
-            "207": {
-              "State": {
-                "nodeId": 28,
-                "unqualifiedName": "S1"
+            "207" : {
+              "State" : {
+                "nodeId" : 28,
+                "unqualifiedName" : "S1"
               }
             },
-            "172": {
-              "Action": {
-                "nodeId": 1,
-                "unqualifiedName": "a2"
+            "172" : {
+              "Action" : {
+                "nodeId" : 1,
+                "unqualifiedName" : "a2"
               }
             },
-            "205": {
-              "Guard": {
-                "nodeId": 5,
-                "unqualifiedName": "g1"
+            "205" : {
+              "Guard" : {
+                "nodeId" : 5,
+                "unqualifiedName" : "g1"
               }
             },
-            "169": {
-              "Action": {
-                "nodeId": 1,
-                "unqualifiedName": "a2"
+            "169" : {
+              "Action" : {
+                "nodeId" : 1,
+                "unqualifiedName" : "a2"
               }
             },
-            "193": {
-              "Action": {
-                "nodeId": 0,
-                "unqualifiedName": "a1"
+            "193" : {
+              "Action" : {
+                "nodeId" : 0,
+                "unqualifiedName" : "a1"
               }
             },
-            "15": {
-              "Action": {
-                "nodeId": 0,
-                "unqualifiedName": "a1"
+            "15" : {
+              "Action" : {
+                "nodeId" : 0,
+                "unqualifiedName" : "a1"
               }
             },
-            "181": {
-              "State": {
-                "nodeId": 28,
-                "unqualifiedName": "S1"
+            "181" : {
+              "State" : {
+                "nodeId" : 28,
+                "unqualifiedName" : "S1"
               }
             },
-            "22": {
-              "State": {
-                "nodeId": 28,
-                "unqualifiedName": "S1"
+            "22" : {
+              "State" : {
+                "nodeId" : 28,
+                "unqualifiedName" : "S1"
               }
             },
-            "212": {
-              "State": {
-                "nodeId": 28,
-                "unqualifiedName": "S1"
+            "212" : {
+              "State" : {
+                "nodeId" : 28,
+                "unqualifiedName" : "S1"
               }
             },
-            "166": {
-              "Action": {
-                "nodeId": 1,
-                "unqualifiedName": "a2"
+            "166" : {
+              "Action" : {
+                "nodeId" : 1,
+                "unqualifiedName" : "a2"
               }
             },
-            "177": {
-              "Guard": {
-                "nodeId": 5,
-                "unqualifiedName": "g1"
+            "177" : {
+              "Guard" : {
+                "nodeId" : 5,
+                "unqualifiedName" : "g1"
               }
             },
-            "17": {
-              "Choice": {
-                "nodeId": 27,
-                "unqualifiedName": "C"
+            "17" : {
+              "Choice" : {
+                "nodeId" : 27,
+                "unqualifiedName" : "C"
               }
             },
-            "25": {
-              "State": {
-                "nodeId": 232,
-                "unqualifiedName": "S2"
+            "25" : {
+              "State" : {
+                "nodeId" : 232,
+                "unqualifiedName" : "S2"
               }
             },
-            "230": {
-              "Action": {
-                "nodeId": 0,
-                "unqualifiedName": "a1"
+            "230" : {
+              "Action" : {
+                "nodeId" : 0,
+                "unqualifiedName" : "a1"
               }
             },
-            "191": {
-              "Signal": {
-                "nodeId": 9,
-                "unqualifiedName": "s1"
+            "191" : {
+              "Signal" : {
+                "nodeId" : 9,
+                "unqualifiedName" : "s1"
               }
             },
-            "20": {
-              "Guard": {
-                "nodeId": 5,
-                "unqualifiedName": "g1"
+            "20" : {
+              "Guard" : {
+                "nodeId" : 5,
+                "unqualifiedName" : "g1"
               }
             },
-            "178": {
-              "Action": {
-                "nodeId": 0,
-                "unqualifiedName": "a1"
+            "178" : {
+              "Action" : {
+                "nodeId" : 0,
+                "unqualifiedName" : "a1"
               }
             },
-            "210": {
-              "Signal": {
-                "nodeId": 12,
-                "unqualifiedName": "s4"
+            "210" : {
+              "Signal" : {
+                "nodeId" : 12,
+                "unqualifiedName" : "s4"
               }
             },
-            "198": {
-              "Signal": {
-                "nodeId": 10,
-                "unqualifiedName": "s2"
+            "198" : {
+              "Signal" : {
+                "nodeId" : 10,
+                "unqualifiedName" : "s2"
               }
             },
-            "187": {
-              "State": {
-                "nodeId": 190,
-                "unqualifiedName": "S3"
+            "187" : {
+              "State" : {
+                "nodeId" : 190,
+                "unqualifiedName" : "S3"
               }
             },
-            "171": {
-              "Action": {
-                "nodeId": 0,
-                "unqualifiedName": "a1"
+            "171" : {
+              "Action" : {
+                "nodeId" : 0,
+                "unqualifiedName" : "a1"
               }
             },
-            "165": {
-              "Action": {
-                "nodeId": 0,
-                "unqualifiedName": "a1"
+            "165" : {
+              "Action" : {
+                "nodeId" : 0,
+                "unqualifiedName" : "a1"
               }
             },
-            "215": {
-              "Signal": {
-                "nodeId": 13,
-                "unqualifiedName": "s5"
+            "215" : {
+              "Signal" : {
+                "nodeId" : 13,
+                "unqualifiedName" : "s5"
               }
             },
-            "183": {
-              "Action": {
-                "nodeId": 1,
-                "unqualifiedName": "a2"
+            "183" : {
+              "Action" : {
+                "nodeId" : 1,
+                "unqualifiedName" : "a2"
               }
             },
-            "179": {
-              "Action": {
-                "nodeId": 1,
-                "unqualifiedName": "a2"
+            "179" : {
+              "Action" : {
+                "nodeId" : 1,
+                "unqualifiedName" : "a2"
               }
             },
-            "218": {
-              "Action": {
-                "nodeId": 0,
-                "unqualifiedName": "a1"
+            "218" : {
+              "Action" : {
+                "nodeId" : 0,
+                "unqualifiedName" : "a1"
               }
             },
-            "168": {
-              "Action": {
-                "nodeId": 0,
-                "unqualifiedName": "a1"
+            "168" : {
+              "Action" : {
+                "nodeId" : 0,
+                "unqualifiedName" : "a1"
               }
             },
-            "204": {
-              "Signal": {
-                "nodeId": 11,
-                "unqualifiedName": "s3"
+            "204" : {
+              "Signal" : {
+                "nodeId" : 11,
+                "unqualifiedName" : "s3"
               }
             }
           },
-          "transitionGraph": {
-            "initialNode": {
-              "Some": {
-                "soc": {
-                  "Choice": {
-                    "symbol": {
-                      "node": {
-                        "astNodeId": 27
+          "transitionGraph" : {
+            "initialNode" : {
+              "Some" : {
+                "soc" : {
+                  "Choice" : {
+                    "symbol" : {
+                      "node" : {
+                        "astNodeId" : 27
                       }
                     }
                   }
                 }
               }
             },
-            "arcMap": {
-              "190": [],
-              "232": [
+            "arcMap" : {
+              "190" : [
+              ],
+              "232" : [
                 {
-                  "State": {
-                    "startState": {
-                      "node": {
-                        "astNodeId": 232
+                  "State" : {
+                    "startState" : {
+                      "node" : {
+                        "astNodeId" : 232
                       }
                     },
-                    "aNode": {
-                      "astNodeId": 214
+                    "aNode" : {
+                      "astNodeId" : 214
                     },
-                    "endNode": {
-                      "soc": {
-                        "State": {
-                          "symbol": {
-                            "node": {
-                              "astNodeId": 28
+                    "endNode" : {
+                      "soc" : {
+                        "State" : {
+                          "symbol" : {
+                            "node" : {
+                              "astNodeId" : 28
                             }
                           }
                         }
@@ -346,21 +373,21 @@
                   }
                 },
                 {
-                  "State": {
-                    "startState": {
-                      "node": {
-                        "astNodeId": 232
+                  "State" : {
+                    "startState" : {
+                      "node" : {
+                        "astNodeId" : 232
                       }
                     },
-                    "aNode": {
-                      "astNodeId": 197
+                    "aNode" : {
+                      "astNodeId" : 197
                     },
-                    "endNode": {
-                      "soc": {
-                        "Choice": {
-                          "symbol": {
-                            "node": {
-                              "astNodeId": 189
+                    "endNode" : {
+                      "soc" : {
+                        "Choice" : {
+                          "symbol" : {
+                            "node" : {
+                              "astNodeId" : 189
                             }
                           }
                         }
@@ -369,21 +396,21 @@
                   }
                 },
                 {
-                  "State": {
-                    "startState": {
-                      "node": {
-                        "astNodeId": 232
+                  "State" : {
+                    "startState" : {
+                      "node" : {
+                        "astNodeId" : 232
                       }
                     },
-                    "aNode": {
-                      "astNodeId": 203
+                    "aNode" : {
+                      "astNodeId" : 203
                     },
-                    "endNode": {
-                      "soc": {
-                        "State": {
-                          "symbol": {
-                            "node": {
-                              "astNodeId": 28
+                    "endNode" : {
+                      "soc" : {
+                        "State" : {
+                          "symbol" : {
+                            "node" : {
+                              "astNodeId" : 28
                             }
                           }
                         }
@@ -392,21 +419,21 @@
                   }
                 },
                 {
-                  "State": {
-                    "startState": {
-                      "node": {
-                        "astNodeId": 232
+                  "State" : {
+                    "startState" : {
+                      "node" : {
+                        "astNodeId" : 232
                       }
                     },
-                    "aNode": {
-                      "astNodeId": 209
+                    "aNode" : {
+                      "astNodeId" : 209
                     },
-                    "endNode": {
-                      "soc": {
-                        "State": {
-                          "symbol": {
-                            "node": {
-                              "astNodeId": 28
+                    "endNode" : {
+                      "soc" : {
+                        "State" : {
+                          "symbol" : {
+                            "node" : {
+                              "astNodeId" : 28
                             }
                           }
                         }
@@ -415,21 +442,21 @@
                   }
                 },
                 {
-                  "Initial": {
-                    "startState": {
-                      "node": {
-                        "astNodeId": 232
+                  "Initial" : {
+                    "startState" : {
+                      "node" : {
+                        "astNodeId" : 232
                       }
                     },
-                    "aNode": {
-                      "astNodeId": 176
+                    "aNode" : {
+                      "astNodeId" : 176
                     },
-                    "endNode": {
-                      "soc": {
-                        "State": {
-                          "symbol": {
-                            "node": {
-                              "astNodeId": 190
+                    "endNode" : {
+                      "soc" : {
+                        "State" : {
+                          "symbol" : {
+                            "node" : {
+                              "astNodeId" : 190
                             }
                           }
                         }
@@ -438,24 +465,25 @@
                   }
                 }
               ],
-              "28": [],
-              "189": [
+              "28" : [
+              ],
+              "189" : [
                 {
-                  "Choice": {
-                    "startChoice": {
-                      "node": {
-                        "astNodeId": 189
+                  "Choice" : {
+                    "startChoice" : {
+                      "node" : {
+                        "astNodeId" : 189
                       }
                     },
-                    "aNode": {
-                      "astNodeId": 182
+                    "aNode" : {
+                      "astNodeId" : 182
                     },
-                    "endNode": {
-                      "soc": {
-                        "State": {
-                          "symbol": {
-                            "node": {
-                              "astNodeId": 28
+                    "endNode" : {
+                      "soc" : {
+                        "State" : {
+                          "symbol" : {
+                            "node" : {
+                              "astNodeId" : 28
                             }
                           }
                         }
@@ -464,21 +492,21 @@
                   }
                 },
                 {
-                  "Choice": {
-                    "startChoice": {
-                      "node": {
-                        "astNodeId": 189
+                  "Choice" : {
+                    "startChoice" : {
+                      "node" : {
+                        "astNodeId" : 189
                       }
                     },
-                    "aNode": {
-                      "astNodeId": 188
+                    "aNode" : {
+                      "astNodeId" : 188
                     },
-                    "endNode": {
-                      "soc": {
-                        "State": {
-                          "symbol": {
-                            "node": {
-                              "astNodeId": 190
+                    "endNode" : {
+                      "soc" : {
+                        "State" : {
+                          "symbol" : {
+                            "node" : {
+                              "astNodeId" : 190
                             }
                           }
                         }
@@ -487,23 +515,23 @@
                   }
                 }
               ],
-              "27": [
+              "27" : [
                 {
-                  "Choice": {
-                    "startChoice": {
-                      "node": {
-                        "astNodeId": 27
+                  "Choice" : {
+                    "startChoice" : {
+                      "node" : {
+                        "astNodeId" : 27
                       }
                     },
-                    "aNode": {
-                      "astNodeId": 23
+                    "aNode" : {
+                      "astNodeId" : 23
                     },
-                    "endNode": {
-                      "soc": {
-                        "State": {
-                          "symbol": {
-                            "node": {
-                              "astNodeId": 28
+                    "endNode" : {
+                      "soc" : {
+                        "State" : {
+                          "symbol" : {
+                            "node" : {
+                              "astNodeId" : 28
                             }
                           }
                         }
@@ -512,21 +540,21 @@
                   }
                 },
                 {
-                  "Choice": {
-                    "startChoice": {
-                      "node": {
-                        "astNodeId": 27
+                  "Choice" : {
+                    "startChoice" : {
+                      "node" : {
+                        "astNodeId" : 27
                       }
                     },
-                    "aNode": {
-                      "astNodeId": 26
+                    "aNode" : {
+                      "astNodeId" : 26
                     },
-                    "endNode": {
-                      "soc": {
-                        "State": {
-                          "symbol": {
-                            "node": {
-                              "astNodeId": 232
+                    "endNode" : {
+                      "soc" : {
+                        "State" : {
+                          "symbol" : {
+                            "node" : {
+                              "astNodeId" : 232
                             }
                           }
                         }
@@ -537,38 +565,38 @@
               ]
             }
           },
-          "reverseTransitionGraph": {
-            "initialNode": {
-              "Some": {
-                "soc": {
-                  "Choice": {
-                    "symbol": {
-                      "node": {
-                        "astNodeId": 27
+          "reverseTransitionGraph" : {
+            "initialNode" : {
+              "Some" : {
+                "soc" : {
+                  "Choice" : {
+                    "symbol" : {
+                      "node" : {
+                        "astNodeId" : 27
                       }
                     }
                   }
                 }
               }
             },
-            "arcMap": {
-              "190": [
+            "arcMap" : {
+              "190" : [
                 {
-                  "Choice": {
-                    "startChoice": {
-                      "node": {
-                        "astNodeId": 189
+                  "Choice" : {
+                    "startChoice" : {
+                      "node" : {
+                        "astNodeId" : 189
                       }
                     },
-                    "aNode": {
-                      "astNodeId": 188
+                    "aNode" : {
+                      "astNodeId" : 188
                     },
-                    "endNode": {
-                      "soc": {
-                        "State": {
-                          "symbol": {
-                            "node": {
-                              "astNodeId": 190
+                    "endNode" : {
+                      "soc" : {
+                        "State" : {
+                          "symbol" : {
+                            "node" : {
+                              "astNodeId" : 190
                             }
                           }
                         }
@@ -577,21 +605,21 @@
                   }
                 },
                 {
-                  "Initial": {
-                    "startState": {
-                      "node": {
-                        "astNodeId": 232
+                  "Initial" : {
+                    "startState" : {
+                      "node" : {
+                        "astNodeId" : 232
                       }
                     },
-                    "aNode": {
-                      "astNodeId": 176
+                    "aNode" : {
+                      "astNodeId" : 176
                     },
-                    "endNode": {
-                      "soc": {
-                        "State": {
-                          "symbol": {
-                            "node": {
-                              "astNodeId": 190
+                    "endNode" : {
+                      "soc" : {
+                        "State" : {
+                          "symbol" : {
+                            "node" : {
+                              "astNodeId" : 190
                             }
                           }
                         }
@@ -600,23 +628,23 @@
                   }
                 }
               ],
-              "232": [
+              "232" : [
                 {
-                  "Choice": {
-                    "startChoice": {
-                      "node": {
-                        "astNodeId": 27
+                  "Choice" : {
+                    "startChoice" : {
+                      "node" : {
+                        "astNodeId" : 27
                       }
                     },
-                    "aNode": {
-                      "astNodeId": 26
+                    "aNode" : {
+                      "astNodeId" : 26
                     },
-                    "endNode": {
-                      "soc": {
-                        "State": {
-                          "symbol": {
-                            "node": {
-                              "astNodeId": 232
+                    "endNode" : {
+                      "soc" : {
+                        "State" : {
+                          "symbol" : {
+                            "node" : {
+                              "astNodeId" : 232
                             }
                           }
                         }
@@ -625,23 +653,23 @@
                   }
                 }
               ],
-              "28": [
+              "28" : [
                 {
-                  "State": {
-                    "startState": {
-                      "node": {
-                        "astNodeId": 232
+                  "State" : {
+                    "startState" : {
+                      "node" : {
+                        "astNodeId" : 232
                       }
                     },
-                    "aNode": {
-                      "astNodeId": 214
+                    "aNode" : {
+                      "astNodeId" : 214
                     },
-                    "endNode": {
-                      "soc": {
-                        "State": {
-                          "symbol": {
-                            "node": {
-                              "astNodeId": 28
+                    "endNode" : {
+                      "soc" : {
+                        "State" : {
+                          "symbol" : {
+                            "node" : {
+                              "astNodeId" : 28
                             }
                           }
                         }
@@ -650,21 +678,21 @@
                   }
                 },
                 {
-                  "Choice": {
-                    "startChoice": {
-                      "node": {
-                        "astNodeId": 27
+                  "Choice" : {
+                    "startChoice" : {
+                      "node" : {
+                        "astNodeId" : 27
                       }
                     },
-                    "aNode": {
-                      "astNodeId": 23
+                    "aNode" : {
+                      "astNodeId" : 23
                     },
-                    "endNode": {
-                      "soc": {
-                        "State": {
-                          "symbol": {
-                            "node": {
-                              "astNodeId": 28
+                    "endNode" : {
+                      "soc" : {
+                        "State" : {
+                          "symbol" : {
+                            "node" : {
+                              "astNodeId" : 28
                             }
                           }
                         }
@@ -673,21 +701,21 @@
                   }
                 },
                 {
-                  "State": {
-                    "startState": {
-                      "node": {
-                        "astNodeId": 232
+                  "State" : {
+                    "startState" : {
+                      "node" : {
+                        "astNodeId" : 232
                       }
                     },
-                    "aNode": {
-                      "astNodeId": 203
+                    "aNode" : {
+                      "astNodeId" : 203
                     },
-                    "endNode": {
-                      "soc": {
-                        "State": {
-                          "symbol": {
-                            "node": {
-                              "astNodeId": 28
+                    "endNode" : {
+                      "soc" : {
+                        "State" : {
+                          "symbol" : {
+                            "node" : {
+                              "astNodeId" : 28
                             }
                           }
                         }
@@ -696,21 +724,21 @@
                   }
                 },
                 {
-                  "State": {
-                    "startState": {
-                      "node": {
-                        "astNodeId": 232
+                  "State" : {
+                    "startState" : {
+                      "node" : {
+                        "astNodeId" : 232
                       }
                     },
-                    "aNode": {
-                      "astNodeId": 209
+                    "aNode" : {
+                      "astNodeId" : 209
                     },
-                    "endNode": {
-                      "soc": {
-                        "State": {
-                          "symbol": {
-                            "node": {
-                              "astNodeId": 28
+                    "endNode" : {
+                      "soc" : {
+                        "State" : {
+                          "symbol" : {
+                            "node" : {
+                              "astNodeId" : 28
                             }
                           }
                         }
@@ -719,21 +747,21 @@
                   }
                 },
                 {
-                  "Choice": {
-                    "startChoice": {
-                      "node": {
-                        "astNodeId": 189
+                  "Choice" : {
+                    "startChoice" : {
+                      "node" : {
+                        "astNodeId" : 189
                       }
                     },
-                    "aNode": {
-                      "astNodeId": 182
+                    "aNode" : {
+                      "astNodeId" : 182
                     },
-                    "endNode": {
-                      "soc": {
-                        "State": {
-                          "symbol": {
-                            "node": {
-                              "astNodeId": 28
+                    "endNode" : {
+                      "soc" : {
+                        "State" : {
+                          "symbol" : {
+                            "node" : {
+                              "astNodeId" : 28
                             }
                           }
                         }
@@ -742,23 +770,23 @@
                   }
                 }
               ],
-              "189": [
+              "189" : [
                 {
-                  "State": {
-                    "startState": {
-                      "node": {
-                        "astNodeId": 232
+                  "State" : {
+                    "startState" : {
+                      "node" : {
+                        "astNodeId" : 232
                       }
                     },
-                    "aNode": {
-                      "astNodeId": 197
+                    "aNode" : {
+                      "astNodeId" : 197
                     },
-                    "endNode": {
-                      "soc": {
-                        "Choice": {
-                          "symbol": {
-                            "node": {
-                              "astNodeId": 189
+                    "endNode" : {
+                      "soc" : {
+                        "Choice" : {
+                          "symbol" : {
+                            "node" : {
+                              "astNodeId" : 189
                             }
                           }
                         }
@@ -767,66 +795,71 @@
                   }
                 }
               ],
-              "27": []
+              "27" : [
+              ]
             }
           },
-          "typeOptionMap": {
-            "170": "None",
-            "19": "None",
-            "197": {
-              "Some": {
-                "Int": {
-                  "PrimitiveInt": {
-                    "kind": {
-                      "U32": {}
+          "typeOptionMap" : {
+            "170" : "None",
+            "19" : "None",
+            "197" : {
+              "Some" : {
+                "Int" : {
+                  "PrimitiveInt" : {
+                    "kind" : {
+                      "U32" : {
+                        
+                      }
                     }
                   }
                 }
               }
             },
-            "209": "None",
-            "231": "None",
-            "219": "None",
-            "214": "None",
-            "203": "None",
-            "167": "None",
-            "176": "None",
-            "189": {
-              "Some": {
-                "Int": {
-                  "PrimitiveInt": {
-                    "kind": {
-                      "U32": {}
+            "209" : "None",
+            "231" : "None",
+            "219" : "None",
+            "214" : "None",
+            "203" : "None",
+            "167" : "None",
+            "176" : "None",
+            "189" : {
+              "Some" : {
+                "Int" : {
+                  "PrimitiveInt" : {
+                    "kind" : {
+                      "U32" : {
+                        
+                      }
                     }
                   }
                 }
               }
             },
-            "27": "None"
+            "27" : "None"
           },
-          "flattenedStateTransitionMap": {
-            "12": {
-              "190": {
-                "guardOpt": "None",
-                "transition": {
-                  "External": {
-                    "actions": [
+          "flattenedStateTransitionMap" : {
+            "12" : {
+              "190" : {
+                "guardOpt" : "None",
+                "transition" : {
+                  "External" : {
+                    "actions" : [
                       {
-                        "node": {
-                          "astNodeId": 0
+                        "node" : {
+                          "astNodeId" : 0
                         }
                       },
                       {
-                        "node": {
-                          "astNodeId": 1
+                        "node" : {
+                          "astNodeId" : 1
                         }
                       }
                     ],
-                    "target": {
-                      "State": {
-                        "symbol": {
-                          "node": {
-                            "astNodeId": 28
+                    "target" : {
+                      "State" : {
+                        "symbol" : {
+                          "node" : {
+                            "astNodeId" : 28
                           }
                         }
                       }
@@ -835,21 +868,21 @@
                 }
               }
             },
-            "13": {
-              "190": {
-                "guardOpt": {
-                  "Some": {
-                    "node": {
-                      "astNodeId": 5
+            "13" : {
+              "190" : {
+                "guardOpt" : {
+                  "Some" : {
+                    "node" : {
+                      "astNodeId" : 5
                     }
                   }
                 },
-                "transition": {
-                  "Internal": {
-                    "actions": [
+                "transition" : {
+                  "Internal" : {
+                    "actions" : [
                       {
-                        "node": {
-                          "astNodeId": 0
+                        "node" : {
+                          "astNodeId" : 0
                         }
                       }
                     ]
@@ -857,34 +890,34 @@
                 }
               }
             },
-            "10": {
-              "190": {
-                "guardOpt": {
-                  "Some": {
-                    "node": {
-                      "astNodeId": 5
+            "10" : {
+              "190" : {
+                "guardOpt" : {
+                  "Some" : {
+                    "node" : {
+                      "astNodeId" : 5
                     }
                   }
                 },
-                "transition": {
-                  "External": {
-                    "actions": [
+                "transition" : {
+                  "External" : {
+                    "actions" : [
                       {
-                        "node": {
-                          "astNodeId": 0
+                        "node" : {
+                          "astNodeId" : 0
                         }
                       },
                       {
-                        "node": {
-                          "astNodeId": 1
+                        "node" : {
+                          "astNodeId" : 1
                         }
                       }
                     ],
-                    "target": {
-                      "State": {
-                        "symbol": {
-                          "node": {
-                            "astNodeId": 28
+                    "target" : {
+                      "State" : {
+                        "symbol" : {
+                          "node" : {
+                            "astNodeId" : 28
                           }
                         }
                       }
@@ -893,15 +926,15 @@
                 }
               }
             },
-            "14": {
-              "190": {
-                "guardOpt": "None",
-                "transition": {
-                  "Internal": {
-                    "actions": [
+            "14" : {
+              "190" : {
+                "guardOpt" : "None",
+                "transition" : {
+                  "Internal" : {
+                    "actions" : [
                       {
-                        "node": {
-                          "astNodeId": 0
+                        "node" : {
+                          "astNodeId" : 0
                         }
                       }
                     ]
@@ -909,34 +942,34 @@
                 }
               }
             },
-            "11": {
-              "190": {
-                "guardOpt": {
-                  "Some": {
-                    "node": {
-                      "astNodeId": 5
+            "11" : {
+              "190" : {
+                "guardOpt" : {
+                  "Some" : {
+                    "node" : {
+                      "astNodeId" : 5
                     }
                   }
                 },
-                "transition": {
-                  "External": {
-                    "actions": [
+                "transition" : {
+                  "External" : {
+                    "actions" : [
                       {
-                        "node": {
-                          "astNodeId": 0
+                        "node" : {
+                          "astNodeId" : 0
                         }
                       },
                       {
-                        "node": {
-                          "astNodeId": 1
+                        "node" : {
+                          "astNodeId" : 1
                         }
                       }
                     ],
-                    "target": {
-                      "State": {
-                        "symbol": {
-                          "node": {
-                            "astNodeId": 28
+                    "target" : {
+                      "State" : {
+                        "symbol" : {
+                          "node" : {
+                            "astNodeId" : 28
                           }
                         }
                       }
@@ -945,29 +978,29 @@
                 }
               }
             },
-            "9": {
-              "190": {
-                "guardOpt": {
-                  "Some": {
-                    "node": {
-                      "astNodeId": 5
+            "9" : {
+              "190" : {
+                "guardOpt" : {
+                  "Some" : {
+                    "node" : {
+                      "astNodeId" : 5
                     }
                   }
                 },
-                "transition": {
-                  "External": {
-                    "actions": [
+                "transition" : {
+                  "External" : {
+                    "actions" : [
                       {
-                        "node": {
-                          "astNodeId": 0
+                        "node" : {
+                          "astNodeId" : 0
                         }
                       }
                     ],
-                    "target": {
-                      "Choice": {
-                        "symbol": {
-                          "node": {
-                            "astNodeId": 189
+                    "target" : {
+                      "Choice" : {
+                        "symbol" : {
+                          "node" : {
+                            "astNodeId" : 189
                           }
                         }
                       }
@@ -977,89 +1010,91 @@
               }
             }
           },
-          "flattenedChoiceTransitionMap": {
-            "23": {
-              "External": {
-                "actions": [],
-                "target": {
-                  "State": {
-                    "symbol": {
-                      "node": {
-                        "astNodeId": 28
+          "flattenedChoiceTransitionMap" : {
+            "23" : {
+              "External" : {
+                "actions" : [
+                ],
+                "target" : {
+                  "State" : {
+                    "symbol" : {
+                      "node" : {
+                        "astNodeId" : 28
                       }
                     }
                   }
                 }
               }
             },
-            "26": {
-              "External": {
-                "actions": [],
-                "target": {
-                  "State": {
-                    "symbol": {
-                      "node": {
-                        "astNodeId": 232
+            "26" : {
+              "External" : {
+                "actions" : [
+                ],
+                "target" : {
+                  "State" : {
+                    "symbol" : {
+                      "node" : {
+                        "astNodeId" : 232
                       }
                     }
                   }
                 }
               }
             },
-            "182": {
-              "External": {
-                "actions": [
+            "182" : {
+              "External" : {
+                "actions" : [
                   {
-                    "node": {
-                      "astNodeId": 0
+                    "node" : {
+                      "astNodeId" : 0
                     }
                   },
                   {
-                    "node": {
-                      "astNodeId": 1
+                    "node" : {
+                      "astNodeId" : 1
                     }
                   },
                   {
-                    "node": {
-                      "astNodeId": 0
+                    "node" : {
+                      "astNodeId" : 0
                     }
                   },
                   {
-                    "node": {
-                      "astNodeId": 1
+                    "node" : {
+                      "astNodeId" : 1
                     }
                   }
                 ],
-                "target": {
-                  "State": {
-                    "symbol": {
-                      "node": {
-                        "astNodeId": 28
+                "target" : {
+                  "State" : {
+                    "symbol" : {
+                      "node" : {
+                        "astNodeId" : 28
                       }
                     }
                   }
                 }
               }
             },
-            "188": {
-              "External": {
-                "actions": [
+            "188" : {
+              "External" : {
+                "actions" : [
                   {
-                    "node": {
-                      "astNodeId": 1
+                    "node" : {
+                      "astNodeId" : 1
                     }
                   },
                   {
-                    "node": {
-                      "astNodeId": 2
+                    "node" : {
+                      "astNodeId" : 2
                     }
                   }
                 ],
-                "target": {
-                  "State": {
-                    "symbol": {
-                      "node": {
-                        "astNodeId": 190
+                "target" : {
+                  "State" : {
+                    "symbol" : {
+                      "node" : {
+                        "astNodeId" : 190
                       }
                     }
                   }
@@ -1070,7 +1105,10 @@
         }
       }
     },
-    "dictionarySymbolSet": [],
-    "interfaceMap": {}
+    "dictionarySymbolSet" : [
+    ],
+    "interfaceMap" : {
+      
+    }
   }
 }

--- a/tests/state_machine/state_machine_analysis.json
+++ b/tests/state_machine/state_machine_analysis.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion": "[ fpp version ]",
+  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
   "analysis": {
     "componentInstanceMap": {},
     "componentMap": {},
@@ -320,57 +320,8 @@
               }
             },
             "arcMap": {
-              "state S1": [],
-              "state S3": [],
-              "choice C": [
-                {
-                  "Choice": {
-                    "startChoice": {
-                      "node": {
-                        "astNodeId": 27
-                      }
-                    },
-                    "aNode": {
-                      "astNodeId": 23
-                    },
-                    "endNode": {
-                      "soc": {
-                        "State": {
-                          "symbol": {
-                            "node": {
-                              "astNodeId": 28
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                {
-                  "Choice": {
-                    "startChoice": {
-                      "node": {
-                        "astNodeId": 27
-                      }
-                    },
-                    "aNode": {
-                      "astNodeId": 26
-                    },
-                    "endNode": {
-                      "soc": {
-                        "State": {
-                          "symbol": {
-                            "node": {
-                              "astNodeId": 232
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              ],
-              "state S2": [
+              "190": [],
+              "232": [
                 {
                   "State": {
                     "startState": {
@@ -486,6 +437,103 @@
                     }
                   }
                 }
+              ],
+              "28": [],
+              "189": [
+                {
+                  "Choice": {
+                    "startChoice": {
+                      "node": {
+                        "astNodeId": 189
+                      }
+                    },
+                    "aNode": {
+                      "astNodeId": 182
+                    },
+                    "endNode": {
+                      "soc": {
+                        "State": {
+                          "symbol": {
+                            "node": {
+                              "astNodeId": 28
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                {
+                  "Choice": {
+                    "startChoice": {
+                      "node": {
+                        "astNodeId": 189
+                      }
+                    },
+                    "aNode": {
+                      "astNodeId": 188
+                    },
+                    "endNode": {
+                      "soc": {
+                        "State": {
+                          "symbol": {
+                            "node": {
+                              "astNodeId": 190
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              ],
+              "27": [
+                {
+                  "Choice": {
+                    "startChoice": {
+                      "node": {
+                        "astNodeId": 27
+                      }
+                    },
+                    "aNode": {
+                      "astNodeId": 23
+                    },
+                    "endNode": {
+                      "soc": {
+                        "State": {
+                          "symbol": {
+                            "node": {
+                              "astNodeId": 28
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                {
+                  "Choice": {
+                    "startChoice": {
+                      "node": {
+                        "astNodeId": 27
+                      }
+                    },
+                    "aNode": {
+                      "astNodeId": 26
+                    },
+                    "endNode": {
+                      "soc": {
+                        "State": {
+                          "symbol": {
+                            "node": {
+                              "astNodeId": 232
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
               ]
             }
           },
@@ -504,7 +552,80 @@
               }
             },
             "arcMap": {
-              "state S1": [
+              "190": [
+                {
+                  "Choice": {
+                    "startChoice": {
+                      "node": {
+                        "astNodeId": 189
+                      }
+                    },
+                    "aNode": {
+                      "astNodeId": 188
+                    },
+                    "endNode": {
+                      "soc": {
+                        "State": {
+                          "symbol": {
+                            "node": {
+                              "astNodeId": 190
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                {
+                  "Initial": {
+                    "startState": {
+                      "node": {
+                        "astNodeId": 232
+                      }
+                    },
+                    "aNode": {
+                      "astNodeId": 176
+                    },
+                    "endNode": {
+                      "soc": {
+                        "State": {
+                          "symbol": {
+                            "node": {
+                              "astNodeId": 190
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              ],
+              "232": [
+                {
+                  "Choice": {
+                    "startChoice": {
+                      "node": {
+                        "astNodeId": 27
+                      }
+                    },
+                    "aNode": {
+                      "astNodeId": 26
+                    },
+                    "endNode": {
+                      "soc": {
+                        "State": {
+                          "symbol": {
+                            "node": {
+                              "astNodeId": 232
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              ],
+              "28": [
                 {
                   "State": {
                     "startState": {
@@ -621,46 +742,23 @@
                   }
                 }
               ],
-              "state S3": [
+              "189": [
                 {
-                  "Choice": {
-                    "startChoice": {
-                      "node": {
-                        "astNodeId": 189
-                      }
-                    },
-                    "aNode": {
-                      "astNodeId": 188
-                    },
-                    "endNode": {
-                      "soc": {
-                        "State": {
-                          "symbol": {
-                            "node": {
-                              "astNodeId": 190
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                {
-                  "Initial": {
+                  "State": {
                     "startState": {
                       "node": {
                         "astNodeId": 232
                       }
                     },
                     "aNode": {
-                      "astNodeId": 176
+                      "astNodeId": 197
                     },
                     "endNode": {
                       "soc": {
-                        "State": {
+                        "Choice": {
                           "symbol": {
                             "node": {
-                              "astNodeId": 190
+                              "astNodeId": 189
                             }
                           }
                         }
@@ -669,32 +767,7 @@
                   }
                 }
               ],
-              "choice C": [],
-              "state S2": [
-                {
-                  "Choice": {
-                    "startChoice": {
-                      "node": {
-                        "astNodeId": 27
-                      }
-                    },
-                    "aNode": {
-                      "astNodeId": 26
-                    },
-                    "endNode": {
-                      "soc": {
-                        "State": {
-                          "symbol": {
-                            "node": {
-                              "astNodeId": 232
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              ]
+              "27": []
             }
           },
           "typeOptionMap": {

--- a/tests/state_machine/state_machine_ast.json
+++ b/tests/state_machine/state_machine_ast.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion": "[ fpp version ]",
+  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
   "ast": [
     {
       "members": [

--- a/tests/state_machine/state_machine_ast.json
+++ b/tests/state_machine/state_machine_ast.json
@@ -1,902 +1,996 @@
 {
-  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
-  "ast": [
+  "fppVersion" : "v3.1.0a10-54-g11243e778",
+  "ast" : [
     {
-      "members": [
+      "members" : [
         [
-          ["State machine M"],
+          [
+            "State machine M"
+          ],
           {
-            "DefStateMachine": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "M",
-                    "members": {
-                      "Some": [
+            "DefStateMachine" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "M",
+                    "members" : {
+                      "Some" : [
                         [
-                          ["Action a1"],
+                          [
+                            "Action a1"
+                          ],
                           {
-                            "DefAction": {
-                              "node": {
-                                "AstNode": {
-                                  "data": {
-                                    "name": "a1",
-                                    "typeName": "None"
+                            "DefAction" : {
+                              "node" : {
+                                "AstNode" : {
+                                  "data" : {
+                                    "name" : "a1",
+                                    "typeName" : "None"
                                   },
-                                  "id": 0
+                                  "id" : 0
                                 }
                               }
                             }
                           },
-                          []
+                          [
+                          ]
                         ],
                         [
-                          ["Action a2"],
+                          [
+                            "Action a2"
+                          ],
                           {
-                            "DefAction": {
-                              "node": {
-                                "AstNode": {
-                                  "data": {
-                                    "name": "a2",
-                                    "typeName": "None"
+                            "DefAction" : {
+                              "node" : {
+                                "AstNode" : {
+                                  "data" : {
+                                    "name" : "a2",
+                                    "typeName" : "None"
                                   },
-                                  "id": 1
+                                  "id" : 1
                                 }
                               }
                             }
                           },
-                          []
+                          [
+                          ]
                         ],
                         [
-                          ["Action a3"],
+                          [
+                            "Action a3"
+                          ],
                           {
-                            "DefAction": {
-                              "node": {
-                                "AstNode": {
-                                  "data": {
-                                    "name": "a3",
-                                    "typeName": "None"
+                            "DefAction" : {
+                              "node" : {
+                                "AstNode" : {
+                                  "data" : {
+                                    "name" : "a3",
+                                    "typeName" : "None"
                                   },
-                                  "id": 2
+                                  "id" : 2
                                 }
                               }
                             }
                           },
-                          []
+                          [
+                          ]
                         ],
                         [
-                          ["Action a4"],
+                          [
+                            "Action a4"
+                          ],
                           {
-                            "DefAction": {
-                              "node": {
-                                "AstNode": {
-                                  "data": {
-                                    "name": "a4",
-                                    "typeName": {
-                                      "Some": {
-                                        "AstNode": {
-                                          "data": {
-                                            "TypeNameInt": {
-                                              "name": {
-                                                "U32": {}
+                            "DefAction" : {
+                              "node" : {
+                                "AstNode" : {
+                                  "data" : {
+                                    "name" : "a4",
+                                    "typeName" : {
+                                      "Some" : {
+                                        "AstNode" : {
+                                          "data" : {
+                                            "TypeNameInt" : {
+                                              "name" : {
+                                                "U32" : {
+                                                  
+                                                }
                                               }
                                             }
                                           },
-                                          "id": 3
+                                          "id" : 3
                                         }
                                       }
                                     }
                                   },
-                                  "id": 4
+                                  "id" : 4
                                 }
                               }
                             }
                           },
-                          []
+                          [
+                          ]
                         ],
                         [
-                          ["Guard g1"],
+                          [
+                            "Guard g1"
+                          ],
                           {
-                            "DefGuard": {
-                              "node": {
-                                "AstNode": {
-                                  "data": {
-                                    "name": "g1",
-                                    "typeName": "None"
+                            "DefGuard" : {
+                              "node" : {
+                                "AstNode" : {
+                                  "data" : {
+                                    "name" : "g1",
+                                    "typeName" : "None"
                                   },
-                                  "id": 5
+                                  "id" : 5
                                 }
                               }
                             }
                           },
-                          []
+                          [
+                          ]
                         ],
                         [
-                          ["Guard g2"],
+                          [
+                            "Guard g2"
+                          ],
                           {
-                            "DefGuard": {
-                              "node": {
-                                "AstNode": {
-                                  "data": {
-                                    "name": "g2",
-                                    "typeName": {
-                                      "Some": {
-                                        "AstNode": {
-                                          "data": {
-                                            "TypeNameInt": {
-                                              "name": {
-                                                "U32": {}
+                            "DefGuard" : {
+                              "node" : {
+                                "AstNode" : {
+                                  "data" : {
+                                    "name" : "g2",
+                                    "typeName" : {
+                                      "Some" : {
+                                        "AstNode" : {
+                                          "data" : {
+                                            "TypeNameInt" : {
+                                              "name" : {
+                                                "U32" : {
+                                                  
+                                                }
                                               }
                                             }
                                           },
-                                          "id": 6
+                                          "id" : 6
                                         }
                                       }
                                     }
                                   },
-                                  "id": 7
+                                  "id" : 7
                                 }
                               }
                             }
                           },
-                          []
+                          [
+                          ]
                         ],
                         [
-                          ["Signal s1"],
+                          [
+                            "Signal s1"
+                          ],
                           {
-                            "DefSignal": {
-                              "node": {
-                                "AstNode": {
-                                  "data": {
-                                    "name": "s1",
-                                    "typeName": {
-                                      "Some": {
-                                        "AstNode": {
-                                          "data": {
-                                            "TypeNameInt": {
-                                              "name": {
-                                                "U32": {}
+                            "DefSignal" : {
+                              "node" : {
+                                "AstNode" : {
+                                  "data" : {
+                                    "name" : "s1",
+                                    "typeName" : {
+                                      "Some" : {
+                                        "AstNode" : {
+                                          "data" : {
+                                            "TypeNameInt" : {
+                                              "name" : {
+                                                "U32" : {
+                                                  
+                                                }
                                               }
                                             }
                                           },
-                                          "id": 8
+                                          "id" : 8
                                         }
                                       }
                                     }
                                   },
-                                  "id": 9
+                                  "id" : 9
                                 }
                               }
                             }
                           },
-                          []
+                          [
+                          ]
                         ],
                         [
-                          ["Signal s2"],
+                          [
+                            "Signal s2"
+                          ],
                           {
-                            "DefSignal": {
-                              "node": {
-                                "AstNode": {
-                                  "data": {
-                                    "name": "s2",
-                                    "typeName": "None"
+                            "DefSignal" : {
+                              "node" : {
+                                "AstNode" : {
+                                  "data" : {
+                                    "name" : "s2",
+                                    "typeName" : "None"
                                   },
-                                  "id": 10
+                                  "id" : 10
                                 }
                               }
                             }
                           },
-                          []
+                          [
+                          ]
                         ],
                         [
-                          ["Signal s3"],
+                          [
+                            "Signal s3"
+                          ],
                           {
-                            "DefSignal": {
-                              "node": {
-                                "AstNode": {
-                                  "data": {
-                                    "name": "s3",
-                                    "typeName": "None"
+                            "DefSignal" : {
+                              "node" : {
+                                "AstNode" : {
+                                  "data" : {
+                                    "name" : "s3",
+                                    "typeName" : "None"
                                   },
-                                  "id": 11
+                                  "id" : 11
                                 }
                               }
                             }
                           },
-                          []
+                          [
+                          ]
                         ],
                         [
-                          ["Signal s4"],
+                          [
+                            "Signal s4"
+                          ],
                           {
-                            "DefSignal": {
-                              "node": {
-                                "AstNode": {
-                                  "data": {
-                                    "name": "s4",
-                                    "typeName": "None"
+                            "DefSignal" : {
+                              "node" : {
+                                "AstNode" : {
+                                  "data" : {
+                                    "name" : "s4",
+                                    "typeName" : "None"
                                   },
-                                  "id": 12
+                                  "id" : 12
                                 }
                               }
                             }
                           },
-                          []
+                          [
+                          ]
                         ],
                         [
-                          ["Signal s5"],
+                          [
+                            "Signal s5"
+                          ],
                           {
-                            "DefSignal": {
-                              "node": {
-                                "AstNode": {
-                                  "data": {
-                                    "name": "s5",
-                                    "typeName": "None"
+                            "DefSignal" : {
+                              "node" : {
+                                "AstNode" : {
+                                  "data" : {
+                                    "name" : "s5",
+                                    "typeName" : "None"
                                   },
-                                  "id": 13
+                                  "id" : 13
                                 }
                               }
                             }
                           },
-                          []
+                          [
+                          ]
                         ],
                         [
-                          ["Signal s6"],
+                          [
+                            "Signal s6"
+                          ],
                           {
-                            "DefSignal": {
-                              "node": {
-                                "AstNode": {
-                                  "data": {
-                                    "name": "s6",
-                                    "typeName": "None"
+                            "DefSignal" : {
+                              "node" : {
+                                "AstNode" : {
+                                  "data" : {
+                                    "name" : "s6",
+                                    "typeName" : "None"
                                   },
-                                  "id": 14
+                                  "id" : 14
                                 }
                               }
                             }
                           },
-                          []
+                          [
+                          ]
                         ],
                         [
-                          ["Initial transition"],
+                          [
+                            "Initial transition"
+                          ],
                           {
-                            "SpecInitialTransition": {
-                              "node": {
-                                "AstNode": {
-                                  "data": {
-                                    "transition": {
-                                      "AstNode": {
-                                        "data": {
-                                          "actions": [
+                            "SpecInitialTransition" : {
+                              "node" : {
+                                "AstNode" : {
+                                  "data" : {
+                                    "transition" : {
+                                      "AstNode" : {
+                                        "data" : {
+                                          "actions" : [
                                             {
-                                              "AstNode": {
-                                                "data": "a1",
-                                                "id": 15
+                                              "AstNode" : {
+                                                "data" : "a1",
+                                                "id" : 15
                                               }
                                             }
                                           ],
-                                          "target": {
-                                            "AstNode": {
-                                              "data": {
-                                                "Unqualified": {
-                                                  "name": "C"
+                                          "target" : {
+                                            "AstNode" : {
+                                              "data" : {
+                                                "Unqualified" : {
+                                                  "name" : "C"
                                                 }
                                               },
-                                              "id": 17
+                                              "id" : 17
                                             }
                                           }
                                         },
-                                        "id": 18
+                                        "id" : 18
                                       }
                                     }
                                   },
-                                  "id": 19
+                                  "id" : 19
                                 }
                               }
                             }
                           },
-                          []
+                          [
+                          ]
                         ],
                         [
-                          ["Choice C"],
+                          [
+                            "Choice C"
+                          ],
                           {
-                            "DefChoice": {
-                              "node": {
-                                "AstNode": {
-                                  "data": {
-                                    "name": "C",
-                                    "guard": {
-                                      "AstNode": {
-                                        "data": "g1",
-                                        "id": 20
+                            "DefChoice" : {
+                              "node" : {
+                                "AstNode" : {
+                                  "data" : {
+                                    "name" : "C",
+                                    "guard" : {
+                                      "AstNode" : {
+                                        "data" : "g1",
+                                        "id" : 20
                                       }
                                     },
-                                    "ifTransition": {
-                                      "AstNode": {
-                                        "data": {
-                                          "actions": [],
-                                          "target": {
-                                            "AstNode": {
-                                              "data": {
-                                                "Unqualified": {
-                                                  "name": "S1"
+                                    "ifTransition" : {
+                                      "AstNode" : {
+                                        "data" : {
+                                          "actions" : [
+                                          ],
+                                          "target" : {
+                                            "AstNode" : {
+                                              "data" : {
+                                                "Unqualified" : {
+                                                  "name" : "S1"
                                                 }
                                               },
-                                              "id": 22
+                                              "id" : 22
                                             }
                                           }
                                         },
-                                        "id": 23
+                                        "id" : 23
                                       }
                                     },
-                                    "elseTransition": {
-                                      "AstNode": {
-                                        "data": {
-                                          "actions": [],
-                                          "target": {
-                                            "AstNode": {
-                                              "data": {
-                                                "Unqualified": {
-                                                  "name": "S2"
+                                    "elseTransition" : {
+                                      "AstNode" : {
+                                        "data" : {
+                                          "actions" : [
+                                          ],
+                                          "target" : {
+                                            "AstNode" : {
+                                              "data" : {
+                                                "Unqualified" : {
+                                                  "name" : "S2"
                                                 }
                                               },
-                                              "id": 25
+                                              "id" : 25
                                             }
                                           }
                                         },
-                                        "id": 26
+                                        "id" : 26
                                       }
                                     }
                                   },
-                                  "id": 27
+                                  "id" : 27
                                 }
                               }
                             }
                           },
-                          []
+                          [
+                          ]
                         ],
                         [
-                          ["State S1"],
+                          [
+                            "State S1"
+                          ],
                           {
-                            "DefState": {
-                              "node": {
-                                "AstNode": {
-                                  "data": {
-                                    "name": "S1",
-                                    "members": []
+                            "DefState" : {
+                              "node" : {
+                                "AstNode" : {
+                                  "data" : {
+                                    "name" : "S1",
+                                    "members" : [
+                                    ]
                                   },
-                                  "id": 28
+                                  "id" : 28
                                 }
                               }
                             }
                           },
-                          []
+                          [
+                          ]
                         ],
                         [
-                          ["State S2"],
+                          [
+                            "State S2"
+                          ],
                           {
-                            "DefState": {
-                              "node": {
-                                "AstNode": {
-                                  "data": {
-                                    "name": "S2",
-                                    "members": [
+                            "DefState" : {
+                              "node" : {
+                                "AstNode" : {
+                                  "data" : {
+                                    "name" : "S2",
+                                    "members" : [
                                       [
-                                        [],
+                                        [
+                                        ],
                                         {
-                                          "SpecStateEntry": {
-                                            "node": {
-                                              "AstNode": {
-                                                "data": {
-                                                  "actions": [
+                                          "SpecStateEntry" : {
+                                            "node" : {
+                                              "AstNode" : {
+                                                "data" : {
+                                                  "actions" : [
                                                     {
-                                                      "AstNode": {
-                                                        "data": "a1",
-                                                        "id": 165
+                                                      "AstNode" : {
+                                                        "data" : "a1",
+                                                        "id" : 165
                                                       }
                                                     },
                                                     {
-                                                      "AstNode": {
-                                                        "data": "a2",
-                                                        "id": 166
+                                                      "AstNode" : {
+                                                        "data" : "a2",
+                                                        "id" : 166
                                                       }
                                                     }
                                                   ]
                                                 },
-                                                "id": 167
+                                                "id" : 167
                                               }
                                             }
                                           }
                                         },
-                                        []
+                                        [
+                                        ]
                                       ],
                                       [
-                                        [],
+                                        [
+                                        ],
                                         {
-                                          "SpecStateExit": {
-                                            "node": {
-                                              "AstNode": {
-                                                "data": {
-                                                  "actions": [
+                                          "SpecStateExit" : {
+                                            "node" : {
+                                              "AstNode" : {
+                                                "data" : {
+                                                  "actions" : [
                                                     {
-                                                      "AstNode": {
-                                                        "data": "a1",
-                                                        "id": 168
+                                                      "AstNode" : {
+                                                        "data" : "a1",
+                                                        "id" : 168
                                                       }
                                                     },
                                                     {
-                                                      "AstNode": {
-                                                        "data": "a2",
-                                                        "id": 169
+                                                      "AstNode" : {
+                                                        "data" : "a2",
+                                                        "id" : 169
                                                       }
                                                     }
                                                   ]
                                                 },
-                                                "id": 170
+                                                "id" : 170
                                               }
                                             }
                                           }
                                         },
-                                        []
+                                        [
+                                        ]
                                       ],
                                       [
-                                        ["Initial transition"],
+                                        [
+                                          "Initial transition"
+                                        ],
                                         {
-                                          "SpecInitialTransition": {
-                                            "node": {
-                                              "AstNode": {
-                                                "data": {
-                                                  "transition": {
-                                                    "AstNode": {
-                                                      "data": {
-                                                        "actions": [
+                                          "SpecInitialTransition" : {
+                                            "node" : {
+                                              "AstNode" : {
+                                                "data" : {
+                                                  "transition" : {
+                                                    "AstNode" : {
+                                                      "data" : {
+                                                        "actions" : [
                                                           {
-                                                            "AstNode": {
-                                                              "data": "a1",
-                                                              "id": 171
+                                                            "AstNode" : {
+                                                              "data" : "a1",
+                                                              "id" : 171
                                                             }
                                                           },
                                                           {
-                                                            "AstNode": {
-                                                              "data": "a2",
-                                                              "id": 172
+                                                            "AstNode" : {
+                                                              "data" : "a2",
+                                                              "id" : 172
                                                             }
                                                           }
                                                         ],
-                                                        "target": {
-                                                          "AstNode": {
-                                                            "data": {
-                                                              "Unqualified": {
-                                                                "name": "S3"
+                                                        "target" : {
+                                                          "AstNode" : {
+                                                            "data" : {
+                                                              "Unqualified" : {
+                                                                "name" : "S3"
                                                               }
                                                             },
-                                                            "id": 174
+                                                            "id" : 174
                                                           }
                                                         }
                                                       },
-                                                      "id": 175
+                                                      "id" : 175
                                                     }
                                                   }
                                                 },
-                                                "id": 176
+                                                "id" : 176
                                               }
                                             }
                                           }
                                         },
-                                        []
+                                        [
+                                        ]
                                       ],
                                       [
-                                        ["Choice C"],
+                                        [
+                                          "Choice C"
+                                        ],
                                         {
-                                          "DefChoice": {
-                                            "node": {
-                                              "AstNode": {
-                                                "data": {
-                                                  "name": "C",
-                                                  "guard": {
-                                                    "AstNode": {
-                                                      "data": "g1",
-                                                      "id": 177
+                                          "DefChoice" : {
+                                            "node" : {
+                                              "AstNode" : {
+                                                "data" : {
+                                                  "name" : "C",
+                                                  "guard" : {
+                                                    "AstNode" : {
+                                                      "data" : "g1",
+                                                      "id" : 177
                                                     }
                                                   },
-                                                  "ifTransition": {
-                                                    "AstNode": {
-                                                      "data": {
-                                                        "actions": [
+                                                  "ifTransition" : {
+                                                    "AstNode" : {
+                                                      "data" : {
+                                                        "actions" : [
                                                           {
-                                                            "AstNode": {
-                                                              "data": "a1",
-                                                              "id": 178
+                                                            "AstNode" : {
+                                                              "data" : "a1",
+                                                              "id" : 178
                                                             }
                                                           },
                                                           {
-                                                            "AstNode": {
-                                                              "data": "a2",
-                                                              "id": 179
+                                                            "AstNode" : {
+                                                              "data" : "a2",
+                                                              "id" : 179
                                                             }
                                                           }
                                                         ],
-                                                        "target": {
-                                                          "AstNode": {
-                                                            "data": {
-                                                              "Unqualified": {
-                                                                "name": "S1"
+                                                        "target" : {
+                                                          "AstNode" : {
+                                                            "data" : {
+                                                              "Unqualified" : {
+                                                                "name" : "S1"
                                                               }
                                                             },
-                                                            "id": 181
+                                                            "id" : 181
                                                           }
                                                         }
                                                       },
-                                                      "id": 182
+                                                      "id" : 182
                                                     }
                                                   },
-                                                  "elseTransition": {
-                                                    "AstNode": {
-                                                      "data": {
-                                                        "actions": [
+                                                  "elseTransition" : {
+                                                    "AstNode" : {
+                                                      "data" : {
+                                                        "actions" : [
                                                           {
-                                                            "AstNode": {
-                                                              "data": "a2",
-                                                              "id": 183
+                                                            "AstNode" : {
+                                                              "data" : "a2",
+                                                              "id" : 183
                                                             }
                                                           },
                                                           {
-                                                            "AstNode": {
-                                                              "data": "a3",
-                                                              "id": 184
+                                                            "AstNode" : {
+                                                              "data" : "a3",
+                                                              "id" : 184
                                                             }
                                                           }
                                                         ],
-                                                        "target": {
-                                                          "AstNode": {
-                                                            "data": {
-                                                              "Qualified": {
-                                                                "qualifier": {
-                                                                  "AstNode": {
-                                                                    "data": {
-                                                                      "Unqualified": {
-                                                                        "name": "S2"
+                                                        "target" : {
+                                                          "AstNode" : {
+                                                            "data" : {
+                                                              "Qualified" : {
+                                                                "qualifier" : {
+                                                                  "AstNode" : {
+                                                                    "data" : {
+                                                                      "Unqualified" : {
+                                                                        "name" : "S2"
                                                                       }
                                                                     },
-                                                                    "id": 185
+                                                                    "id" : 185
                                                                   }
                                                                 },
-                                                                "name": {
-                                                                  "AstNode": {
-                                                                    "data": "S3",
-                                                                    "id": 186
+                                                                "name" : {
+                                                                  "AstNode" : {
+                                                                    "data" : "S3",
+                                                                    "id" : 186
                                                                   }
                                                                 }
                                                               }
                                                             },
-                                                            "id": 187
+                                                            "id" : 187
                                                           }
                                                         }
                                                       },
-                                                      "id": 188
+                                                      "id" : 188
                                                     }
                                                   }
                                                 },
-                                                "id": 189
+                                                "id" : 189
                                               }
                                             }
                                           }
                                         },
-                                        []
+                                        [
+                                        ]
                                       ],
                                       [
-                                        ["State S3"],
+                                        [
+                                          "State S3"
+                                        ],
                                         {
-                                          "DefState": {
-                                            "node": {
-                                              "AstNode": {
-                                                "data": {
-                                                  "name": "S3",
-                                                  "members": []
+                                          "DefState" : {
+                                            "node" : {
+                                              "AstNode" : {
+                                                "data" : {
+                                                  "name" : "S3",
+                                                  "members" : [
+                                                  ]
                                                 },
-                                                "id": 190
+                                                "id" : 190
                                               }
                                             }
                                           }
                                         },
-                                        []
+                                        [
+                                        ]
                                       ],
                                       [
-                                        ["Transition to S1"],
+                                        [
+                                          "Transition to S1"
+                                        ],
                                         {
-                                          "SpecStateTransition": {
-                                            "node": {
-                                              "AstNode": {
-                                                "data": {
-                                                  "signal": {
-                                                    "AstNode": {
-                                                      "data": "s1",
-                                                      "id": 191
+                                          "SpecStateTransition" : {
+                                            "node" : {
+                                              "AstNode" : {
+                                                "data" : {
+                                                  "signal" : {
+                                                    "AstNode" : {
+                                                      "data" : "s1",
+                                                      "id" : 191
                                                     }
                                                   },
-                                                  "guard": {
-                                                    "Some": {
-                                                      "AstNode": {
-                                                        "data": "g1",
-                                                        "id": 192
+                                                  "guard" : {
+                                                    "Some" : {
+                                                      "AstNode" : {
+                                                        "data" : "g1",
+                                                        "id" : 192
                                                       }
                                                     }
                                                   },
-                                                  "transitionOrDo": {
-                                                    "Transition": {
-                                                      "transition": {
-                                                        "AstNode": {
-                                                          "data": {
-                                                            "actions": [
+                                                  "transitionOrDo" : {
+                                                    "Transition" : {
+                                                      "transition" : {
+                                                        "AstNode" : {
+                                                          "data" : {
+                                                            "actions" : [
                                                               {
-                                                                "AstNode": {
-                                                                  "data": "a1",
-                                                                  "id": 193
+                                                                "AstNode" : {
+                                                                  "data" : "a1",
+                                                                  "id" : 193
                                                                 }
                                                               }
                                                             ],
-                                                            "target": {
-                                                              "AstNode": {
-                                                                "data": {
-                                                                  "Unqualified": {
-                                                                    "name": "C"
+                                                            "target" : {
+                                                              "AstNode" : {
+                                                                "data" : {
+                                                                  "Unqualified" : {
+                                                                    "name" : "C"
                                                                   }
                                                                 },
-                                                                "id": 195
+                                                                "id" : 195
                                                               }
                                                             }
                                                           },
-                                                          "id": 196
+                                                          "id" : 196
                                                         }
                                                       }
                                                     }
                                                   }
                                                 },
-                                                "id": 197
+                                                "id" : 197
                                               }
                                             }
                                           }
                                         },
-                                        []
+                                        [
+                                        ]
                                       ],
                                       [
-                                        [],
+                                        [
+                                        ],
                                         {
-                                          "SpecStateTransition": {
-                                            "node": {
-                                              "AstNode": {
-                                                "data": {
-                                                  "signal": {
-                                                    "AstNode": {
-                                                      "data": "s2",
-                                                      "id": 198
+                                          "SpecStateTransition" : {
+                                            "node" : {
+                                              "AstNode" : {
+                                                "data" : {
+                                                  "signal" : {
+                                                    "AstNode" : {
+                                                      "data" : "s2",
+                                                      "id" : 198
                                                     }
                                                   },
-                                                  "guard": {
-                                                    "Some": {
-                                                      "AstNode": {
-                                                        "data": "g1",
-                                                        "id": 199
+                                                  "guard" : {
+                                                    "Some" : {
+                                                      "AstNode" : {
+                                                        "data" : "g1",
+                                                        "id" : 199
                                                       }
                                                     }
                                                   },
-                                                  "transitionOrDo": {
-                                                    "Transition": {
-                                                      "transition": {
-                                                        "AstNode": {
-                                                          "data": {
-                                                            "actions": [],
-                                                            "target": {
-                                                              "AstNode": {
-                                                                "data": {
-                                                                  "Unqualified": {
-                                                                    "name": "S1"
+                                                  "transitionOrDo" : {
+                                                    "Transition" : {
+                                                      "transition" : {
+                                                        "AstNode" : {
+                                                          "data" : {
+                                                            "actions" : [
+                                                            ],
+                                                            "target" : {
+                                                              "AstNode" : {
+                                                                "data" : {
+                                                                  "Unqualified" : {
+                                                                    "name" : "S1"
                                                                   }
                                                                 },
-                                                                "id": 201
+                                                                "id" : 201
                                                               }
                                                             }
                                                           },
-                                                          "id": 202
+                                                          "id" : 202
                                                         }
                                                       }
                                                     }
                                                   }
                                                 },
-                                                "id": 203
+                                                "id" : 203
                                               }
                                             }
                                           }
                                         },
-                                        []
+                                        [
+                                        ]
                                       ],
                                       [
-                                        ["Transition to S1"],
+                                        [
+                                          "Transition to S1"
+                                        ],
                                         {
-                                          "SpecStateTransition": {
-                                            "node": {
-                                              "AstNode": {
-                                                "data": {
-                                                  "signal": {
-                                                    "AstNode": {
-                                                      "data": "s3",
-                                                      "id": 204
+                                          "SpecStateTransition" : {
+                                            "node" : {
+                                              "AstNode" : {
+                                                "data" : {
+                                                  "signal" : {
+                                                    "AstNode" : {
+                                                      "data" : "s3",
+                                                      "id" : 204
                                                     }
                                                   },
-                                                  "guard": {
-                                                    "Some": {
-                                                      "AstNode": {
-                                                        "data": "g1",
-                                                        "id": 205
+                                                  "guard" : {
+                                                    "Some" : {
+                                                      "AstNode" : {
+                                                        "data" : "g1",
+                                                        "id" : 205
                                                       }
                                                     }
                                                   },
-                                                  "transitionOrDo": {
-                                                    "Transition": {
-                                                      "transition": {
-                                                        "AstNode": {
-                                                          "data": {
-                                                            "actions": [],
-                                                            "target": {
-                                                              "AstNode": {
-                                                                "data": {
-                                                                  "Unqualified": {
-                                                                    "name": "S1"
+                                                  "transitionOrDo" : {
+                                                    "Transition" : {
+                                                      "transition" : {
+                                                        "AstNode" : {
+                                                          "data" : {
+                                                            "actions" : [
+                                                            ],
+                                                            "target" : {
+                                                              "AstNode" : {
+                                                                "data" : {
+                                                                  "Unqualified" : {
+                                                                    "name" : "S1"
                                                                   }
                                                                 },
-                                                                "id": 207
+                                                                "id" : 207
                                                               }
                                                             }
                                                           },
-                                                          "id": 208
+                                                          "id" : 208
                                                         }
                                                       }
                                                     }
                                                   }
                                                 },
-                                                "id": 209
+                                                "id" : 209
                                               }
                                             }
                                           }
                                         },
-                                        []
+                                        [
+                                        ]
                                       ],
                                       [
-                                        ["Transition to S1"],
+                                        [
+                                          "Transition to S1"
+                                        ],
                                         {
-                                          "SpecStateTransition": {
-                                            "node": {
-                                              "AstNode": {
-                                                "data": {
-                                                  "signal": {
-                                                    "AstNode": {
-                                                      "data": "s4",
-                                                      "id": 210
+                                          "SpecStateTransition" : {
+                                            "node" : {
+                                              "AstNode" : {
+                                                "data" : {
+                                                  "signal" : {
+                                                    "AstNode" : {
+                                                      "data" : "s4",
+                                                      "id" : 210
                                                     }
                                                   },
-                                                  "guard": "None",
-                                                  "transitionOrDo": {
-                                                    "Transition": {
-                                                      "transition": {
-                                                        "AstNode": {
-                                                          "data": {
-                                                            "actions": [],
-                                                            "target": {
-                                                              "AstNode": {
-                                                                "data": {
-                                                                  "Unqualified": {
-                                                                    "name": "S1"
+                                                  "guard" : "None",
+                                                  "transitionOrDo" : {
+                                                    "Transition" : {
+                                                      "transition" : {
+                                                        "AstNode" : {
+                                                          "data" : {
+                                                            "actions" : [
+                                                            ],
+                                                            "target" : {
+                                                              "AstNode" : {
+                                                                "data" : {
+                                                                  "Unqualified" : {
+                                                                    "name" : "S1"
                                                                   }
                                                                 },
-                                                                "id": 212
+                                                                "id" : 212
                                                               }
                                                             }
                                                           },
-                                                          "id": 213
+                                                          "id" : 213
                                                         }
                                                       }
                                                     }
                                                   }
                                                 },
-                                                "id": 214
+                                                "id" : 214
                                               }
                                             }
                                           }
                                         },
-                                        []
+                                        [
+                                        ]
                                       ],
                                       [
-                                        ["Internal transition"],
+                                        [
+                                          "Internal transition"
+                                        ],
                                         {
-                                          "SpecStateTransition": {
-                                            "node": {
-                                              "AstNode": {
-                                                "data": {
-                                                  "signal": {
-                                                    "AstNode": {
-                                                      "data": "s5",
-                                                      "id": 215
+                                          "SpecStateTransition" : {
+                                            "node" : {
+                                              "AstNode" : {
+                                                "data" : {
+                                                  "signal" : {
+                                                    "AstNode" : {
+                                                      "data" : "s5",
+                                                      "id" : 215
                                                     }
                                                   },
-                                                  "guard": {
-                                                    "Some": {
-                                                      "AstNode": {
-                                                        "data": "g1",
-                                                        "id": 216
+                                                  "guard" : {
+                                                    "Some" : {
+                                                      "AstNode" : {
+                                                        "data" : "g1",
+                                                        "id" : 216
                                                       }
                                                     }
                                                   },
-                                                  "transitionOrDo": {
-                                                    "Do": {
-                                                      "actions": [
+                                                  "transitionOrDo" : {
+                                                    "Do" : {
+                                                      "actions" : [
                                                         {
-                                                          "AstNode": {
-                                                            "data": "a1",
-                                                            "id": 218
+                                                          "AstNode" : {
+                                                            "data" : "a1",
+                                                            "id" : 218
                                                           }
                                                         }
                                                       ]
                                                     }
                                                   }
                                                 },
-                                                "id": 219
+                                                "id" : 219
                                               }
                                             }
                                           }
                                         },
-                                        []
+                                        [
+                                        ]
                                       ],
                                       [
-                                        ["Internal transition"],
+                                        [
+                                          "Internal transition"
+                                        ],
                                         {
-                                          "SpecStateTransition": {
-                                            "node": {
-                                              "AstNode": {
-                                                "data": {
-                                                  "signal": {
-                                                    "AstNode": {
-                                                      "data": "s6",
-                                                      "id": 228
+                                          "SpecStateTransition" : {
+                                            "node" : {
+                                              "AstNode" : {
+                                                "data" : {
+                                                  "signal" : {
+                                                    "AstNode" : {
+                                                      "data" : "s6",
+                                                      "id" : 228
                                                     }
                                                   },
-                                                  "guard": "None",
-                                                  "transitionOrDo": {
-                                                    "Do": {
-                                                      "actions": [
+                                                  "guard" : "None",
+                                                  "transitionOrDo" : {
+                                                    "Do" : {
+                                                      "actions" : [
                                                         {
-                                                          "AstNode": {
-                                                            "data": "a1",
-                                                            "id": 230
+                                                          "AstNode" : {
+                                                            "data" : "a1",
+                                                            "id" : 230
                                                           }
                                                         }
                                                       ]
                                                     }
                                                   }
                                                 },
-                                                "id": 231
+                                                "id" : 231
                                               }
                                             }
                                           }
                                         },
-                                        []
+                                        [
+                                        ]
                                       ]
                                     ]
                                   },
-                                  "id": 232
+                                  "id" : 232
                                 }
                               }
                             }
                           },
-                          []
+                          [
+                          ]
                         ]
                       ]
                     }
                   },
-                  "id": 233
+                  "id" : 233
                 }
               }
             }
           },
-          []
+          [
+          ]
         ]
       ]
     }

--- a/tests/state_machine/state_machine_locations.json
+++ b/tests/state_machine/state_machine_locations.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion": "[ fpp version ]",
+  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
   "locationMap": {
     "0": {
       "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",

--- a/tests/state_machine/state_machine_locations.json
+++ b/tests/state_machine/state_machine_locations.json
@@ -1,1175 +1,1175 @@
 {
-  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
-  "locationMap": {
-    "0": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "5.3",
-      "includingLoc": "None"
-    },
-    "1": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "8.3",
-      "includingLoc": "None"
-    },
-    "2": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "11.3",
-      "includingLoc": "None"
-    },
-    "3": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "14.14",
-      "includingLoc": "None"
-    },
-    "4": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "14.3",
-      "includingLoc": "None"
-    },
-    "5": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "17.3",
-      "includingLoc": "None"
-    },
-    "6": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "20.13",
-      "includingLoc": "None"
-    },
-    "7": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "20.3",
-      "includingLoc": "None"
-    },
-    "8": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "23.14",
-      "includingLoc": "None"
-    },
-    "9": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "23.3",
-      "includingLoc": "None"
-    },
-    "10": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "26.3",
-      "includingLoc": "None"
-    },
-    "11": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "29.3",
-      "includingLoc": "None"
-    },
-    "12": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "32.3",
-      "includingLoc": "None"
-    },
-    "13": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "35.3",
-      "includingLoc": "None"
-    },
-    "14": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "38.3",
-      "includingLoc": "None"
-    },
-    "15": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "41.16",
-      "includingLoc": "None"
-    },
-    "16": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "41.27",
-      "includingLoc": "None"
-    },
-    "17": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "41.27",
-      "includingLoc": "None"
-    },
-    "18": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "41.11",
-      "includingLoc": "None"
-    },
-    "19": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "41.3",
-      "includingLoc": "None"
-    },
-    "20": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "44.17",
-      "includingLoc": "None"
-    },
-    "21": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "44.26",
-      "includingLoc": "None"
-    },
-    "22": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "44.26",
-      "includingLoc": "None"
-    },
-    "23": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "44.20",
-      "includingLoc": "None"
-    },
-    "24": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "44.40",
-      "includingLoc": "None"
-    },
-    "25": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "44.40",
-      "includingLoc": "None"
-    },
-    "26": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "44.34",
-      "includingLoc": "None"
-    },
-    "27": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "44.3",
-      "includingLoc": "None"
-    },
-    "28": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "47.3",
-      "includingLoc": "None"
-    },
-    "29": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "52.16",
-      "includingLoc": "None"
-    },
-    "30": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "52.20",
-      "includingLoc": "None"
-    },
-    "31": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "52.5",
-      "includingLoc": "None"
-    },
-    "32": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "53.15",
-      "includingLoc": "None"
-    },
-    "33": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "53.19",
-      "includingLoc": "None"
-    },
-    "34": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "53.5",
-      "includingLoc": "None"
-    },
-    "35": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "56.18",
-      "includingLoc": "None"
-    },
-    "36": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "56.22",
-      "includingLoc": "None"
-    },
-    "37": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "56.33",
-      "includingLoc": "None"
-    },
-    "38": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "56.33",
-      "includingLoc": "None"
-    },
-    "39": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "56.13",
-      "includingLoc": "None"
-    },
-    "40": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "56.5",
-      "includingLoc": "None"
-    },
-    "41": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "59.19",
-      "includingLoc": "None"
-    },
-    "42": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "59.27",
-      "includingLoc": "None"
-    },
-    "43": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "59.31",
-      "includingLoc": "None"
-    },
-    "44": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "59.42",
-      "includingLoc": "None"
-    },
-    "45": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "59.42",
-      "includingLoc": "None"
-    },
-    "46": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "59.22",
-      "includingLoc": "None"
-    },
-    "47": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "59.55",
-      "includingLoc": "None"
-    },
-    "48": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "59.59",
-      "includingLoc": "None"
-    },
-    "49": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "59.70",
-      "includingLoc": "None"
-    },
-    "50": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "59.73",
-      "includingLoc": "None"
-    },
-    "51": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "59.70",
-      "includingLoc": "None"
-    },
-    "52": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "59.50",
-      "includingLoc": "None"
-    },
-    "53": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "59.5",
-      "includingLoc": "None"
-    },
-    "54": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "62.5",
-      "includingLoc": "None"
-    },
-    "55": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "65.8",
-      "includingLoc": "None"
-    },
-    "56": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "65.14",
-      "includingLoc": "None"
-    },
-    "57": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "65.22",
-      "includingLoc": "None"
-    },
-    "58": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "65.33",
-      "includingLoc": "None"
-    },
-    "59": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "65.33",
-      "includingLoc": "None"
-    },
-    "60": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "65.17",
-      "includingLoc": "None"
-    },
-    "61": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "65.5",
-      "includingLoc": "None"
-    },
-    "62": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "66.8",
-      "includingLoc": "None"
-    },
-    "63": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "66.14",
-      "includingLoc": "None"
-    },
-    "64": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "66.23",
-      "includingLoc": "None"
-    },
-    "65": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "66.23",
-      "includingLoc": "None"
-    },
-    "66": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "66.17",
-      "includingLoc": "None"
-    },
-    "67": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "66.5",
-      "includingLoc": "None"
-    },
-    "68": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "69.8",
-      "includingLoc": "None"
-    },
-    "69": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "69.14",
-      "includingLoc": "None"
-    },
-    "70": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "69.23",
-      "includingLoc": "None"
-    },
-    "71": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "69.23",
-      "includingLoc": "None"
-    },
-    "72": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "69.17",
-      "includingLoc": "None"
-    },
-    "73": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "69.5",
-      "includingLoc": "None"
-    },
-    "74": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "72.8",
-      "includingLoc": "None"
-    },
-    "75": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "72.17",
-      "includingLoc": "None"
-    },
-    "76": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "72.17",
-      "includingLoc": "None"
-    },
-    "77": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "72.11",
-      "includingLoc": "None"
-    },
-    "78": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "72.5",
-      "includingLoc": "None"
-    },
-    "79": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "75.8",
-      "includingLoc": "None"
-    },
-    "80": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "75.14",
-      "includingLoc": "None"
-    },
-    "81": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "75.22",
-      "includingLoc": "None"
-    },
-    "82": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "75.22",
-      "includingLoc": "None"
-    },
-    "83": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "75.5",
-      "includingLoc": "None"
-    },
-    "84": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "78.8",
-      "includingLoc": "None"
-    },
-    "85": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "78.16",
-      "includingLoc": "None"
-    },
-    "86": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "78.16",
-      "includingLoc": "None"
-    },
-    "87": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "78.5",
-      "includingLoc": "None"
-    },
-    "88": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "78.8",
-      "includingLoc": "None"
-    },
-    "89": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "78.16",
-      "includingLoc": "None"
-    },
-    "90": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "78.16",
-      "includingLoc": "None"
-    },
-    "91": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "78.5",
-      "includingLoc": "None"
-    },
-    "92": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "78.8",
-      "includingLoc": "None"
-    },
-    "93": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "78.16",
-      "includingLoc": "None"
-    },
-    "94": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "78.16",
-      "includingLoc": "None"
-    },
-    "95": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "78.5",
-      "includingLoc": "None"
-    },
-    "96": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "50.3",
-      "includingLoc": "None"
-    },
-    "97": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "52.16",
-      "includingLoc": "None"
-    },
-    "98": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "52.20",
-      "includingLoc": "None"
-    },
-    "99": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "52.5",
-      "includingLoc": "None"
-    },
-    "100": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "53.15",
-      "includingLoc": "None"
-    },
-    "101": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "53.19",
-      "includingLoc": "None"
-    },
-    "102": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "53.5",
-      "includingLoc": "None"
-    },
-    "103": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "56.18",
-      "includingLoc": "None"
-    },
-    "104": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "56.22",
-      "includingLoc": "None"
-    },
-    "105": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "56.33",
-      "includingLoc": "None"
-    },
-    "106": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "56.33",
-      "includingLoc": "None"
-    },
-    "107": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "56.13",
-      "includingLoc": "None"
-    },
-    "108": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "56.5",
-      "includingLoc": "None"
-    },
-    "109": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "59.19",
-      "includingLoc": "None"
-    },
-    "110": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "59.27",
-      "includingLoc": "None"
-    },
-    "111": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "59.31",
-      "includingLoc": "None"
-    },
-    "112": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "59.42",
-      "includingLoc": "None"
-    },
-    "113": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "59.42",
-      "includingLoc": "None"
-    },
-    "114": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "59.22",
-      "includingLoc": "None"
-    },
-    "115": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "59.55",
-      "includingLoc": "None"
-    },
-    "116": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "59.59",
-      "includingLoc": "None"
-    },
-    "117": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "59.70",
-      "includingLoc": "None"
-    },
-    "118": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "59.73",
-      "includingLoc": "None"
-    },
-    "119": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "59.70",
-      "includingLoc": "None"
-    },
-    "120": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "59.50",
-      "includingLoc": "None"
-    },
-    "121": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "59.5",
-      "includingLoc": "None"
-    },
-    "122": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "62.5",
-      "includingLoc": "None"
-    },
-    "123": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "65.8",
-      "includingLoc": "None"
-    },
-    "124": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "65.14",
-      "includingLoc": "None"
-    },
-    "125": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "65.22",
-      "includingLoc": "None"
-    },
-    "126": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "65.33",
-      "includingLoc": "None"
-    },
-    "127": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "65.33",
-      "includingLoc": "None"
-    },
-    "128": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "65.17",
-      "includingLoc": "None"
-    },
-    "129": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "65.5",
-      "includingLoc": "None"
-    },
-    "130": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "66.8",
-      "includingLoc": "None"
-    },
-    "131": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "66.14",
-      "includingLoc": "None"
-    },
-    "132": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "66.23",
-      "includingLoc": "None"
-    },
-    "133": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "66.23",
-      "includingLoc": "None"
-    },
-    "134": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "66.17",
-      "includingLoc": "None"
-    },
-    "135": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "66.5",
-      "includingLoc": "None"
-    },
-    "136": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "69.8",
-      "includingLoc": "None"
-    },
-    "137": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "69.14",
-      "includingLoc": "None"
-    },
-    "138": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "69.23",
-      "includingLoc": "None"
-    },
-    "139": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "69.23",
-      "includingLoc": "None"
-    },
-    "140": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "69.17",
-      "includingLoc": "None"
-    },
-    "141": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "69.5",
-      "includingLoc": "None"
-    },
-    "142": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "72.8",
-      "includingLoc": "None"
-    },
-    "143": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "72.17",
-      "includingLoc": "None"
-    },
-    "144": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "72.17",
-      "includingLoc": "None"
-    },
-    "145": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "72.11",
-      "includingLoc": "None"
-    },
-    "146": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "72.5",
-      "includingLoc": "None"
-    },
-    "147": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "75.8",
-      "includingLoc": "None"
-    },
-    "148": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "75.14",
-      "includingLoc": "None"
-    },
-    "149": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "75.22",
-      "includingLoc": "None"
-    },
-    "150": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "75.22",
-      "includingLoc": "None"
-    },
-    "151": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "75.5",
-      "includingLoc": "None"
-    },
-    "152": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "78.8",
-      "includingLoc": "None"
-    },
-    "153": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "78.16",
-      "includingLoc": "None"
-    },
-    "154": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "78.16",
-      "includingLoc": "None"
-    },
-    "155": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "78.5",
-      "includingLoc": "None"
-    },
-    "156": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "78.8",
-      "includingLoc": "None"
-    },
-    "157": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "78.16",
-      "includingLoc": "None"
-    },
-    "158": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "78.16",
-      "includingLoc": "None"
-    },
-    "159": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "78.5",
-      "includingLoc": "None"
-    },
-    "160": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "78.8",
-      "includingLoc": "None"
-    },
-    "161": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "78.16",
-      "includingLoc": "None"
-    },
-    "162": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "78.16",
-      "includingLoc": "None"
-    },
-    "163": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "78.5",
-      "includingLoc": "None"
-    },
-    "164": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "50.3",
-      "includingLoc": "None"
-    },
-    "165": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "52.16",
-      "includingLoc": "None"
-    },
-    "166": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "52.20",
-      "includingLoc": "None"
-    },
-    "167": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "52.5",
-      "includingLoc": "None"
-    },
-    "168": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "53.15",
-      "includingLoc": "None"
-    },
-    "169": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "53.19",
-      "includingLoc": "None"
-    },
-    "170": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "53.5",
-      "includingLoc": "None"
-    },
-    "171": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "56.18",
-      "includingLoc": "None"
-    },
-    "172": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "56.22",
-      "includingLoc": "None"
-    },
-    "173": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "56.33",
-      "includingLoc": "None"
-    },
-    "174": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "56.33",
-      "includingLoc": "None"
-    },
-    "175": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "56.13",
-      "includingLoc": "None"
-    },
-    "176": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "56.5",
-      "includingLoc": "None"
-    },
-    "177": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "59.19",
-      "includingLoc": "None"
-    },
-    "178": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "59.27",
-      "includingLoc": "None"
-    },
-    "179": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "59.31",
-      "includingLoc": "None"
-    },
-    "180": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "59.42",
-      "includingLoc": "None"
-    },
-    "181": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "59.42",
-      "includingLoc": "None"
-    },
-    "182": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "59.22",
-      "includingLoc": "None"
-    },
-    "183": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "59.55",
-      "includingLoc": "None"
-    },
-    "184": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "59.59",
-      "includingLoc": "None"
-    },
-    "185": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "59.70",
-      "includingLoc": "None"
-    },
-    "186": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "59.73",
-      "includingLoc": "None"
-    },
-    "187": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "59.70",
-      "includingLoc": "None"
-    },
-    "188": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "59.50",
-      "includingLoc": "None"
-    },
-    "189": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "59.5",
-      "includingLoc": "None"
-    },
-    "190": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "62.5",
-      "includingLoc": "None"
-    },
-    "191": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "65.8",
-      "includingLoc": "None"
-    },
-    "192": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "65.14",
-      "includingLoc": "None"
-    },
-    "193": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "65.22",
-      "includingLoc": "None"
-    },
-    "194": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "65.33",
-      "includingLoc": "None"
-    },
-    "195": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "65.33",
-      "includingLoc": "None"
-    },
-    "196": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "65.17",
-      "includingLoc": "None"
-    },
-    "197": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "65.5",
-      "includingLoc": "None"
-    },
-    "198": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "66.8",
-      "includingLoc": "None"
-    },
-    "199": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "66.14",
-      "includingLoc": "None"
-    },
-    "200": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "66.23",
-      "includingLoc": "None"
-    },
-    "201": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "66.23",
-      "includingLoc": "None"
-    },
-    "202": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "66.17",
-      "includingLoc": "None"
-    },
-    "203": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "66.5",
-      "includingLoc": "None"
-    },
-    "204": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "69.8",
-      "includingLoc": "None"
-    },
-    "205": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "69.14",
-      "includingLoc": "None"
-    },
-    "206": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "69.23",
-      "includingLoc": "None"
-    },
-    "207": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "69.23",
-      "includingLoc": "None"
-    },
-    "208": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "69.17",
-      "includingLoc": "None"
-    },
-    "209": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "69.5",
-      "includingLoc": "None"
-    },
-    "210": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "72.8",
-      "includingLoc": "None"
-    },
-    "211": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "72.17",
-      "includingLoc": "None"
-    },
-    "212": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "72.17",
-      "includingLoc": "None"
-    },
-    "213": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "72.11",
-      "includingLoc": "None"
-    },
-    "214": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "72.5",
-      "includingLoc": "None"
-    },
-    "215": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "75.8",
-      "includingLoc": "None"
-    },
-    "216": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "75.14",
-      "includingLoc": "None"
-    },
-    "217": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "75.22",
-      "includingLoc": "None"
-    },
-    "218": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "75.22",
-      "includingLoc": "None"
-    },
-    "219": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "75.5",
-      "includingLoc": "None"
-    },
-    "220": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "78.8",
-      "includingLoc": "None"
-    },
-    "221": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "78.16",
-      "includingLoc": "None"
-    },
-    "222": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "78.16",
-      "includingLoc": "None"
-    },
-    "223": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "78.5",
-      "includingLoc": "None"
-    },
-    "224": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "78.8",
-      "includingLoc": "None"
-    },
-    "225": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "78.16",
-      "includingLoc": "None"
-    },
-    "226": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "78.16",
-      "includingLoc": "None"
-    },
-    "227": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "78.5",
-      "includingLoc": "None"
-    },
-    "228": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "78.8",
-      "includingLoc": "None"
-    },
-    "229": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "78.16",
-      "includingLoc": "None"
-    },
-    "230": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "78.16",
-      "includingLoc": "None"
-    },
-    "231": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "78.5",
-      "includingLoc": "None"
-    },
-    "232": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "50.3",
-      "includingLoc": "None"
-    },
-    "233": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
-      "pos": "2.1",
-      "includingLoc": "None"
+  "fppVersion" : "v3.1.0a10-54-g11243e778",
+  "locationMap" : {
+    "0" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "5.3",
+      "includingLoc" : "None"
+    },
+    "1" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "8.3",
+      "includingLoc" : "None"
+    },
+    "2" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "11.3",
+      "includingLoc" : "None"
+    },
+    "3" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "14.14",
+      "includingLoc" : "None"
+    },
+    "4" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "14.3",
+      "includingLoc" : "None"
+    },
+    "5" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "17.3",
+      "includingLoc" : "None"
+    },
+    "6" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "20.13",
+      "includingLoc" : "None"
+    },
+    "7" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "20.3",
+      "includingLoc" : "None"
+    },
+    "8" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "23.14",
+      "includingLoc" : "None"
+    },
+    "9" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "23.3",
+      "includingLoc" : "None"
+    },
+    "10" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "26.3",
+      "includingLoc" : "None"
+    },
+    "11" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "29.3",
+      "includingLoc" : "None"
+    },
+    "12" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "32.3",
+      "includingLoc" : "None"
+    },
+    "13" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "35.3",
+      "includingLoc" : "None"
+    },
+    "14" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "38.3",
+      "includingLoc" : "None"
+    },
+    "15" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "41.16",
+      "includingLoc" : "None"
+    },
+    "16" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "41.27",
+      "includingLoc" : "None"
+    },
+    "17" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "41.27",
+      "includingLoc" : "None"
+    },
+    "18" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "41.11",
+      "includingLoc" : "None"
+    },
+    "19" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "41.3",
+      "includingLoc" : "None"
+    },
+    "20" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "44.17",
+      "includingLoc" : "None"
+    },
+    "21" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "44.26",
+      "includingLoc" : "None"
+    },
+    "22" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "44.26",
+      "includingLoc" : "None"
+    },
+    "23" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "44.20",
+      "includingLoc" : "None"
+    },
+    "24" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "44.40",
+      "includingLoc" : "None"
+    },
+    "25" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "44.40",
+      "includingLoc" : "None"
+    },
+    "26" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "44.34",
+      "includingLoc" : "None"
+    },
+    "27" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "44.3",
+      "includingLoc" : "None"
+    },
+    "28" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "47.3",
+      "includingLoc" : "None"
+    },
+    "29" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "52.16",
+      "includingLoc" : "None"
+    },
+    "30" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "52.20",
+      "includingLoc" : "None"
+    },
+    "31" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "52.5",
+      "includingLoc" : "None"
+    },
+    "32" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "53.15",
+      "includingLoc" : "None"
+    },
+    "33" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "53.19",
+      "includingLoc" : "None"
+    },
+    "34" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "53.5",
+      "includingLoc" : "None"
+    },
+    "35" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "56.18",
+      "includingLoc" : "None"
+    },
+    "36" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "56.22",
+      "includingLoc" : "None"
+    },
+    "37" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "56.33",
+      "includingLoc" : "None"
+    },
+    "38" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "56.33",
+      "includingLoc" : "None"
+    },
+    "39" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "56.13",
+      "includingLoc" : "None"
+    },
+    "40" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "56.5",
+      "includingLoc" : "None"
+    },
+    "41" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "59.19",
+      "includingLoc" : "None"
+    },
+    "42" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "59.27",
+      "includingLoc" : "None"
+    },
+    "43" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "59.31",
+      "includingLoc" : "None"
+    },
+    "44" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "59.42",
+      "includingLoc" : "None"
+    },
+    "45" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "59.42",
+      "includingLoc" : "None"
+    },
+    "46" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "59.22",
+      "includingLoc" : "None"
+    },
+    "47" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "59.55",
+      "includingLoc" : "None"
+    },
+    "48" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "59.59",
+      "includingLoc" : "None"
+    },
+    "49" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "59.70",
+      "includingLoc" : "None"
+    },
+    "50" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "59.73",
+      "includingLoc" : "None"
+    },
+    "51" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "59.70",
+      "includingLoc" : "None"
+    },
+    "52" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "59.50",
+      "includingLoc" : "None"
+    },
+    "53" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "59.5",
+      "includingLoc" : "None"
+    },
+    "54" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "62.5",
+      "includingLoc" : "None"
+    },
+    "55" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "65.8",
+      "includingLoc" : "None"
+    },
+    "56" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "65.14",
+      "includingLoc" : "None"
+    },
+    "57" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "65.22",
+      "includingLoc" : "None"
+    },
+    "58" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "65.33",
+      "includingLoc" : "None"
+    },
+    "59" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "65.33",
+      "includingLoc" : "None"
+    },
+    "60" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "65.17",
+      "includingLoc" : "None"
+    },
+    "61" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "65.5",
+      "includingLoc" : "None"
+    },
+    "62" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "66.8",
+      "includingLoc" : "None"
+    },
+    "63" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "66.14",
+      "includingLoc" : "None"
+    },
+    "64" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "66.23",
+      "includingLoc" : "None"
+    },
+    "65" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "66.23",
+      "includingLoc" : "None"
+    },
+    "66" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "66.17",
+      "includingLoc" : "None"
+    },
+    "67" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "66.5",
+      "includingLoc" : "None"
+    },
+    "68" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "69.8",
+      "includingLoc" : "None"
+    },
+    "69" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "69.14",
+      "includingLoc" : "None"
+    },
+    "70" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "69.23",
+      "includingLoc" : "None"
+    },
+    "71" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "69.23",
+      "includingLoc" : "None"
+    },
+    "72" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "69.17",
+      "includingLoc" : "None"
+    },
+    "73" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "69.5",
+      "includingLoc" : "None"
+    },
+    "74" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "72.8",
+      "includingLoc" : "None"
+    },
+    "75" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "72.17",
+      "includingLoc" : "None"
+    },
+    "76" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "72.17",
+      "includingLoc" : "None"
+    },
+    "77" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "72.11",
+      "includingLoc" : "None"
+    },
+    "78" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "72.5",
+      "includingLoc" : "None"
+    },
+    "79" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "75.8",
+      "includingLoc" : "None"
+    },
+    "80" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "75.14",
+      "includingLoc" : "None"
+    },
+    "81" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "75.22",
+      "includingLoc" : "None"
+    },
+    "82" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "75.22",
+      "includingLoc" : "None"
+    },
+    "83" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "75.5",
+      "includingLoc" : "None"
+    },
+    "84" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "78.8",
+      "includingLoc" : "None"
+    },
+    "85" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "78.16",
+      "includingLoc" : "None"
+    },
+    "86" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "78.16",
+      "includingLoc" : "None"
+    },
+    "87" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "78.5",
+      "includingLoc" : "None"
+    },
+    "88" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "78.8",
+      "includingLoc" : "None"
+    },
+    "89" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "78.16",
+      "includingLoc" : "None"
+    },
+    "90" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "78.16",
+      "includingLoc" : "None"
+    },
+    "91" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "78.5",
+      "includingLoc" : "None"
+    },
+    "92" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "78.8",
+      "includingLoc" : "None"
+    },
+    "93" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "78.16",
+      "includingLoc" : "None"
+    },
+    "94" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "78.16",
+      "includingLoc" : "None"
+    },
+    "95" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "78.5",
+      "includingLoc" : "None"
+    },
+    "96" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "50.3",
+      "includingLoc" : "None"
+    },
+    "97" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "52.16",
+      "includingLoc" : "None"
+    },
+    "98" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "52.20",
+      "includingLoc" : "None"
+    },
+    "99" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "52.5",
+      "includingLoc" : "None"
+    },
+    "100" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "53.15",
+      "includingLoc" : "None"
+    },
+    "101" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "53.19",
+      "includingLoc" : "None"
+    },
+    "102" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "53.5",
+      "includingLoc" : "None"
+    },
+    "103" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "56.18",
+      "includingLoc" : "None"
+    },
+    "104" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "56.22",
+      "includingLoc" : "None"
+    },
+    "105" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "56.33",
+      "includingLoc" : "None"
+    },
+    "106" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "56.33",
+      "includingLoc" : "None"
+    },
+    "107" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "56.13",
+      "includingLoc" : "None"
+    },
+    "108" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "56.5",
+      "includingLoc" : "None"
+    },
+    "109" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "59.19",
+      "includingLoc" : "None"
+    },
+    "110" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "59.27",
+      "includingLoc" : "None"
+    },
+    "111" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "59.31",
+      "includingLoc" : "None"
+    },
+    "112" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "59.42",
+      "includingLoc" : "None"
+    },
+    "113" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "59.42",
+      "includingLoc" : "None"
+    },
+    "114" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "59.22",
+      "includingLoc" : "None"
+    },
+    "115" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "59.55",
+      "includingLoc" : "None"
+    },
+    "116" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "59.59",
+      "includingLoc" : "None"
+    },
+    "117" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "59.70",
+      "includingLoc" : "None"
+    },
+    "118" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "59.73",
+      "includingLoc" : "None"
+    },
+    "119" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "59.70",
+      "includingLoc" : "None"
+    },
+    "120" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "59.50",
+      "includingLoc" : "None"
+    },
+    "121" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "59.5",
+      "includingLoc" : "None"
+    },
+    "122" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "62.5",
+      "includingLoc" : "None"
+    },
+    "123" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "65.8",
+      "includingLoc" : "None"
+    },
+    "124" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "65.14",
+      "includingLoc" : "None"
+    },
+    "125" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "65.22",
+      "includingLoc" : "None"
+    },
+    "126" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "65.33",
+      "includingLoc" : "None"
+    },
+    "127" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "65.33",
+      "includingLoc" : "None"
+    },
+    "128" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "65.17",
+      "includingLoc" : "None"
+    },
+    "129" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "65.5",
+      "includingLoc" : "None"
+    },
+    "130" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "66.8",
+      "includingLoc" : "None"
+    },
+    "131" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "66.14",
+      "includingLoc" : "None"
+    },
+    "132" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "66.23",
+      "includingLoc" : "None"
+    },
+    "133" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "66.23",
+      "includingLoc" : "None"
+    },
+    "134" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "66.17",
+      "includingLoc" : "None"
+    },
+    "135" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "66.5",
+      "includingLoc" : "None"
+    },
+    "136" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "69.8",
+      "includingLoc" : "None"
+    },
+    "137" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "69.14",
+      "includingLoc" : "None"
+    },
+    "138" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "69.23",
+      "includingLoc" : "None"
+    },
+    "139" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "69.23",
+      "includingLoc" : "None"
+    },
+    "140" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "69.17",
+      "includingLoc" : "None"
+    },
+    "141" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "69.5",
+      "includingLoc" : "None"
+    },
+    "142" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "72.8",
+      "includingLoc" : "None"
+    },
+    "143" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "72.17",
+      "includingLoc" : "None"
+    },
+    "144" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "72.17",
+      "includingLoc" : "None"
+    },
+    "145" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "72.11",
+      "includingLoc" : "None"
+    },
+    "146" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "72.5",
+      "includingLoc" : "None"
+    },
+    "147" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "75.8",
+      "includingLoc" : "None"
+    },
+    "148" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "75.14",
+      "includingLoc" : "None"
+    },
+    "149" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "75.22",
+      "includingLoc" : "None"
+    },
+    "150" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "75.22",
+      "includingLoc" : "None"
+    },
+    "151" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "75.5",
+      "includingLoc" : "None"
+    },
+    "152" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "78.8",
+      "includingLoc" : "None"
+    },
+    "153" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "78.16",
+      "includingLoc" : "None"
+    },
+    "154" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "78.16",
+      "includingLoc" : "None"
+    },
+    "155" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "78.5",
+      "includingLoc" : "None"
+    },
+    "156" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "78.8",
+      "includingLoc" : "None"
+    },
+    "157" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "78.16",
+      "includingLoc" : "None"
+    },
+    "158" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "78.16",
+      "includingLoc" : "None"
+    },
+    "159" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "78.5",
+      "includingLoc" : "None"
+    },
+    "160" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "78.8",
+      "includingLoc" : "None"
+    },
+    "161" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "78.16",
+      "includingLoc" : "None"
+    },
+    "162" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "78.16",
+      "includingLoc" : "None"
+    },
+    "163" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "78.5",
+      "includingLoc" : "None"
+    },
+    "164" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "50.3",
+      "includingLoc" : "None"
+    },
+    "165" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "52.16",
+      "includingLoc" : "None"
+    },
+    "166" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "52.20",
+      "includingLoc" : "None"
+    },
+    "167" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "52.5",
+      "includingLoc" : "None"
+    },
+    "168" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "53.15",
+      "includingLoc" : "None"
+    },
+    "169" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "53.19",
+      "includingLoc" : "None"
+    },
+    "170" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "53.5",
+      "includingLoc" : "None"
+    },
+    "171" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "56.18",
+      "includingLoc" : "None"
+    },
+    "172" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "56.22",
+      "includingLoc" : "None"
+    },
+    "173" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "56.33",
+      "includingLoc" : "None"
+    },
+    "174" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "56.33",
+      "includingLoc" : "None"
+    },
+    "175" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "56.13",
+      "includingLoc" : "None"
+    },
+    "176" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "56.5",
+      "includingLoc" : "None"
+    },
+    "177" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "59.19",
+      "includingLoc" : "None"
+    },
+    "178" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "59.27",
+      "includingLoc" : "None"
+    },
+    "179" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "59.31",
+      "includingLoc" : "None"
+    },
+    "180" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "59.42",
+      "includingLoc" : "None"
+    },
+    "181" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "59.42",
+      "includingLoc" : "None"
+    },
+    "182" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "59.22",
+      "includingLoc" : "None"
+    },
+    "183" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "59.55",
+      "includingLoc" : "None"
+    },
+    "184" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "59.59",
+      "includingLoc" : "None"
+    },
+    "185" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "59.70",
+      "includingLoc" : "None"
+    },
+    "186" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "59.73",
+      "includingLoc" : "None"
+    },
+    "187" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "59.70",
+      "includingLoc" : "None"
+    },
+    "188" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "59.50",
+      "includingLoc" : "None"
+    },
+    "189" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "59.5",
+      "includingLoc" : "None"
+    },
+    "190" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "62.5",
+      "includingLoc" : "None"
+    },
+    "191" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "65.8",
+      "includingLoc" : "None"
+    },
+    "192" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "65.14",
+      "includingLoc" : "None"
+    },
+    "193" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "65.22",
+      "includingLoc" : "None"
+    },
+    "194" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "65.33",
+      "includingLoc" : "None"
+    },
+    "195" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "65.33",
+      "includingLoc" : "None"
+    },
+    "196" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "65.17",
+      "includingLoc" : "None"
+    },
+    "197" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "65.5",
+      "includingLoc" : "None"
+    },
+    "198" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "66.8",
+      "includingLoc" : "None"
+    },
+    "199" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "66.14",
+      "includingLoc" : "None"
+    },
+    "200" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "66.23",
+      "includingLoc" : "None"
+    },
+    "201" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "66.23",
+      "includingLoc" : "None"
+    },
+    "202" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "66.17",
+      "includingLoc" : "None"
+    },
+    "203" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "66.5",
+      "includingLoc" : "None"
+    },
+    "204" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "69.8",
+      "includingLoc" : "None"
+    },
+    "205" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "69.14",
+      "includingLoc" : "None"
+    },
+    "206" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "69.23",
+      "includingLoc" : "None"
+    },
+    "207" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "69.23",
+      "includingLoc" : "None"
+    },
+    "208" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "69.17",
+      "includingLoc" : "None"
+    },
+    "209" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "69.5",
+      "includingLoc" : "None"
+    },
+    "210" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "72.8",
+      "includingLoc" : "None"
+    },
+    "211" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "72.17",
+      "includingLoc" : "None"
+    },
+    "212" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "72.17",
+      "includingLoc" : "None"
+    },
+    "213" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "72.11",
+      "includingLoc" : "None"
+    },
+    "214" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "72.5",
+      "includingLoc" : "None"
+    },
+    "215" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "75.8",
+      "includingLoc" : "None"
+    },
+    "216" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "75.14",
+      "includingLoc" : "None"
+    },
+    "217" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "75.22",
+      "includingLoc" : "None"
+    },
+    "218" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "75.22",
+      "includingLoc" : "None"
+    },
+    "219" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "75.5",
+      "includingLoc" : "None"
+    },
+    "220" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "78.8",
+      "includingLoc" : "None"
+    },
+    "221" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "78.16",
+      "includingLoc" : "None"
+    },
+    "222" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "78.16",
+      "includingLoc" : "None"
+    },
+    "223" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "78.5",
+      "includingLoc" : "None"
+    },
+    "224" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "78.8",
+      "includingLoc" : "None"
+    },
+    "225" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "78.16",
+      "includingLoc" : "None"
+    },
+    "226" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "78.16",
+      "includingLoc" : "None"
+    },
+    "227" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "78.5",
+      "includingLoc" : "None"
+    },
+    "228" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "78.8",
+      "includingLoc" : "None"
+    },
+    "229" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "78.16",
+      "includingLoc" : "None"
+    },
+    "230" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "78.16",
+      "includingLoc" : "None"
+    },
+    "231" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "78.5",
+      "includingLoc" : "None"
+    },
+    "232" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "50.3",
+      "includingLoc" : "None"
+    },
+    "233" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",
+      "pos" : "2.1",
+      "includingLoc" : "None"
     }
   }
 }

--- a/tests/telemetry/telemetry_analysis.json
+++ b/tests/telemetry/telemetry_analysis.json
@@ -1,221 +1,252 @@
 {
-  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
-  "analysis": {
-    "componentInstanceMap": {
-      "67": {
-        "aNode": {
-          "astNodeId": 67
+  "fppVersion" : "v3.1.0a10-54-g11243e778",
+  "analysis" : {
+    "componentInstanceMap" : {
+      "67" : {
+        "aNode" : {
+          "astNodeId" : 67
         },
-        "qualifiedName": {
-          "qualifier": [],
-          "base": "i"
+        "qualifiedName" : {
+          "qualifier" : [
+          ],
+          "base" : "i"
         },
-        "component": {
-          "astNodeId": 58
+        "component" : {
+          "astNodeId" : 58
         },
-        "baseId": 18944,
-        "maxId": 18961,
-        "file": "None",
-        "queueSize": "None",
-        "stackSize": "None",
-        "priority": "None",
-        "cpu": "None",
-        "initSpecifierMap": {}
+        "baseId" : 18944,
+        "maxId" : 18961,
+        "file" : "None",
+        "queueSize" : "None",
+        "stackSize" : "None",
+        "priority" : "None",
+        "cpu" : "None",
+        "initSpecifierMap" : {
+          
+        }
       }
     },
-    "componentMap": {
-      "58": {
-        "aNode": {
-          "astNodeId": 58
+    "componentMap" : {
+      "58" : {
+        "aNode" : {
+          "astNodeId" : 58
         },
-        "portMap": {
-          "tlmOut": {
-            "Special": {
-              "aNode": {
-                "astNodeId": 0
+        "portMap" : {
+          "tlmOut" : {
+            "Special" : {
+              "aNode" : {
+                "astNodeId" : 0
               },
-              "specifier": {
-                "inputKind": "None",
-                "kind": {
-                  "Telemetry": {}
+              "specifier" : {
+                "inputKind" : "None",
+                "kind" : {
+                  "Telemetry" : {
+                    
+                  }
                 },
-                "name": "tlmOut",
-                "priority": "None",
-                "queueFull": "None"
+                "name" : "tlmOut",
+                "priority" : "None",
+                "queueFull" : "None"
               },
-              "symbol": {
-                "Port": {
-                  "nodeId": 59,
-                  "unqualifiedName": "Tlm"
+              "symbol" : {
+                "Port" : {
+                  "nodeId" : 59,
+                  "unqualifiedName" : "Tlm"
                 }
               },
-              "priority": "None",
-              "queueFull": "None",
-              "importNodeIds": []
+              "priority" : "None",
+              "queueFull" : "None",
+              "importNodeIds" : [
+              ]
             }
           },
-          "timeGetOut": {
-            "Special": {
-              "aNode": {
-                "astNodeId": 1
+          "timeGetOut" : {
+            "Special" : {
+              "aNode" : {
+                "astNodeId" : 1
               },
-              "specifier": {
-                "inputKind": "None",
-                "kind": {
-                  "TimeGet": {}
+              "specifier" : {
+                "inputKind" : "None",
+                "kind" : {
+                  "TimeGet" : {
+                    
+                  }
                 },
-                "name": "timeGetOut",
-                "priority": "None",
-                "queueFull": "None"
+                "name" : "timeGetOut",
+                "priority" : "None",
+                "queueFull" : "None"
               },
-              "symbol": {
-                "Port": {
-                  "nodeId": 62,
-                  "unqualifiedName": "Time"
+              "symbol" : {
+                "Port" : {
+                  "nodeId" : 62,
+                  "unqualifiedName" : "Time"
                 }
               },
-              "priority": "None",
-              "queueFull": "None",
-              "importNodeIds": []
+              "priority" : "None",
+              "queueFull" : "None",
+              "importNodeIds" : [
+              ]
             }
           }
         },
-        "specialPortMap": {
-          "telemetry": {
-            "aNode": {
-              "astNodeId": 0
+        "specialPortMap" : {
+          "telemetry" : {
+            "aNode" : {
+              "astNodeId" : 0
             },
-            "specifier": {
-              "inputKind": "None",
-              "kind": {
-                "Telemetry": {}
+            "specifier" : {
+              "inputKind" : "None",
+              "kind" : {
+                "Telemetry" : {
+                  
+                }
               },
-              "name": "tlmOut",
-              "priority": "None",
-              "queueFull": "None"
+              "name" : "tlmOut",
+              "priority" : "None",
+              "queueFull" : "None"
             },
-            "symbol": {
-              "Port": {
-                "nodeId": 59,
-                "unqualifiedName": "Tlm"
+            "symbol" : {
+              "Port" : {
+                "nodeId" : 59,
+                "unqualifiedName" : "Tlm"
               }
             },
-            "priority": "None",
-            "queueFull": "None",
-            "importNodeIds": []
+            "priority" : "None",
+            "queueFull" : "None",
+            "importNodeIds" : [
+            ]
           },
-          "time get": {
-            "aNode": {
-              "astNodeId": 1
+          "time get" : {
+            "aNode" : {
+              "astNodeId" : 1
             },
-            "specifier": {
-              "inputKind": "None",
-              "kind": {
-                "TimeGet": {}
+            "specifier" : {
+              "inputKind" : "None",
+              "kind" : {
+                "TimeGet" : {
+                  
+                }
               },
-              "name": "timeGetOut",
-              "priority": "None",
-              "queueFull": "None"
+              "name" : "timeGetOut",
+              "priority" : "None",
+              "queueFull" : "None"
             },
-            "symbol": {
-              "Port": {
-                "nodeId": 62,
-                "unqualifiedName": "Time"
+            "symbol" : {
+              "Port" : {
+                "nodeId" : 62,
+                "unqualifiedName" : "Time"
               }
             },
-            "priority": "None",
-            "queueFull": "None",
-            "importNodeIds": []
+            "priority" : "None",
+            "queueFull" : "None",
+            "importNodeIds" : [
+            ]
           }
         },
-        "commandMap": {},
-        "defaultOpcode": 0,
-        "tlmChannelMap": {
-          "0": {
-            "aNode": {
-              "astNodeId": 11
+        "commandMap" : {
+          
+        },
+        "defaultOpcode" : 0,
+        "tlmChannelMap" : {
+          "0" : {
+            "aNode" : {
+              "astNodeId" : 11
             },
-            "channelType": {
-              "Int": {
-                "PrimitiveInt": {
-                  "kind": {
-                    "U32": {}
+            "channelType" : {
+              "Int" : {
+                "PrimitiveInt" : {
+                  "kind" : {
+                    "U32" : {
+                      
+                    }
                   }
                 }
               }
             },
-            "update": {
-              "Always": {}
+            "update" : {
+              "Always" : {
+                
+              }
             },
-            "format": {
-              "Some": {
-                "prefix": "",
-                "fields": [
+            "format" : {
+              "Some" : {
+                "prefix" : "",
+                "fields" : [
                   [
                     {
-                      "Default": {}
+                      "Default" : {
+                        
+                      }
                     },
                     "s"
                   ]
                 ]
               }
             },
-            "lowLimits": {
-              "red": [
+            "lowLimits" : {
+              "red" : [
                 5,
                 {
-                  "Integer": {
-                    "value": 0
+                  "Integer" : {
+                    "value" : 0
                   }
                 }
               ],
-              "orange": [
+              "orange" : [
                 7,
                 {
-                  "Integer": {
-                    "value": 1
+                  "Integer" : {
+                    "value" : 1
                   }
                 }
               ],
-              "yellow": [
+              "yellow" : [
                 9,
                 {
-                  "Integer": {
-                    "value": 2
+                  "Integer" : {
+                    "value" : 2
                   }
                 }
               ]
             },
-            "highLimits": {}
+            "highLimits" : {
+              
+            }
           },
-          "16": {
-            "aNode": {
-              "astNodeId": 30
+          "16" : {
+            "aNode" : {
+              "astNodeId" : 30
             },
-            "channelType": {
-              "Primitive": {
-                "Float": {
-                  "kind": {
-                    "F64": {}
+            "channelType" : {
+              "Primitive" : {
+                "Float" : {
+                  "kind" : {
+                    "F64" : {
+                      
+                    }
                   }
                 }
               }
             },
-            "update": {
-              "OnChange": {}
+            "update" : {
+              "OnChange" : {
+                
+              }
             },
-            "format": {
-              "Some": {
-                "prefix": "",
-                "fields": [
+            "format" : {
+              "Some" : {
+                "prefix" : "",
+                "fields" : [
                   [
                     {
-                      "Rational": {
-                        "precision": {
-                          "Some": 3
+                      "Rational" : {
+                        "precision" : {
+                          "Some" : 3
                         },
-                        "t": {
-                          "Fixed": {}
+                        "t" : {
+                          "Fixed" : {
+                            
+                          }
                         }
                       }
                     },
@@ -224,85 +255,91 @@
                 ]
               }
             },
-            "lowLimits": {
-              "red": [
+            "lowLimits" : {
+              "red" : [
                 15,
                 {
-                  "Integer": {
-                    "value": -3
+                  "Integer" : {
+                    "value" : -3
                   }
                 }
               ],
-              "orange": [
+              "orange" : [
                 18,
                 {
-                  "Integer": {
-                    "value": -2
+                  "Integer" : {
+                    "value" : -2
                   }
                 }
               ],
-              "yellow": [
+              "yellow" : [
                 21,
                 {
-                  "Integer": {
-                    "value": -1
+                  "Integer" : {
+                    "value" : -1
                   }
                 }
               ]
             },
-            "highLimits": {
-              "red": [
+            "highLimits" : {
+              "red" : [
                 24,
                 {
-                  "Integer": {
-                    "value": 3
+                  "Integer" : {
+                    "value" : 3
                   }
                 }
               ],
-              "orange": [
+              "orange" : [
                 26,
                 {
-                  "Integer": {
-                    "value": 2
+                  "Integer" : {
+                    "value" : 2
                   }
                 }
               ],
-              "yellow": [
+              "yellow" : [
                 28,
                 {
-                  "Integer": {
-                    "value": 1
+                  "Integer" : {
+                    "value" : 1
                   }
                 }
               ]
             }
           },
-          "17": {
-            "aNode": {
-              "astNodeId": 57
+          "17" : {
+            "aNode" : {
+              "astNodeId" : 57
             },
-            "channelType": {
-              "Primitive": {
-                "Float": {
-                  "kind": {
-                    "F64": {}
+            "channelType" : {
+              "Primitive" : {
+                "Float" : {
+                  "kind" : {
+                    "F64" : {
+                      
+                    }
                   }
                 }
               }
             },
-            "update": {
-              "Always": {}
+            "update" : {
+              "Always" : {
+                
+              }
             },
-            "format": {
-              "Some": {
-                "prefix": "",
-                "fields": [
+            "format" : {
+              "Some" : {
+                "prefix" : "",
+                "fields" : [
                   [
                     {
-                      "Rational": {
-                        "precision": "None",
-                        "t": {
-                          "Exponent": {}
+                      "Rational" : {
+                        "precision" : "None",
+                        "t" : {
+                          "Exponent" : {
+                            
+                          }
                         }
                       }
                     },
@@ -311,121 +348,137 @@
                 ]
               }
             },
-            "lowLimits": {},
-            "highLimits": {
-              "red": [
+            "lowLimits" : {
+              
+            },
+            "highLimits" : {
+              "red" : [
                 51,
                 {
-                  "Integer": {
-                    "value": 3
+                  "Integer" : {
+                    "value" : 3
                   }
                 }
               ],
-              "orange": [
+              "orange" : [
                 53,
                 {
-                  "Integer": {
-                    "value": 2
+                  "Integer" : {
+                    "value" : 2
                   }
                 }
               ],
-              "yellow": [
+              "yellow" : [
                 55,
                 {
-                  "Integer": {
-                    "value": 1
+                  "Integer" : {
+                    "value" : 1
                   }
                 }
               ]
             }
           }
         },
-        "tlmChannelNameMap": {
-          "Channel1": {
-            "aNode": {
-              "astNodeId": 11
+        "tlmChannelNameMap" : {
+          "Channel1" : {
+            "aNode" : {
+              "astNodeId" : 11
             },
-            "channelType": {
-              "Int": {
-                "PrimitiveInt": {
-                  "kind": {
-                    "U32": {}
+            "channelType" : {
+              "Int" : {
+                "PrimitiveInt" : {
+                  "kind" : {
+                    "U32" : {
+                      
+                    }
                   }
                 }
               }
             },
-            "update": {
-              "Always": {}
+            "update" : {
+              "Always" : {
+                
+              }
             },
-            "format": {
-              "Some": {
-                "prefix": "",
-                "fields": [
+            "format" : {
+              "Some" : {
+                "prefix" : "",
+                "fields" : [
                   [
                     {
-                      "Default": {}
+                      "Default" : {
+                        
+                      }
                     },
                     "s"
                   ]
                 ]
               }
             },
-            "lowLimits": {
-              "red": [
+            "lowLimits" : {
+              "red" : [
                 5,
                 {
-                  "Integer": {
-                    "value": 0
+                  "Integer" : {
+                    "value" : 0
                   }
                 }
               ],
-              "orange": [
+              "orange" : [
                 7,
                 {
-                  "Integer": {
-                    "value": 1
+                  "Integer" : {
+                    "value" : 1
                   }
                 }
               ],
-              "yellow": [
+              "yellow" : [
                 9,
                 {
-                  "Integer": {
-                    "value": 2
+                  "Integer" : {
+                    "value" : 2
                   }
                 }
               ]
             },
-            "highLimits": {}
+            "highLimits" : {
+              
+            }
           },
-          "Channel2": {
-            "aNode": {
-              "astNodeId": 30
+          "Channel2" : {
+            "aNode" : {
+              "astNodeId" : 30
             },
-            "channelType": {
-              "Primitive": {
-                "Float": {
-                  "kind": {
-                    "F64": {}
+            "channelType" : {
+              "Primitive" : {
+                "Float" : {
+                  "kind" : {
+                    "F64" : {
+                      
+                    }
                   }
                 }
               }
             },
-            "update": {
-              "OnChange": {}
+            "update" : {
+              "OnChange" : {
+                
+              }
             },
-            "format": {
-              "Some": {
-                "prefix": "",
-                "fields": [
+            "format" : {
+              "Some" : {
+                "prefix" : "",
+                "fields" : [
                   [
                     {
-                      "Rational": {
-                        "precision": {
-                          "Some": 3
+                      "Rational" : {
+                        "precision" : {
+                          "Some" : 3
                         },
-                        "t": {
-                          "Fixed": {}
+                        "t" : {
+                          "Fixed" : {
+                            
+                          }
                         }
                       }
                     },
@@ -434,85 +487,91 @@
                 ]
               }
             },
-            "lowLimits": {
-              "red": [
+            "lowLimits" : {
+              "red" : [
                 15,
                 {
-                  "Integer": {
-                    "value": -3
+                  "Integer" : {
+                    "value" : -3
                   }
                 }
               ],
-              "orange": [
+              "orange" : [
                 18,
                 {
-                  "Integer": {
-                    "value": -2
+                  "Integer" : {
+                    "value" : -2
                   }
                 }
               ],
-              "yellow": [
+              "yellow" : [
                 21,
                 {
-                  "Integer": {
-                    "value": -1
+                  "Integer" : {
+                    "value" : -1
                   }
                 }
               ]
             },
-            "highLimits": {
-              "red": [
+            "highLimits" : {
+              "red" : [
                 24,
                 {
-                  "Integer": {
-                    "value": 3
+                  "Integer" : {
+                    "value" : 3
                   }
                 }
               ],
-              "orange": [
+              "orange" : [
                 26,
                 {
-                  "Integer": {
-                    "value": 2
+                  "Integer" : {
+                    "value" : 2
                   }
                 }
               ],
-              "yellow": [
+              "yellow" : [
                 28,
                 {
-                  "Integer": {
-                    "value": 1
+                  "Integer" : {
+                    "value" : 1
                   }
                 }
               ]
             }
           },
-          "Channel3": {
-            "aNode": {
-              "astNodeId": 57
+          "Channel3" : {
+            "aNode" : {
+              "astNodeId" : 57
             },
-            "channelType": {
-              "Primitive": {
-                "Float": {
-                  "kind": {
-                    "F64": {}
+            "channelType" : {
+              "Primitive" : {
+                "Float" : {
+                  "kind" : {
+                    "F64" : {
+                      
+                    }
                   }
                 }
               }
             },
-            "update": {
-              "Always": {}
+            "update" : {
+              "Always" : {
+                
+              }
             },
-            "format": {
-              "Some": {
-                "prefix": "",
-                "fields": [
+            "format" : {
+              "Some" : {
+                "prefix" : "",
+                "fields" : [
                   [
                     {
-                      "Rational": {
-                        "precision": "None",
-                        "t": {
-                          "Exponent": {}
+                      "Rational" : {
+                        "precision" : "None",
+                        "t" : {
+                          "Exponent" : {
+                            
+                          }
                         }
                       }
                     },
@@ -521,106 +580,124 @@
                 ]
               }
             },
-            "lowLimits": {},
-            "highLimits": {
-              "red": [
+            "lowLimits" : {
+              
+            },
+            "highLimits" : {
+              "red" : [
                 51,
                 {
-                  "Integer": {
-                    "value": 3
+                  "Integer" : {
+                    "value" : 3
                   }
                 }
               ],
-              "orange": [
+              "orange" : [
                 53,
                 {
-                  "Integer": {
-                    "value": 2
+                  "Integer" : {
+                    "value" : 2
                   }
                 }
               ],
-              "yellow": [
+              "yellow" : [
                 55,
                 {
-                  "Integer": {
-                    "value": 1
+                  "Integer" : {
+                    "value" : 1
                   }
                 }
               ]
             }
           }
         },
-        "defaultTlmChannelId": 18,
-        "eventMap": {},
-        "defaultEventId": 0,
-        "paramMap": {},
-        "specPortMatchingList": [],
-        "stateMachineInstanceMap": {},
-        "portMatchingList": [],
-        "defaultParamId": 0,
-        "containerMap": {},
-        "defaultContainerId": 0,
-        "recordMap": {},
-        "defaultRecordId": 0
+        "defaultTlmChannelId" : 18,
+        "eventMap" : {
+          
+        },
+        "defaultEventId" : 0,
+        "paramMap" : {
+          
+        },
+        "specPortMatchingList" : [
+        ],
+        "stateMachineInstanceMap" : {
+          
+        },
+        "portMatchingList" : [
+        ],
+        "defaultParamId" : 0,
+        "containerMap" : {
+          
+        },
+        "defaultContainerId" : 0,
+        "recordMap" : {
+          
+        },
+        "defaultRecordId" : 0
       }
     },
-    "includedFileSet": [],
-    "inputFileSet": [
+    "includedFileSet" : [
+    ],
+    "inputFileSet" : [
       "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp"
     ],
-    "locationSpecifierMap": [],
-    "parentSymbolMap": {
-      "59": {
-        "Module": {
-          "nodeId": 63,
-          "unqualifiedName": "Fw"
+    "locationSpecifierMap" : [
+    ],
+    "parentSymbolMap" : {
+      "59" : {
+        "Module" : {
+          "nodeId" : 63,
+          "unqualifiedName" : "Fw"
         }
       },
-      "62": {
-        "Module": {
-          "nodeId": 63,
-          "unqualifiedName": "Fw"
+      "62" : {
+        "Module" : {
+          "nodeId" : 63,
+          "unqualifiedName" : "Fw"
         }
       },
-      "97": {
-        "Module": {
-          "nodeId": 98,
-          "unqualifiedName": "M"
+      "97" : {
+        "Module" : {
+          "nodeId" : 98,
+          "unqualifiedName" : "M"
         }
       }
     },
-    "symbolScopeMap": {
-      "58": {
-        "map": {}
+    "symbolScopeMap" : {
+      "58" : {
+        "map" : {
+          
+        }
       },
-      "63": {
-        "map": {
-          "Port": {
-            "map": {
-              "Tlm": {
-                "Port": {
-                  "nodeId": 59,
-                  "unqualifiedName": "Tlm"
+      "63" : {
+        "map" : {
+          "Port" : {
+            "map" : {
+              "Tlm" : {
+                "Port" : {
+                  "nodeId" : 59,
+                  "unqualifiedName" : "Tlm"
                 }
               },
-              "Time": {
-                "Port": {
-                  "nodeId": 62,
-                  "unqualifiedName": "Time"
+              "Time" : {
+                "Port" : {
+                  "nodeId" : 62,
+                  "unqualifiedName" : "Time"
                 }
               }
             }
           }
         }
       },
-      "98": {
-        "map": {
-          "Topology": {
-            "map": {
-              "T": {
-                "Topology": {
-                  "nodeId": 97,
-                  "unqualifiedName": "T"
+      "98" : {
+        "map" : {
+          "Topology" : {
+            "map" : {
+              "T" : {
+                "Topology" : {
+                  "nodeId" : 97,
+                  "unqualifiedName" : "T"
                 }
               }
             }
@@ -628,391 +705,468 @@
         }
       }
     },
-    "topologyMap": {
-      "97": {
-        "aNode": {
-          "astNodeId": 97
+    "topologyMap" : {
+      "97" : {
+        "aNode" : {
+          "astNodeId" : 97
         },
-        "directImportMap": {},
-        "transitiveImportSet": [],
-        "instanceMap": [
+        "directImportMap" : {
+          
+        },
+        "transitiveImportSet" : [
+        ],
+        "instanceMap" : [
           [
             {
-              "aNode": {
-                "astNodeId": 67
+              "aNode" : {
+                "astNodeId" : 67
               },
-              "qualifiedName": {
-                "qualifier": [],
-                "base": "i"
+              "qualifiedName" : {
+                "qualifier" : [
+                ],
+                "base" : "i"
               },
-              "component": {
-                "astNodeId": 58
+              "component" : {
+                "astNodeId" : 58
               },
-              "baseId": 18944,
-              "maxId": 18961,
-              "file": "None",
-              "queueSize": "None",
-              "stackSize": "None",
-              "priority": "None",
-              "cpu": "None",
-              "initSpecifierMap": {}
+              "baseId" : 18944,
+              "maxId" : 18961,
+              "file" : "None",
+              "queueSize" : "None",
+              "stackSize" : "None",
+              "priority" : "None",
+              "cpu" : "None",
+              "initSpecifierMap" : {
+                
+              }
             },
             [
               {
-                "Public": {}
+                "Public" : {
+                  
+                }
               },
               {
-                "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-                "pos": "47.9",
-                "includingLoc": "None"
+                "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+                "pos" : "47.9",
+                "includingLoc" : "None"
               }
             ]
           ]
         ],
-        "patternMap": {},
-        "connectionMap": {},
-        "localConnectionMap": {},
-        "outputConnectionMap": [],
-        "inputConnectionMap": [],
-        "fromPortNumberMap": [],
-        "toPortNumberMap": [],
-        "unconnectedPortSet": [
+        "patternMap" : {
+          
+        },
+        "connectionMap" : {
+          
+        },
+        "localConnectionMap" : {
+          
+        },
+        "outputConnectionMap" : [
+        ],
+        "inputConnectionMap" : [
+        ],
+        "fromPortNumberMap" : [
+        ],
+        "toPortNumberMap" : [
+        ],
+        "unconnectedPortSet" : [
           {
-            "componentInstance": {
-              "aNode": {
-                "astNodeId": 67
+            "componentInstance" : {
+              "aNode" : {
+                "astNodeId" : 67
               },
-              "qualifiedName": {
-                "qualifier": [],
-                "base": "i"
+              "qualifiedName" : {
+                "qualifier" : [
+                ],
+                "base" : "i"
               },
-              "component": {
-                "astNodeId": 58
+              "component" : {
+                "astNodeId" : 58
               },
-              "baseId": 18944,
-              "maxId": 18961,
-              "file": "None",
-              "queueSize": "None",
-              "stackSize": "None",
-              "priority": "None",
-              "cpu": "None",
-              "initSpecifierMap": {}
+              "baseId" : 18944,
+              "maxId" : 18961,
+              "file" : "None",
+              "queueSize" : "None",
+              "stackSize" : "None",
+              "priority" : "None",
+              "cpu" : "None",
+              "initSpecifierMap" : {
+                
+              }
             },
-            "portInstance": {
-              "Special": {
-                "aNode": {
-                  "astNodeId": 0
+            "portInstance" : {
+              "Special" : {
+                "aNode" : {
+                  "astNodeId" : 0
                 },
-                "specifier": {
-                  "inputKind": "None",
-                  "kind": {
-                    "Telemetry": {}
+                "specifier" : {
+                  "inputKind" : "None",
+                  "kind" : {
+                    "Telemetry" : {
+                      
+                    }
                   },
-                  "name": "tlmOut",
-                  "priority": "None",
-                  "queueFull": "None"
+                  "name" : "tlmOut",
+                  "priority" : "None",
+                  "queueFull" : "None"
                 },
-                "symbol": {
-                  "Port": {
-                    "nodeId": 59,
-                    "unqualifiedName": "Tlm"
+                "symbol" : {
+                  "Port" : {
+                    "nodeId" : 59,
+                    "unqualifiedName" : "Tlm"
                   }
                 },
-                "priority": "None",
-                "queueFull": "None",
-                "importNodeIds": []
+                "priority" : "None",
+                "queueFull" : "None",
+                "importNodeIds" : [
+                ]
               }
             }
           },
           {
-            "componentInstance": {
-              "aNode": {
-                "astNodeId": 67
+            "componentInstance" : {
+              "aNode" : {
+                "astNodeId" : 67
               },
-              "qualifiedName": {
-                "qualifier": [],
-                "base": "i"
+              "qualifiedName" : {
+                "qualifier" : [
+                ],
+                "base" : "i"
               },
-              "component": {
-                "astNodeId": 58
+              "component" : {
+                "astNodeId" : 58
               },
-              "baseId": 18944,
-              "maxId": 18961,
-              "file": "None",
-              "queueSize": "None",
-              "stackSize": "None",
-              "priority": "None",
-              "cpu": "None",
-              "initSpecifierMap": {}
+              "baseId" : 18944,
+              "maxId" : 18961,
+              "file" : "None",
+              "queueSize" : "None",
+              "stackSize" : "None",
+              "priority" : "None",
+              "cpu" : "None",
+              "initSpecifierMap" : {
+                
+              }
             },
-            "portInstance": {
-              "Special": {
-                "aNode": {
-                  "astNodeId": 1
+            "portInstance" : {
+              "Special" : {
+                "aNode" : {
+                  "astNodeId" : 1
                 },
-                "specifier": {
-                  "inputKind": "None",
-                  "kind": {
-                    "TimeGet": {}
+                "specifier" : {
+                  "inputKind" : "None",
+                  "kind" : {
+                    "TimeGet" : {
+                      
+                    }
                   },
-                  "name": "timeGetOut",
-                  "priority": "None",
-                  "queueFull": "None"
+                  "name" : "timeGetOut",
+                  "priority" : "None",
+                  "queueFull" : "None"
                 },
-                "symbol": {
-                  "Port": {
-                    "nodeId": 62,
-                    "unqualifiedName": "Time"
+                "symbol" : {
+                  "Port" : {
+                    "nodeId" : 62,
+                    "unqualifiedName" : "Time"
                   }
                 },
-                "priority": "None",
-                "queueFull": "None",
-                "importNodeIds": []
+                "priority" : "None",
+                "queueFull" : "None",
+                "importNodeIds" : [
+                ]
               }
             }
           }
         ]
       }
     },
-    "typeMap": {
-      "8": {
-        "Int": {
-          "Integer": {}
+    "typeMap" : {
+      "8" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "13": {
-        "Int": {
-          "Integer": {}
+      "13" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "16": {
-        "Int": {
-          "Integer": {}
+      "16" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "10": {
-        "Int": {
-          "Integer": {}
+      "10" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "54": {
-        "Int": {
-          "Integer": {}
+      "54" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "2": {
-        "Int": {
-          "PrimitiveInt": {
-            "kind": {
-              "U32": {}
+      "2" : {
+        "Int" : {
+          "PrimitiveInt" : {
+            "kind" : {
+              "U32" : {
+                
+              }
             }
           }
         }
       },
-      "29": {
-        "Int": {
-          "Integer": {}
+      "29" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "3": {
-        "Int": {
-          "Integer": {}
+      "3" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "52": {
-        "Int": {
-          "Integer": {}
+      "52" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "12": {
-        "Primitive": {
-          "Float": {
-            "kind": {
-              "F64": {}
+      "12" : {
+        "Primitive" : {
+          "Float" : {
+            "kind" : {
+              "F64" : {
+                
+              }
             }
           }
         }
       },
-      "66": {
-        "Int": {
-          "Integer": {}
+      "66" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "19": {
-        "Int": {
-          "Integer": {}
+      "19" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "23": {
-        "Int": {
-          "Integer": {}
+      "23" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "22": {
-        "Int": {
-          "Integer": {}
+      "22" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "56": {
-        "Int": {
-          "Integer": {}
+      "56" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "49": {
-        "Primitive": {
-          "Float": {
-            "kind": {
-              "F64": {}
+      "49" : {
+        "Primitive" : {
+          "Float" : {
+            "kind" : {
+              "F64" : {
+                
+              }
             }
           }
         }
       },
-      "6": {
-        "Int": {
-          "Integer": {}
+      "6" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "17": {
-        "Int": {
-          "Integer": {}
+      "17" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "25": {
-        "Int": {
-          "Integer": {}
+      "25" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "20": {
-        "Int": {
-          "Integer": {}
+      "20" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "27": {
-        "Int": {
-          "Integer": {}
+      "27" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       }
     },
-    "useDefMap": {
-      "0": {
-        "Port": {
-          "nodeId": 59,
-          "unqualifiedName": "Tlm"
+    "useDefMap" : {
+      "0" : {
+        "Port" : {
+          "nodeId" : 59,
+          "unqualifiedName" : "Tlm"
         }
       },
-      "1": {
-        "Port": {
-          "nodeId": 62,
-          "unqualifiedName": "Time"
+      "1" : {
+        "Port" : {
+          "nodeId" : 62,
+          "unqualifiedName" : "Time"
         }
       },
-      "65": {
-        "Component": {
-          "nodeId": 58,
-          "unqualifiedName": "TlmLimits"
+      "65" : {
+        "Component" : {
+          "nodeId" : 58,
+          "unqualifiedName" : "TlmLimits"
         }
       },
-      "95": {
-        "ComponentInstance": {
-          "nodeId": 67,
-          "unqualifiedName": "i"
+      "95" : {
+        "ComponentInstance" : {
+          "nodeId" : 67,
+          "unqualifiedName" : "i"
         }
       }
     },
-    "valueMap": {
-      "66": {
-        "Integer": {
-          "value": 18944
+    "valueMap" : {
+      "66" : {
+        "Integer" : {
+          "value" : 18944
         }
       },
-      "8": {
-        "Integer": {
-          "value": 1
+      "8" : {
+        "Integer" : {
+          "value" : 1
         }
       },
-      "13": {
-        "Integer": {
-          "value": 16
+      "13" : {
+        "Integer" : {
+          "value" : 16
         }
       },
-      "16": {
-        "Integer": {
-          "value": 3
+      "16" : {
+        "Integer" : {
+          "value" : 3
         }
       },
-      "10": {
-        "Integer": {
-          "value": 2
+      "10" : {
+        "Integer" : {
+          "value" : 2
         }
       },
-      "54": {
-        "Integer": {
-          "value": 2
+      "54" : {
+        "Integer" : {
+          "value" : 2
         }
       },
-      "6": {
-        "Integer": {
-          "value": 0
+      "6" : {
+        "Integer" : {
+          "value" : 0
         }
       },
-      "29": {
-        "Integer": {
-          "value": 1
+      "29" : {
+        "Integer" : {
+          "value" : 1
         }
       },
-      "3": {
-        "Integer": {
-          "value": 0
+      "3" : {
+        "Integer" : {
+          "value" : 0
         }
       },
-      "52": {
-        "Integer": {
-          "value": 3
+      "52" : {
+        "Integer" : {
+          "value" : 3
         }
       },
-      "19": {
-        "Integer": {
-          "value": 2
+      "19" : {
+        "Integer" : {
+          "value" : 2
         }
       },
-      "23": {
-        "Integer": {
-          "value": -1
+      "23" : {
+        "Integer" : {
+          "value" : -1
         }
       },
-      "22": {
-        "Integer": {
-          "value": 1
+      "22" : {
+        "Integer" : {
+          "value" : 1
         }
       },
-      "56": {
-        "Integer": {
-          "value": 1
+      "56" : {
+        "Integer" : {
+          "value" : 1
         }
       },
-      "17": {
-        "Integer": {
-          "value": -3
+      "17" : {
+        "Integer" : {
+          "value" : -3
         }
       },
-      "25": {
-        "Integer": {
-          "value": 3
+      "25" : {
+        "Integer" : {
+          "value" : 3
         }
       },
-      "20": {
-        "Integer": {
-          "value": -2
+      "20" : {
+        "Integer" : {
+          "value" : -2
         }
       },
-      "27": {
-        "Integer": {
-          "value": 2
+      "27" : {
+        "Integer" : {
+          "value" : 2
         }
       }
     },
-    "stateMachineMap": {},
-    "dictionarySymbolSet": [],
-    "interfaceMap": {}
+    "stateMachineMap" : {
+      
+    },
+    "dictionarySymbolSet" : [
+    ],
+    "interfaceMap" : {
+      
+    }
   }
 }

--- a/tests/telemetry/telemetry_analysis.json
+++ b/tests/telemetry/telemetry_analysis.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion": "[ fpp version ]",
+  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
   "analysis": {
     "componentInstanceMap": {
       "67": {

--- a/tests/telemetry/telemetry_ast.json
+++ b/tests/telemetry/telemetry_ast.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion": "[ fpp version ]",
+  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
   "ast": [
     {
       "members": [

--- a/tests/telemetry/telemetry_ast.json
+++ b/tests/telemetry/telemetry_ast.json
@@ -1,667 +1,752 @@
 {
-  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
-  "ast": [
+  "fppVersion" : "v3.1.0a10-54-g11243e778",
+  "ast" : [
     {
-      "members": [
+      "members" : [
         [
-          ["Component for illustrating telemetry channel limits"],
+          [
+            "Component for illustrating telemetry channel limits"
+          ],
           {
-            "DefComponent": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "kind": {
-                      "Passive": {}
+            "DefComponent" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "kind" : {
+                      "Passive" : {
+                        
+                      }
                     },
-                    "name": "TlmLimits",
-                    "members": [
+                    "name" : "TlmLimits",
+                    "members" : [
                       [
-                        ["Telemetry port"],
+                        [
+                          "Telemetry port"
+                        ],
                         {
-                          "SpecPortInstance": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "Special": {
-                                    "inputKind": "None",
-                                    "kind": {
-                                      "Telemetry": {}
+                          "SpecPortInstance" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "Special" : {
+                                    "inputKind" : "None",
+                                    "kind" : {
+                                      "Telemetry" : {
+                                        
+                                      }
                                     },
-                                    "name": "tlmOut",
-                                    "priority": "None",
-                                    "queueFull": "None"
+                                    "name" : "tlmOut",
+                                    "priority" : "None",
+                                    "queueFull" : "None"
                                   }
                                 },
-                                "id": 0
+                                "id" : 0
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        ["Time get port"],
+                        [
+                          "Time get port"
+                        ],
                         {
-                          "SpecPortInstance": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "Special": {
-                                    "inputKind": "None",
-                                    "kind": {
-                                      "TimeGet": {}
+                          "SpecPortInstance" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "Special" : {
+                                    "inputKind" : "None",
+                                    "kind" : {
+                                      "TimeGet" : {
+                                        
+                                      }
                                     },
-                                    "name": "timeGetOut",
-                                    "priority": "None",
-                                    "queueFull": "None"
+                                    "name" : "timeGetOut",
+                                    "priority" : "None",
+                                    "queueFull" : "None"
                                   }
                                 },
-                                "id": 1
+                                "id" : 1
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        ["Telemetry channel 1"],
+                        [
+                          "Telemetry channel 1"
+                        ],
                         {
-                          "SpecTlmChannel": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "name": "Channel1",
-                                  "typeName": {
-                                    "AstNode": {
-                                      "data": {
-                                        "TypeNameInt": {
-                                          "name": {
-                                            "U32": {}
+                          "SpecTlmChannel" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "name" : "Channel1",
+                                  "typeName" : {
+                                    "AstNode" : {
+                                      "data" : {
+                                        "TypeNameInt" : {
+                                          "name" : {
+                                            "U32" : {
+                                              
+                                            }
                                           }
                                         }
                                       },
-                                      "id": 2
+                                      "id" : 2
                                     }
                                   },
-                                  "id": {
-                                    "Some": {
-                                      "AstNode": {
-                                        "data": {
-                                          "ExprLiteralInt": {
-                                            "value": "0"
+                                  "id" : {
+                                    "Some" : {
+                                      "AstNode" : {
+                                        "data" : {
+                                          "ExprLiteralInt" : {
+                                            "value" : "0"
                                           }
                                         },
-                                        "id": 3
+                                        "id" : 3
                                       }
                                     }
                                   },
-                                  "update": "None",
-                                  "format": {
-                                    "Some": {
-                                      "AstNode": {
-                                        "data": "{}s",
-                                        "id": 4
+                                  "update" : "None",
+                                  "format" : {
+                                    "Some" : {
+                                      "AstNode" : {
+                                        "data" : "{}s",
+                                        "id" : 4
                                       }
                                     }
                                   },
-                                  "low": [
+                                  "low" : [
                                     [
                                       {
-                                        "AstNode": {
-                                          "data": {
-                                            "Red": {}
+                                        "AstNode" : {
+                                          "data" : {
+                                            "Red" : {
+                                              
+                                            }
                                           },
-                                          "id": 5
+                                          "id" : 5
                                         }
                                       },
                                       {
-                                        "AstNode": {
-                                          "data": {
-                                            "ExprLiteralInt": {
-                                              "value": "0"
+                                        "AstNode" : {
+                                          "data" : {
+                                            "ExprLiteralInt" : {
+                                              "value" : "0"
                                             }
                                           },
-                                          "id": 6
+                                          "id" : 6
                                         }
                                       }
                                     ],
                                     [
                                       {
-                                        "AstNode": {
-                                          "data": {
-                                            "Orange": {}
+                                        "AstNode" : {
+                                          "data" : {
+                                            "Orange" : {
+                                              
+                                            }
                                           },
-                                          "id": 7
+                                          "id" : 7
                                         }
                                       },
                                       {
-                                        "AstNode": {
-                                          "data": {
-                                            "ExprLiteralInt": {
-                                              "value": "1"
+                                        "AstNode" : {
+                                          "data" : {
+                                            "ExprLiteralInt" : {
+                                              "value" : "1"
                                             }
                                           },
-                                          "id": 8
+                                          "id" : 8
                                         }
                                       }
                                     ],
                                     [
                                       {
-                                        "AstNode": {
-                                          "data": {
-                                            "Yellow": {}
+                                        "AstNode" : {
+                                          "data" : {
+                                            "Yellow" : {
+                                              
+                                            }
                                           },
-                                          "id": 9
+                                          "id" : 9
                                         }
                                       },
                                       {
-                                        "AstNode": {
-                                          "data": {
-                                            "ExprLiteralInt": {
-                                              "value": "2"
+                                        "AstNode" : {
+                                          "data" : {
+                                            "ExprLiteralInt" : {
+                                              "value" : "2"
                                             }
                                           },
-                                          "id": 10
+                                          "id" : 10
                                         }
                                       }
                                     ]
                                   ],
-                                  "high": []
+                                  "high" : [
+                                  ]
                                 },
-                                "id": 11
+                                "id" : 11
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        ["Telemetry channel 2"],
+                        [
+                          "Telemetry channel 2"
+                        ],
                         {
-                          "SpecTlmChannel": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "name": "Channel2",
-                                  "typeName": {
-                                    "AstNode": {
-                                      "data": {
-                                        "TypeNameFloat": {
-                                          "name": {
-                                            "F64": {}
+                          "SpecTlmChannel" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "name" : "Channel2",
+                                  "typeName" : {
+                                    "AstNode" : {
+                                      "data" : {
+                                        "TypeNameFloat" : {
+                                          "name" : {
+                                            "F64" : {
+                                              
+                                            }
                                           }
                                         }
                                       },
-                                      "id": 12
+                                      "id" : 12
                                     }
                                   },
-                                  "id": {
-                                    "Some": {
-                                      "AstNode": {
-                                        "data": {
-                                          "ExprLiteralInt": {
-                                            "value": "0x10"
+                                  "id" : {
+                                    "Some" : {
+                                      "AstNode" : {
+                                        "data" : {
+                                          "ExprLiteralInt" : {
+                                            "value" : "0x10"
                                           }
                                         },
-                                        "id": 13
+                                        "id" : 13
                                       }
                                     }
                                   },
-                                  "update": {
-                                    "Some": {
-                                      "OnChange": {}
-                                    }
-                                  },
-                                  "format": {
-                                    "Some": {
-                                      "AstNode": {
-                                        "data": "{.3f}",
-                                        "id": 14
+                                  "update" : {
+                                    "Some" : {
+                                      "OnChange" : {
+                                        
                                       }
                                     }
                                   },
-                                  "low": [
+                                  "format" : {
+                                    "Some" : {
+                                      "AstNode" : {
+                                        "data" : "{.3f}",
+                                        "id" : 14
+                                      }
+                                    }
+                                  },
+                                  "low" : [
                                     [
                                       {
-                                        "AstNode": {
-                                          "data": {
-                                            "Red": {}
+                                        "AstNode" : {
+                                          "data" : {
+                                            "Red" : {
+                                              
+                                            }
                                           },
-                                          "id": 15
+                                          "id" : 15
                                         }
                                       },
                                       {
-                                        "AstNode": {
-                                          "data": {
-                                            "ExprUnop": {
-                                              "op": {
-                                                "Minus": {}
+                                        "AstNode" : {
+                                          "data" : {
+                                            "ExprUnop" : {
+                                              "op" : {
+                                                "Minus" : {
+                                                  
+                                                }
                                               },
-                                              "e": {
-                                                "AstNode": {
-                                                  "data": {
-                                                    "ExprLiteralInt": {
-                                                      "value": "3"
+                                              "e" : {
+                                                "AstNode" : {
+                                                  "data" : {
+                                                    "ExprLiteralInt" : {
+                                                      "value" : "3"
                                                     }
                                                   },
-                                                  "id": 16
+                                                  "id" : 16
                                                 }
                                               }
                                             }
                                           },
-                                          "id": 17
+                                          "id" : 17
                                         }
                                       }
                                     ],
                                     [
                                       {
-                                        "AstNode": {
-                                          "data": {
-                                            "Orange": {}
+                                        "AstNode" : {
+                                          "data" : {
+                                            "Orange" : {
+                                              
+                                            }
                                           },
-                                          "id": 18
+                                          "id" : 18
                                         }
                                       },
                                       {
-                                        "AstNode": {
-                                          "data": {
-                                            "ExprUnop": {
-                                              "op": {
-                                                "Minus": {}
+                                        "AstNode" : {
+                                          "data" : {
+                                            "ExprUnop" : {
+                                              "op" : {
+                                                "Minus" : {
+                                                  
+                                                }
                                               },
-                                              "e": {
-                                                "AstNode": {
-                                                  "data": {
-                                                    "ExprLiteralInt": {
-                                                      "value": "2"
+                                              "e" : {
+                                                "AstNode" : {
+                                                  "data" : {
+                                                    "ExprLiteralInt" : {
+                                                      "value" : "2"
                                                     }
                                                   },
-                                                  "id": 19
+                                                  "id" : 19
                                                 }
                                               }
                                             }
                                           },
-                                          "id": 20
+                                          "id" : 20
                                         }
                                       }
                                     ],
                                     [
                                       {
-                                        "AstNode": {
-                                          "data": {
-                                            "Yellow": {}
+                                        "AstNode" : {
+                                          "data" : {
+                                            "Yellow" : {
+                                              
+                                            }
                                           },
-                                          "id": 21
+                                          "id" : 21
                                         }
                                       },
                                       {
-                                        "AstNode": {
-                                          "data": {
-                                            "ExprUnop": {
-                                              "op": {
-                                                "Minus": {}
+                                        "AstNode" : {
+                                          "data" : {
+                                            "ExprUnop" : {
+                                              "op" : {
+                                                "Minus" : {
+                                                  
+                                                }
                                               },
-                                              "e": {
-                                                "AstNode": {
-                                                  "data": {
-                                                    "ExprLiteralInt": {
-                                                      "value": "1"
+                                              "e" : {
+                                                "AstNode" : {
+                                                  "data" : {
+                                                    "ExprLiteralInt" : {
+                                                      "value" : "1"
                                                     }
                                                   },
-                                                  "id": 22
+                                                  "id" : 22
                                                 }
                                               }
                                             }
                                           },
-                                          "id": 23
+                                          "id" : 23
                                         }
                                       }
                                     ]
                                   ],
-                                  "high": [
+                                  "high" : [
                                     [
                                       {
-                                        "AstNode": {
-                                          "data": {
-                                            "Red": {}
+                                        "AstNode" : {
+                                          "data" : {
+                                            "Red" : {
+                                              
+                                            }
                                           },
-                                          "id": 24
+                                          "id" : 24
                                         }
                                       },
                                       {
-                                        "AstNode": {
-                                          "data": {
-                                            "ExprLiteralInt": {
-                                              "value": "3"
+                                        "AstNode" : {
+                                          "data" : {
+                                            "ExprLiteralInt" : {
+                                              "value" : "3"
                                             }
                                           },
-                                          "id": 25
+                                          "id" : 25
                                         }
                                       }
                                     ],
                                     [
                                       {
-                                        "AstNode": {
-                                          "data": {
-                                            "Orange": {}
+                                        "AstNode" : {
+                                          "data" : {
+                                            "Orange" : {
+                                              
+                                            }
                                           },
-                                          "id": 26
+                                          "id" : 26
                                         }
                                       },
                                       {
-                                        "AstNode": {
-                                          "data": {
-                                            "ExprLiteralInt": {
-                                              "value": "2"
+                                        "AstNode" : {
+                                          "data" : {
+                                            "ExprLiteralInt" : {
+                                              "value" : "2"
                                             }
                                           },
-                                          "id": 27
+                                          "id" : 27
                                         }
                                       }
                                     ],
                                     [
                                       {
-                                        "AstNode": {
-                                          "data": {
-                                            "Yellow": {}
+                                        "AstNode" : {
+                                          "data" : {
+                                            "Yellow" : {
+                                              
+                                            }
                                           },
-                                          "id": 28
+                                          "id" : 28
                                         }
                                       },
                                       {
-                                        "AstNode": {
-                                          "data": {
-                                            "ExprLiteralInt": {
-                                              "value": "1"
+                                        "AstNode" : {
+                                          "data" : {
+                                            "ExprLiteralInt" : {
+                                              "value" : "1"
                                             }
                                           },
-                                          "id": 29
+                                          "id" : 29
                                         }
                                       }
                                     ]
                                   ]
                                 },
-                                "id": 30
+                                "id" : 30
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        ["Telemetry channel 3"],
+                        [
+                          "Telemetry channel 3"
+                        ],
                         {
-                          "SpecTlmChannel": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "name": "Channel3",
-                                  "typeName": {
-                                    "AstNode": {
-                                      "data": {
-                                        "TypeNameFloat": {
-                                          "name": {
-                                            "F64": {}
+                          "SpecTlmChannel" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "name" : "Channel3",
+                                  "typeName" : {
+                                    "AstNode" : {
+                                      "data" : {
+                                        "TypeNameFloat" : {
+                                          "name" : {
+                                            "F64" : {
+                                              
+                                            }
                                           }
                                         }
                                       },
-                                      "id": 49
+                                      "id" : 49
                                     }
                                   },
-                                  "id": "None",
-                                  "update": {
-                                    "Some": {
-                                      "Always": {}
-                                    }
-                                  },
-                                  "format": {
-                                    "Some": {
-                                      "AstNode": {
-                                        "data": "{e}",
-                                        "id": 50
+                                  "id" : "None",
+                                  "update" : {
+                                    "Some" : {
+                                      "Always" : {
+                                        
                                       }
                                     }
                                   },
-                                  "low": [],
-                                  "high": [
-                                    [
-                                      {
-                                        "AstNode": {
-                                          "data": {
-                                            "Red": {}
-                                          },
-                                          "id": 51
-                                        }
-                                      },
-                                      {
-                                        "AstNode": {
-                                          "data": {
-                                            "ExprLiteralInt": {
-                                              "value": "3"
-                                            }
-                                          },
-                                          "id": 52
-                                        }
+                                  "format" : {
+                                    "Some" : {
+                                      "AstNode" : {
+                                        "data" : "{e}",
+                                        "id" : 50
                                       }
-                                    ],
+                                    }
+                                  },
+                                  "low" : [
+                                  ],
+                                  "high" : [
                                     [
                                       {
-                                        "AstNode": {
-                                          "data": {
-                                            "Orange": {}
+                                        "AstNode" : {
+                                          "data" : {
+                                            "Red" : {
+                                              
+                                            }
                                           },
-                                          "id": 53
+                                          "id" : 51
                                         }
                                       },
                                       {
-                                        "AstNode": {
-                                          "data": {
-                                            "ExprLiteralInt": {
-                                              "value": "2"
+                                        "AstNode" : {
+                                          "data" : {
+                                            "ExprLiteralInt" : {
+                                              "value" : "3"
                                             }
                                           },
-                                          "id": 54
+                                          "id" : 52
                                         }
                                       }
                                     ],
                                     [
                                       {
-                                        "AstNode": {
-                                          "data": {
-                                            "Yellow": {}
+                                        "AstNode" : {
+                                          "data" : {
+                                            "Orange" : {
+                                              
+                                            }
                                           },
-                                          "id": 55
+                                          "id" : 53
                                         }
                                       },
                                       {
-                                        "AstNode": {
-                                          "data": {
-                                            "ExprLiteralInt": {
-                                              "value": "1"
+                                        "AstNode" : {
+                                          "data" : {
+                                            "ExprLiteralInt" : {
+                                              "value" : "2"
                                             }
                                           },
-                                          "id": 56
+                                          "id" : 54
+                                        }
+                                      }
+                                    ],
+                                    [
+                                      {
+                                        "AstNode" : {
+                                          "data" : {
+                                            "Yellow" : {
+                                              
+                                            }
+                                          },
+                                          "id" : 55
+                                        }
+                                      },
+                                      {
+                                        "AstNode" : {
+                                          "data" : {
+                                            "ExprLiteralInt" : {
+                                              "value" : "1"
+                                            }
+                                          },
+                                          "id" : 56
                                         }
                                       }
                                     ]
                                   ]
                                 },
-                                "id": 57
+                                "id" : 57
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ]
                     ]
                   },
-                  "id": 58
+                  "id" : 58
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          [],
+          [
+          ],
           {
-            "DefModule": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "Fw",
-                    "members": [
+            "DefModule" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "Fw",
+                    "members" : [
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "DefPort": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "name": "Tlm",
-                                  "params": [],
-                                  "returnType": "None"
+                          "DefPort" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "name" : "Tlm",
+                                  "params" : [
+                                  ],
+                                  "returnType" : "None"
                                 },
-                                "id": 59
+                                "id" : 59
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "DefPort": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "name": "Time",
-                                  "params": [],
-                                  "returnType": "None"
+                          "DefPort" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "name" : "Time",
+                                  "params" : [
+                                  ],
+                                  "returnType" : "None"
                                 },
-                                "id": 62
+                                "id" : 62
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ]
                     ]
                   },
-                  "id": 63
+                  "id" : 63
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          [],
+          [
+          ],
           {
-            "DefComponentInstance": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "i",
-                    "component": {
-                      "AstNode": {
-                        "data": {
-                          "Unqualified": {
-                            "name": "TlmLimits"
+            "DefComponentInstance" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "i",
+                    "component" : {
+                      "AstNode" : {
+                        "data" : {
+                          "Unqualified" : {
+                            "name" : "TlmLimits"
                           }
                         },
-                        "id": 65
+                        "id" : 65
                       }
                     },
-                    "baseId": {
-                      "AstNode": {
-                        "data": {
-                          "ExprLiteralInt": {
-                            "value": "0x4A00"
+                    "baseId" : {
+                      "AstNode" : {
+                        "data" : {
+                          "ExprLiteralInt" : {
+                            "value" : "0x4A00"
                           }
                         },
-                        "id": 66
+                        "id" : 66
                       }
                     },
-                    "implType": "None",
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecs": []
+                    "implType" : "None",
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecs" : [
+                    ]
                   },
-                  "id": 67
+                  "id" : 67
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          [],
+          [
+          ],
           {
-            "DefModule": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "M",
-                    "members": [
+            "DefModule" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "M",
+                    "members" : [
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "DefTopology": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "name": "T",
-                                  "members": [
+                          "DefTopology" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "name" : "T",
+                                  "members" : [
                                     [
-                                      [],
+                                      [
+                                      ],
                                       {
-                                        "SpecCompInstance": {
-                                          "node": {
-                                            "AstNode": {
-                                              "data": {
-                                                "visibility": {
-                                                  "Public": {}
+                                        "SpecCompInstance" : {
+                                          "node" : {
+                                            "AstNode" : {
+                                              "data" : {
+                                                "visibility" : {
+                                                  "Public" : {
+                                                    
+                                                  }
                                                 },
-                                                "instance": {
-                                                  "AstNode": {
-                                                    "data": {
-                                                      "Unqualified": {
-                                                        "name": "i"
+                                                "instance" : {
+                                                  "AstNode" : {
+                                                    "data" : {
+                                                      "Unqualified" : {
+                                                        "name" : "i"
                                                       }
                                                     },
-                                                    "id": 95
+                                                    "id" : 95
                                                   }
                                                 }
                                               },
-                                              "id": 96
+                                              "id" : 96
                                             }
                                           }
                                         }
                                       },
-                                      []
+                                      [
+                                      ]
                                     ]
                                   ]
                                 },
-                                "id": 97
+                                "id" : 97
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ]
                     ]
                   },
-                  "id": 98
+                  "id" : 98
                 }
               }
             }
           },
-          []
+          [
+          ]
         ]
       ]
     }

--- a/tests/telemetry/telemetry_locations.json
+++ b/tests/telemetry/telemetry_locations.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion": "[ fpp version ]",
+  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
   "locationMap": {
     "0": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",

--- a/tests/telemetry/telemetry_locations.json
+++ b/tests/telemetry/telemetry_locations.json
@@ -1,500 +1,500 @@
 {
-  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
-  "locationMap": {
-    "0": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "9.3",
-      "includingLoc": "None"
-    },
-    "1": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "12.3",
-      "includingLoc": "None"
-    },
-    "2": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "19.23",
-      "includingLoc": "None"
-    },
-    "3": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "19.30",
-      "includingLoc": "None"
-    },
-    "4": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "20.12",
-      "includingLoc": "None"
-    },
-    "5": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "21.11",
-      "includingLoc": "None"
-    },
-    "6": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "21.15",
-      "includingLoc": "None"
-    },
-    "7": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "21.18",
-      "includingLoc": "None"
-    },
-    "8": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "21.25",
-      "includingLoc": "None"
-    },
-    "9": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "21.28",
-      "includingLoc": "None"
-    },
-    "10": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "21.35",
-      "includingLoc": "None"
-    },
-    "11": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "19.3",
-      "includingLoc": "None"
-    },
-    "12": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "24.23",
-      "includingLoc": "None"
-    },
-    "13": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "24.30",
-      "includingLoc": "None"
-    },
-    "14": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "26.12",
-      "includingLoc": "None"
-    },
-    "15": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "27.11",
-      "includingLoc": "None"
-    },
-    "16": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "27.16",
-      "includingLoc": "None"
-    },
-    "17": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "27.15",
-      "includingLoc": "None"
-    },
-    "18": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "27.19",
-      "includingLoc": "None"
-    },
-    "19": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "27.27",
-      "includingLoc": "None"
-    },
-    "20": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "27.26",
-      "includingLoc": "None"
-    },
-    "21": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "27.30",
-      "includingLoc": "None"
-    },
-    "22": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "27.38",
-      "includingLoc": "None"
-    },
-    "23": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "27.37",
-      "includingLoc": "None"
-    },
-    "24": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "28.12",
-      "includingLoc": "None"
-    },
-    "25": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "28.16",
-      "includingLoc": "None"
-    },
-    "26": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "28.19",
-      "includingLoc": "None"
-    },
-    "27": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "28.26",
-      "includingLoc": "None"
-    },
-    "28": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "28.29",
-      "includingLoc": "None"
-    },
-    "29": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "28.36",
-      "includingLoc": "None"
-    },
-    "30": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "24.3",
-      "includingLoc": "None"
-    },
-    "31": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "31.23",
-      "includingLoc": "None"
-    },
-    "32": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "33.12",
-      "includingLoc": "None"
-    },
-    "33": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "34.12",
-      "includingLoc": "None"
-    },
-    "34": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "34.16",
-      "includingLoc": "None"
-    },
-    "35": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "34.19",
-      "includingLoc": "None"
-    },
-    "36": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "34.26",
-      "includingLoc": "None"
-    },
-    "37": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "34.29",
-      "includingLoc": "None"
-    },
-    "38": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "34.36",
-      "includingLoc": "None"
-    },
-    "39": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "31.3",
-      "includingLoc": "None"
-    },
-    "40": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "31.23",
-      "includingLoc": "None"
-    },
-    "41": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "33.12",
-      "includingLoc": "None"
-    },
-    "42": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "34.12",
-      "includingLoc": "None"
-    },
-    "43": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "34.16",
-      "includingLoc": "None"
-    },
-    "44": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "34.19",
-      "includingLoc": "None"
-    },
-    "45": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "34.26",
-      "includingLoc": "None"
-    },
-    "46": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "34.29",
-      "includingLoc": "None"
-    },
-    "47": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "34.36",
-      "includingLoc": "None"
-    },
-    "48": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "31.3",
-      "includingLoc": "None"
-    },
-    "49": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "31.23",
-      "includingLoc": "None"
-    },
-    "50": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "33.12",
-      "includingLoc": "None"
-    },
-    "51": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "34.12",
-      "includingLoc": "None"
-    },
-    "52": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "34.16",
-      "includingLoc": "None"
-    },
-    "53": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "34.19",
-      "includingLoc": "None"
-    },
-    "54": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "34.26",
-      "includingLoc": "None"
-    },
-    "55": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "34.29",
-      "includingLoc": "None"
-    },
-    "56": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "34.36",
-      "includingLoc": "None"
-    },
-    "57": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "31.3",
-      "includingLoc": "None"
-    },
-    "58": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "2.1",
-      "includingLoc": "None"
-    },
-    "59": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "39.3",
-      "includingLoc": "None"
-    },
-    "60": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "40.3",
-      "includingLoc": "None"
-    },
-    "61": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "40.3",
-      "includingLoc": "None"
-    },
-    "62": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "40.3",
-      "includingLoc": "None"
-    },
-    "63": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "38.1",
-      "includingLoc": "None"
-    },
-    "64": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "43.13",
-      "includingLoc": "None"
-    },
-    "65": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "43.13",
-      "includingLoc": "None"
-    },
-    "66": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "43.31",
-      "includingLoc": "None"
-    },
-    "67": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "43.1",
-      "includingLoc": "None"
-    },
-    "68": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "47.18",
-      "includingLoc": "None"
-    },
-    "69": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "47.18",
-      "includingLoc": "None"
-    },
-    "70": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "47.9",
-      "includingLoc": "None"
-    },
-    "71": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "47.18",
-      "includingLoc": "None"
-    },
-    "72": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "47.18",
-      "includingLoc": "None"
-    },
-    "73": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "47.9",
-      "includingLoc": "None"
-    },
-    "74": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "47.18",
-      "includingLoc": "None"
-    },
-    "75": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "47.18",
-      "includingLoc": "None"
-    },
-    "76": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "47.9",
-      "includingLoc": "None"
-    },
-    "77": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "46.5",
-      "includingLoc": "None"
-    },
-    "78": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "47.18",
-      "includingLoc": "None"
-    },
-    "79": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "47.18",
-      "includingLoc": "None"
-    },
-    "80": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "47.9",
-      "includingLoc": "None"
-    },
-    "81": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "47.18",
-      "includingLoc": "None"
-    },
-    "82": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "47.18",
-      "includingLoc": "None"
-    },
-    "83": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "47.9",
-      "includingLoc": "None"
-    },
-    "84": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "47.18",
-      "includingLoc": "None"
-    },
-    "85": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "47.18",
-      "includingLoc": "None"
-    },
-    "86": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "47.9",
-      "includingLoc": "None"
-    },
-    "87": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "46.5",
-      "includingLoc": "None"
-    },
-    "88": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "47.18",
-      "includingLoc": "None"
-    },
-    "89": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "47.18",
-      "includingLoc": "None"
-    },
-    "90": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "47.9",
-      "includingLoc": "None"
-    },
-    "91": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "47.18",
-      "includingLoc": "None"
-    },
-    "92": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "47.18",
-      "includingLoc": "None"
-    },
-    "93": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "47.9",
-      "includingLoc": "None"
-    },
-    "94": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "47.18",
-      "includingLoc": "None"
-    },
-    "95": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "47.18",
-      "includingLoc": "None"
-    },
-    "96": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "47.9",
-      "includingLoc": "None"
-    },
-    "97": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "46.5",
-      "includingLoc": "None"
-    },
-    "98": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
-      "pos": "45.1",
-      "includingLoc": "None"
+  "fppVersion" : "v3.1.0a10-54-g11243e778",
+  "locationMap" : {
+    "0" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "9.3",
+      "includingLoc" : "None"
+    },
+    "1" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "12.3",
+      "includingLoc" : "None"
+    },
+    "2" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "19.23",
+      "includingLoc" : "None"
+    },
+    "3" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "19.30",
+      "includingLoc" : "None"
+    },
+    "4" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "20.12",
+      "includingLoc" : "None"
+    },
+    "5" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "21.11",
+      "includingLoc" : "None"
+    },
+    "6" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "21.15",
+      "includingLoc" : "None"
+    },
+    "7" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "21.18",
+      "includingLoc" : "None"
+    },
+    "8" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "21.25",
+      "includingLoc" : "None"
+    },
+    "9" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "21.28",
+      "includingLoc" : "None"
+    },
+    "10" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "21.35",
+      "includingLoc" : "None"
+    },
+    "11" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "19.3",
+      "includingLoc" : "None"
+    },
+    "12" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "24.23",
+      "includingLoc" : "None"
+    },
+    "13" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "24.30",
+      "includingLoc" : "None"
+    },
+    "14" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "26.12",
+      "includingLoc" : "None"
+    },
+    "15" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "27.11",
+      "includingLoc" : "None"
+    },
+    "16" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "27.16",
+      "includingLoc" : "None"
+    },
+    "17" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "27.15",
+      "includingLoc" : "None"
+    },
+    "18" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "27.19",
+      "includingLoc" : "None"
+    },
+    "19" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "27.27",
+      "includingLoc" : "None"
+    },
+    "20" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "27.26",
+      "includingLoc" : "None"
+    },
+    "21" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "27.30",
+      "includingLoc" : "None"
+    },
+    "22" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "27.38",
+      "includingLoc" : "None"
+    },
+    "23" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "27.37",
+      "includingLoc" : "None"
+    },
+    "24" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "28.12",
+      "includingLoc" : "None"
+    },
+    "25" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "28.16",
+      "includingLoc" : "None"
+    },
+    "26" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "28.19",
+      "includingLoc" : "None"
+    },
+    "27" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "28.26",
+      "includingLoc" : "None"
+    },
+    "28" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "28.29",
+      "includingLoc" : "None"
+    },
+    "29" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "28.36",
+      "includingLoc" : "None"
+    },
+    "30" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "24.3",
+      "includingLoc" : "None"
+    },
+    "31" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "31.23",
+      "includingLoc" : "None"
+    },
+    "32" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "33.12",
+      "includingLoc" : "None"
+    },
+    "33" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "34.12",
+      "includingLoc" : "None"
+    },
+    "34" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "34.16",
+      "includingLoc" : "None"
+    },
+    "35" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "34.19",
+      "includingLoc" : "None"
+    },
+    "36" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "34.26",
+      "includingLoc" : "None"
+    },
+    "37" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "34.29",
+      "includingLoc" : "None"
+    },
+    "38" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "34.36",
+      "includingLoc" : "None"
+    },
+    "39" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "31.3",
+      "includingLoc" : "None"
+    },
+    "40" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "31.23",
+      "includingLoc" : "None"
+    },
+    "41" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "33.12",
+      "includingLoc" : "None"
+    },
+    "42" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "34.12",
+      "includingLoc" : "None"
+    },
+    "43" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "34.16",
+      "includingLoc" : "None"
+    },
+    "44" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "34.19",
+      "includingLoc" : "None"
+    },
+    "45" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "34.26",
+      "includingLoc" : "None"
+    },
+    "46" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "34.29",
+      "includingLoc" : "None"
+    },
+    "47" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "34.36",
+      "includingLoc" : "None"
+    },
+    "48" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "31.3",
+      "includingLoc" : "None"
+    },
+    "49" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "31.23",
+      "includingLoc" : "None"
+    },
+    "50" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "33.12",
+      "includingLoc" : "None"
+    },
+    "51" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "34.12",
+      "includingLoc" : "None"
+    },
+    "52" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "34.16",
+      "includingLoc" : "None"
+    },
+    "53" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "34.19",
+      "includingLoc" : "None"
+    },
+    "54" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "34.26",
+      "includingLoc" : "None"
+    },
+    "55" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "34.29",
+      "includingLoc" : "None"
+    },
+    "56" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "34.36",
+      "includingLoc" : "None"
+    },
+    "57" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "31.3",
+      "includingLoc" : "None"
+    },
+    "58" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "2.1",
+      "includingLoc" : "None"
+    },
+    "59" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "39.3",
+      "includingLoc" : "None"
+    },
+    "60" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "40.3",
+      "includingLoc" : "None"
+    },
+    "61" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "40.3",
+      "includingLoc" : "None"
+    },
+    "62" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "40.3",
+      "includingLoc" : "None"
+    },
+    "63" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "38.1",
+      "includingLoc" : "None"
+    },
+    "64" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "43.13",
+      "includingLoc" : "None"
+    },
+    "65" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "43.13",
+      "includingLoc" : "None"
+    },
+    "66" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "43.31",
+      "includingLoc" : "None"
+    },
+    "67" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "43.1",
+      "includingLoc" : "None"
+    },
+    "68" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "47.18",
+      "includingLoc" : "None"
+    },
+    "69" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "47.18",
+      "includingLoc" : "None"
+    },
+    "70" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "47.9",
+      "includingLoc" : "None"
+    },
+    "71" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "47.18",
+      "includingLoc" : "None"
+    },
+    "72" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "47.18",
+      "includingLoc" : "None"
+    },
+    "73" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "47.9",
+      "includingLoc" : "None"
+    },
+    "74" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "47.18",
+      "includingLoc" : "None"
+    },
+    "75" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "47.18",
+      "includingLoc" : "None"
+    },
+    "76" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "47.9",
+      "includingLoc" : "None"
+    },
+    "77" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "46.5",
+      "includingLoc" : "None"
+    },
+    "78" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "47.18",
+      "includingLoc" : "None"
+    },
+    "79" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "47.18",
+      "includingLoc" : "None"
+    },
+    "80" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "47.9",
+      "includingLoc" : "None"
+    },
+    "81" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "47.18",
+      "includingLoc" : "None"
+    },
+    "82" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "47.18",
+      "includingLoc" : "None"
+    },
+    "83" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "47.9",
+      "includingLoc" : "None"
+    },
+    "84" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "47.18",
+      "includingLoc" : "None"
+    },
+    "85" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "47.18",
+      "includingLoc" : "None"
+    },
+    "86" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "47.9",
+      "includingLoc" : "None"
+    },
+    "87" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "46.5",
+      "includingLoc" : "None"
+    },
+    "88" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "47.18",
+      "includingLoc" : "None"
+    },
+    "89" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "47.18",
+      "includingLoc" : "None"
+    },
+    "90" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "47.9",
+      "includingLoc" : "None"
+    },
+    "91" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "47.18",
+      "includingLoc" : "None"
+    },
+    "92" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "47.18",
+      "includingLoc" : "None"
+    },
+    "93" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "47.9",
+      "includingLoc" : "None"
+    },
+    "94" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "47.18",
+      "includingLoc" : "None"
+    },
+    "95" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "47.18",
+      "includingLoc" : "None"
+    },
+    "96" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "47.9",
+      "includingLoc" : "None"
+    },
+    "97" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "46.5",
+      "includingLoc" : "None"
+    },
+    "98" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",
+      "pos" : "45.1",
+      "includingLoc" : "None"
     }
   }
 }

--- a/tests/telemetry_packets/telemetry_packets_analysis.json
+++ b/tests/telemetry_packets/telemetry_packets_analysis.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion": "[ fpp version ]",
+  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
   "analysis": {
     "componentInstanceMap": {
       "24": {

--- a/tests/telemetry_packets/telemetry_packets_analysis.json
+++ b/tests/telemetry_packets/telemetry_packets_analysis.json
@@ -1,938 +1,1082 @@
 {
-  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
-  "analysis": {
-    "componentInstanceMap": {
-      "24": {
-        "aNode": {
-          "astNodeId": 24
+  "fppVersion" : "v3.1.0a10-54-g11243e778",
+  "analysis" : {
+    "componentInstanceMap" : {
+      "24" : {
+        "aNode" : {
+          "astNodeId" : 24
         },
-        "qualifiedName": {
-          "qualifier": [],
-          "base": "c1"
+        "qualifiedName" : {
+          "qualifier" : [
+          ],
+          "base" : "c1"
         },
-        "component": {
-          "astNodeId": 20
+        "component" : {
+          "astNodeId" : 20
         },
-        "baseId": 256,
-        "maxId": 256,
-        "file": "None",
-        "queueSize": "None",
-        "stackSize": "None",
-        "priority": "None",
-        "cpu": "None",
-        "initSpecifierMap": {}
+        "baseId" : 256,
+        "maxId" : 256,
+        "file" : "None",
+        "queueSize" : "None",
+        "stackSize" : "None",
+        "priority" : "None",
+        "cpu" : "None",
+        "initSpecifierMap" : {
+          
+        }
       },
-      "28": {
-        "aNode": {
-          "astNodeId": 28
+      "28" : {
+        "aNode" : {
+          "astNodeId" : 28
         },
-        "qualifiedName": {
-          "qualifier": [],
-          "base": "c2"
+        "qualifiedName" : {
+          "qualifier" : [
+          ],
+          "base" : "c2"
         },
-        "component": {
-          "astNodeId": 20
+        "component" : {
+          "astNodeId" : 20
         },
-        "baseId": 512,
-        "maxId": 512,
-        "file": "None",
-        "queueSize": "None",
-        "stackSize": "None",
-        "priority": "None",
-        "cpu": "None",
-        "initSpecifierMap": {}
+        "baseId" : 512,
+        "maxId" : 512,
+        "file" : "None",
+        "queueSize" : "None",
+        "stackSize" : "None",
+        "priority" : "None",
+        "cpu" : "None",
+        "initSpecifierMap" : {
+          
+        }
       }
     },
-    "componentMap": {
-      "20": {
-        "aNode": {
-          "astNodeId": 20
+    "componentMap" : {
+      "20" : {
+        "aNode" : {
+          "astNodeId" : 20
         },
-        "portMap": {
-          "pIn": {
-            "General": {
-              "aNode": {
-                "astNodeId": 8
+        "portMap" : {
+          "pIn" : {
+            "General" : {
+              "aNode" : {
+                "astNodeId" : 8
               },
-              "specifier": {
-                "kind": {
-                  "SyncInput": {}
-                },
-                "name": "pIn",
-                "size": "None",
-                "port": {
-                  "Some": {
-                    "astNodeId": 7
+              "specifier" : {
+                "kind" : {
+                  "SyncInput" : {
+                    
                   }
                 },
-                "priority": "None",
-                "queueFull": "None"
+                "name" : "pIn",
+                "size" : "None",
+                "port" : {
+                  "Some" : {
+                    "astNodeId" : 7
+                  }
+                },
+                "priority" : "None",
+                "queueFull" : "None"
               },
-              "kind": "SyncInput",
-              "size": 1,
-              "ty": {
-                "DefPort": {
-                  "symbol": {
-                    "Port": {
-                      "nodeId": 5,
-                      "unqualifiedName": "P"
+              "kind" : "SyncInput",
+              "size" : 1,
+              "ty" : {
+                "DefPort" : {
+                  "symbol" : {
+                    "Port" : {
+                      "nodeId" : 5,
+                      "unqualifiedName" : "P"
                     }
                   }
                 }
               },
-              "importNodeIds": []
+              "importNodeIds" : [
+              ]
             }
           },
-          "pOut": {
-            "General": {
-              "aNode": {
-                "astNodeId": 11
+          "pOut" : {
+            "General" : {
+              "aNode" : {
+                "astNodeId" : 11
               },
-              "specifier": {
-                "kind": {
-                  "Output": {}
-                },
-                "name": "pOut",
-                "size": "None",
-                "port": {
-                  "Some": {
-                    "astNodeId": 10
+              "specifier" : {
+                "kind" : {
+                  "Output" : {
+                    
                   }
                 },
-                "priority": "None",
-                "queueFull": "None"
+                "name" : "pOut",
+                "size" : "None",
+                "port" : {
+                  "Some" : {
+                    "astNodeId" : 10
+                  }
+                },
+                "priority" : "None",
+                "queueFull" : "None"
               },
-              "kind": "Output",
-              "size": 1,
-              "ty": {
-                "DefPort": {
-                  "symbol": {
-                    "Port": {
-                      "nodeId": 5,
-                      "unqualifiedName": "P"
+              "kind" : "Output",
+              "size" : 1,
+              "ty" : {
+                "DefPort" : {
+                  "symbol" : {
+                    "Port" : {
+                      "nodeId" : 5,
+                      "unqualifiedName" : "P"
                     }
                   }
                 }
               },
-              "importNodeIds": []
+              "importNodeIds" : [
+              ]
             }
           },
-          "tlmOut": {
-            "Special": {
-              "aNode": {
-                "astNodeId": 12
+          "tlmOut" : {
+            "Special" : {
+              "aNode" : {
+                "astNodeId" : 12
               },
-              "specifier": {
-                "inputKind": "None",
-                "kind": {
-                  "Telemetry": {}
+              "specifier" : {
+                "inputKind" : "None",
+                "kind" : {
+                  "Telemetry" : {
+                    
+                  }
                 },
-                "name": "tlmOut",
-                "priority": "None",
-                "queueFull": "None"
+                "name" : "tlmOut",
+                "priority" : "None",
+                "queueFull" : "None"
               },
-              "symbol": {
-                "Port": {
-                  "nodeId": 0,
-                  "unqualifiedName": "Tlm"
+              "symbol" : {
+                "Port" : {
+                  "nodeId" : 0,
+                  "unqualifiedName" : "Tlm"
                 }
               },
-              "priority": "None",
-              "queueFull": "None",
-              "importNodeIds": []
+              "priority" : "None",
+              "queueFull" : "None",
+              "importNodeIds" : [
+              ]
             }
           },
-          "timeGetOut": {
-            "Special": {
-              "aNode": {
-                "astNodeId": 13
+          "timeGetOut" : {
+            "Special" : {
+              "aNode" : {
+                "astNodeId" : 13
               },
-              "specifier": {
-                "inputKind": "None",
-                "kind": {
-                  "TimeGet": {}
+              "specifier" : {
+                "inputKind" : "None",
+                "kind" : {
+                  "TimeGet" : {
+                    
+                  }
                 },
-                "name": "timeGetOut",
-                "priority": "None",
-                "queueFull": "None"
+                "name" : "timeGetOut",
+                "priority" : "None",
+                "queueFull" : "None"
               },
-              "symbol": {
-                "Port": {
-                  "nodeId": 3,
-                  "unqualifiedName": "Time"
+              "symbol" : {
+                "Port" : {
+                  "nodeId" : 3,
+                  "unqualifiedName" : "Time"
                 }
               },
-              "priority": "None",
-              "queueFull": "None",
-              "importNodeIds": []
+              "priority" : "None",
+              "queueFull" : "None",
+              "importNodeIds" : [
+              ]
             }
           }
         },
-        "specialPortMap": {
-          "telemetry": {
-            "aNode": {
-              "astNodeId": 12
+        "specialPortMap" : {
+          "telemetry" : {
+            "aNode" : {
+              "astNodeId" : 12
             },
-            "specifier": {
-              "inputKind": "None",
-              "kind": {
-                "Telemetry": {}
+            "specifier" : {
+              "inputKind" : "None",
+              "kind" : {
+                "Telemetry" : {
+                  
+                }
               },
-              "name": "tlmOut",
-              "priority": "None",
-              "queueFull": "None"
+              "name" : "tlmOut",
+              "priority" : "None",
+              "queueFull" : "None"
             },
-            "symbol": {
-              "Port": {
-                "nodeId": 0,
-                "unqualifiedName": "Tlm"
+            "symbol" : {
+              "Port" : {
+                "nodeId" : 0,
+                "unqualifiedName" : "Tlm"
               }
             },
-            "priority": "None",
-            "queueFull": "None",
-            "importNodeIds": []
+            "priority" : "None",
+            "queueFull" : "None",
+            "importNodeIds" : [
+            ]
           },
-          "time get": {
-            "aNode": {
-              "astNodeId": 13
+          "time get" : {
+            "aNode" : {
+              "astNodeId" : 13
             },
-            "specifier": {
-              "inputKind": "None",
-              "kind": {
-                "TimeGet": {}
+            "specifier" : {
+              "inputKind" : "None",
+              "kind" : {
+                "TimeGet" : {
+                  
+                }
               },
-              "name": "timeGetOut",
-              "priority": "None",
-              "queueFull": "None"
+              "name" : "timeGetOut",
+              "priority" : "None",
+              "queueFull" : "None"
             },
-            "symbol": {
-              "Port": {
-                "nodeId": 3,
-                "unqualifiedName": "Time"
+            "symbol" : {
+              "Port" : {
+                "nodeId" : 3,
+                "unqualifiedName" : "Time"
               }
             },
-            "priority": "None",
-            "queueFull": "None",
-            "importNodeIds": []
+            "priority" : "None",
+            "queueFull" : "None",
+            "importNodeIds" : [
+            ]
           }
         },
-        "commandMap": {},
-        "defaultOpcode": 0,
-        "tlmChannelMap": {
-          "0": {
-            "aNode": {
-              "astNodeId": 19
+        "commandMap" : {
+          
+        },
+        "defaultOpcode" : 0,
+        "tlmChannelMap" : {
+          "0" : {
+            "aNode" : {
+              "astNodeId" : 19
             },
-            "channelType": {
-              "Int": {
-                "PrimitiveInt": {
-                  "kind": {
-                    "U32": {}
+            "channelType" : {
+              "Int" : {
+                "PrimitiveInt" : {
+                  "kind" : {
+                    "U32" : {
+                      
+                    }
                   }
                 }
               }
             },
-            "update": {
-              "Always": {}
+            "update" : {
+              "Always" : {
+                
+              }
             },
-            "format": "None",
-            "lowLimits": {},
-            "highLimits": {}
+            "format" : "None",
+            "lowLimits" : {
+              
+            },
+            "highLimits" : {
+              
+            }
           }
         },
-        "tlmChannelNameMap": {
-          "T": {
-            "aNode": {
-              "astNodeId": 19
+        "tlmChannelNameMap" : {
+          "T" : {
+            "aNode" : {
+              "astNodeId" : 19
             },
-            "channelType": {
-              "Int": {
-                "PrimitiveInt": {
-                  "kind": {
-                    "U32": {}
+            "channelType" : {
+              "Int" : {
+                "PrimitiveInt" : {
+                  "kind" : {
+                    "U32" : {
+                      
+                    }
                   }
                 }
               }
             },
-            "update": {
-              "Always": {}
+            "update" : {
+              "Always" : {
+                
+              }
             },
-            "format": "None",
-            "lowLimits": {},
-            "highLimits": {}
+            "format" : "None",
+            "lowLimits" : {
+              
+            },
+            "highLimits" : {
+              
+            }
           }
         },
-        "defaultTlmChannelId": 1,
-        "eventMap": {},
-        "defaultEventId": 0,
-        "paramMap": {},
-        "specPortMatchingList": [],
-        "stateMachineInstanceMap": {},
-        "portMatchingList": [],
-        "defaultParamId": 0,
-        "containerMap": {},
-        "defaultContainerId": 0,
-        "recordMap": {},
-        "defaultRecordId": 0
+        "defaultTlmChannelId" : 1,
+        "eventMap" : {
+          
+        },
+        "defaultEventId" : 0,
+        "paramMap" : {
+          
+        },
+        "specPortMatchingList" : [
+        ],
+        "stateMachineInstanceMap" : {
+          
+        },
+        "portMatchingList" : [
+        ],
+        "defaultParamId" : 0,
+        "containerMap" : {
+          
+        },
+        "defaultContainerId" : 0,
+        "recordMap" : {
+          
+        },
+        "defaultRecordId" : 0
       }
     },
-    "includedFileSet": [],
-    "inputFileSet": [
+    "includedFileSet" : [
+    ],
+    "inputFileSet" : [
       "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp"
     ],
-    "locationSpecifierMap": [],
-    "parentSymbolMap": {
-      "0": {
-        "Module": {
-          "nodeId": 4,
-          "unqualifiedName": "Fw"
+    "locationSpecifierMap" : [
+    ],
+    "parentSymbolMap" : {
+      "0" : {
+        "Module" : {
+          "nodeId" : 4,
+          "unqualifiedName" : "Fw"
         }
       },
-      "3": {
-        "Module": {
-          "nodeId": 4,
-          "unqualifiedName": "Fw"
+      "3" : {
+        "Module" : {
+          "nodeId" : 4,
+          "unqualifiedName" : "Fw"
         }
       }
     },
-    "symbolScopeMap": {
-      "4": {
-        "map": {
-          "Port": {
-            "map": {
-              "Tlm": {
-                "Port": {
-                  "nodeId": 0,
-                  "unqualifiedName": "Tlm"
+    "symbolScopeMap" : {
+      "4" : {
+        "map" : {
+          "Port" : {
+            "map" : {
+              "Tlm" : {
+                "Port" : {
+                  "nodeId" : 0,
+                  "unqualifiedName" : "Tlm"
                 }
               },
-              "Time": {
-                "Port": {
-                  "nodeId": 3,
-                  "unqualifiedName": "Time"
+              "Time" : {
+                "Port" : {
+                  "nodeId" : 3,
+                  "unqualifiedName" : "Time"
                 }
               }
             }
           }
         }
       },
-      "20": {
-        "map": {}
+      "20" : {
+        "map" : {
+          
+        }
       }
     },
-    "topologyMap": {
-      "113": {
-        "aNode": {
-          "astNodeId": 113
+    "topologyMap" : {
+      "113" : {
+        "aNode" : {
+          "astNodeId" : 113
         },
-        "directImportMap": {},
-        "transitiveImportSet": [],
-        "instanceMap": [
+        "directImportMap" : {
+          
+        },
+        "transitiveImportSet" : [
+        ],
+        "instanceMap" : [
           [
             {
-              "aNode": {
-                "astNodeId": 24
+              "aNode" : {
+                "astNodeId" : 24
               },
-              "qualifiedName": {
-                "qualifier": [],
-                "base": "c1"
+              "qualifiedName" : {
+                "qualifier" : [
+                ],
+                "base" : "c1"
               },
-              "component": {
-                "astNodeId": 20
+              "component" : {
+                "astNodeId" : 20
               },
-              "baseId": 256,
-              "maxId": 256,
-              "file": "None",
-              "queueSize": "None",
-              "stackSize": "None",
-              "priority": "None",
-              "cpu": "None",
-              "initSpecifierMap": {}
+              "baseId" : 256,
+              "maxId" : 256,
+              "file" : "None",
+              "queueSize" : "None",
+              "stackSize" : "None",
+              "priority" : "None",
+              "cpu" : "None",
+              "initSpecifierMap" : {
+                
+              }
             },
             [
               {
-                "Public": {}
+                "Public" : {
+                  
+                }
               },
               {
-                "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-                "pos": "22.3",
-                "includingLoc": "None"
+                "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+                "pos" : "22.3",
+                "includingLoc" : "None"
               }
             ]
           ],
           [
             {
-              "aNode": {
-                "astNodeId": 28
+              "aNode" : {
+                "astNodeId" : 28
               },
-              "qualifiedName": {
-                "qualifier": [],
-                "base": "c2"
+              "qualifiedName" : {
+                "qualifier" : [
+                ],
+                "base" : "c2"
               },
-              "component": {
-                "astNodeId": 20
+              "component" : {
+                "astNodeId" : 20
               },
-              "baseId": 512,
-              "maxId": 512,
-              "file": "None",
-              "queueSize": "None",
-              "stackSize": "None",
-              "priority": "None",
-              "cpu": "None",
-              "initSpecifierMap": {}
+              "baseId" : 512,
+              "maxId" : 512,
+              "file" : "None",
+              "queueSize" : "None",
+              "stackSize" : "None",
+              "priority" : "None",
+              "cpu" : "None",
+              "initSpecifierMap" : {
+                
+              }
             },
             [
               {
-                "Public": {}
+                "Public" : {
+                  
+                }
               },
               {
-                "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-                "pos": "23.3",
-                "includingLoc": "None"
+                "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+                "pos" : "23.3",
+                "includingLoc" : "None"
               }
             ]
           ]
         ],
-        "patternMap": {},
-        "connectionMap": {},
-        "localConnectionMap": {},
-        "outputConnectionMap": [],
-        "inputConnectionMap": [],
-        "fromPortNumberMap": [],
-        "toPortNumberMap": [],
-        "unconnectedPortSet": [
+        "patternMap" : {
+          
+        },
+        "connectionMap" : {
+          
+        },
+        "localConnectionMap" : {
+          
+        },
+        "outputConnectionMap" : [
+        ],
+        "inputConnectionMap" : [
+        ],
+        "fromPortNumberMap" : [
+        ],
+        "toPortNumberMap" : [
+        ],
+        "unconnectedPortSet" : [
           {
-            "componentInstance": {
-              "aNode": {
-                "astNodeId": 28
+            "componentInstance" : {
+              "aNode" : {
+                "astNodeId" : 28
               },
-              "qualifiedName": {
-                "qualifier": [],
-                "base": "c2"
+              "qualifiedName" : {
+                "qualifier" : [
+                ],
+                "base" : "c2"
               },
-              "component": {
-                "astNodeId": 20
+              "component" : {
+                "astNodeId" : 20
               },
-              "baseId": 512,
-              "maxId": 512,
-              "file": "None",
-              "queueSize": "None",
-              "stackSize": "None",
-              "priority": "None",
-              "cpu": "None",
-              "initSpecifierMap": {}
+              "baseId" : 512,
+              "maxId" : 512,
+              "file" : "None",
+              "queueSize" : "None",
+              "stackSize" : "None",
+              "priority" : "None",
+              "cpu" : "None",
+              "initSpecifierMap" : {
+                
+              }
             },
-            "portInstance": {
-              "General": {
-                "aNode": {
-                  "astNodeId": 11
+            "portInstance" : {
+              "General" : {
+                "aNode" : {
+                  "astNodeId" : 11
                 },
-                "specifier": {
-                  "kind": {
-                    "Output": {}
-                  },
-                  "name": "pOut",
-                  "size": "None",
-                  "port": {
-                    "Some": {
-                      "astNodeId": 10
+                "specifier" : {
+                  "kind" : {
+                    "Output" : {
+                      
                     }
                   },
-                  "priority": "None",
-                  "queueFull": "None"
+                  "name" : "pOut",
+                  "size" : "None",
+                  "port" : {
+                    "Some" : {
+                      "astNodeId" : 10
+                    }
+                  },
+                  "priority" : "None",
+                  "queueFull" : "None"
                 },
-                "kind": "Output",
-                "size": 1,
-                "ty": {
-                  "DefPort": {
-                    "symbol": {
-                      "Port": {
-                        "nodeId": 5,
-                        "unqualifiedName": "P"
+                "kind" : "Output",
+                "size" : 1,
+                "ty" : {
+                  "DefPort" : {
+                    "symbol" : {
+                      "Port" : {
+                        "nodeId" : 5,
+                        "unqualifiedName" : "P"
                       }
                     }
                   }
                 },
-                "importNodeIds": []
+                "importNodeIds" : [
+                ]
               }
             }
           },
           {
-            "componentInstance": {
-              "aNode": {
-                "astNodeId": 28
+            "componentInstance" : {
+              "aNode" : {
+                "astNodeId" : 28
               },
-              "qualifiedName": {
-                "qualifier": [],
-                "base": "c2"
+              "qualifiedName" : {
+                "qualifier" : [
+                ],
+                "base" : "c2"
               },
-              "component": {
-                "astNodeId": 20
+              "component" : {
+                "astNodeId" : 20
               },
-              "baseId": 512,
-              "maxId": 512,
-              "file": "None",
-              "queueSize": "None",
-              "stackSize": "None",
-              "priority": "None",
-              "cpu": "None",
-              "initSpecifierMap": {}
+              "baseId" : 512,
+              "maxId" : 512,
+              "file" : "None",
+              "queueSize" : "None",
+              "stackSize" : "None",
+              "priority" : "None",
+              "cpu" : "None",
+              "initSpecifierMap" : {
+                
+              }
             },
-            "portInstance": {
-              "General": {
-                "aNode": {
-                  "astNodeId": 8
+            "portInstance" : {
+              "General" : {
+                "aNode" : {
+                  "astNodeId" : 8
                 },
-                "specifier": {
-                  "kind": {
-                    "SyncInput": {}
-                  },
-                  "name": "pIn",
-                  "size": "None",
-                  "port": {
-                    "Some": {
-                      "astNodeId": 7
+                "specifier" : {
+                  "kind" : {
+                    "SyncInput" : {
+                      
                     }
                   },
-                  "priority": "None",
-                  "queueFull": "None"
+                  "name" : "pIn",
+                  "size" : "None",
+                  "port" : {
+                    "Some" : {
+                      "astNodeId" : 7
+                    }
+                  },
+                  "priority" : "None",
+                  "queueFull" : "None"
                 },
-                "kind": "SyncInput",
-                "size": 1,
-                "ty": {
-                  "DefPort": {
-                    "symbol": {
-                      "Port": {
-                        "nodeId": 5,
-                        "unqualifiedName": "P"
+                "kind" : "SyncInput",
+                "size" : 1,
+                "ty" : {
+                  "DefPort" : {
+                    "symbol" : {
+                      "Port" : {
+                        "nodeId" : 5,
+                        "unqualifiedName" : "P"
                       }
                     }
                   }
                 },
-                "importNodeIds": []
+                "importNodeIds" : [
+                ]
               }
             }
           },
           {
-            "componentInstance": {
-              "aNode": {
-                "astNodeId": 24
+            "componentInstance" : {
+              "aNode" : {
+                "astNodeId" : 24
               },
-              "qualifiedName": {
-                "qualifier": [],
-                "base": "c1"
+              "qualifiedName" : {
+                "qualifier" : [
+                ],
+                "base" : "c1"
               },
-              "component": {
-                "astNodeId": 20
+              "component" : {
+                "astNodeId" : 20
               },
-              "baseId": 256,
-              "maxId": 256,
-              "file": "None",
-              "queueSize": "None",
-              "stackSize": "None",
-              "priority": "None",
-              "cpu": "None",
-              "initSpecifierMap": {}
+              "baseId" : 256,
+              "maxId" : 256,
+              "file" : "None",
+              "queueSize" : "None",
+              "stackSize" : "None",
+              "priority" : "None",
+              "cpu" : "None",
+              "initSpecifierMap" : {
+                
+              }
             },
-            "portInstance": {
-              "General": {
-                "aNode": {
-                  "astNodeId": 11
+            "portInstance" : {
+              "General" : {
+                "aNode" : {
+                  "astNodeId" : 11
                 },
-                "specifier": {
-                  "kind": {
-                    "Output": {}
-                  },
-                  "name": "pOut",
-                  "size": "None",
-                  "port": {
-                    "Some": {
-                      "astNodeId": 10
+                "specifier" : {
+                  "kind" : {
+                    "Output" : {
+                      
                     }
                   },
-                  "priority": "None",
-                  "queueFull": "None"
+                  "name" : "pOut",
+                  "size" : "None",
+                  "port" : {
+                    "Some" : {
+                      "astNodeId" : 10
+                    }
+                  },
+                  "priority" : "None",
+                  "queueFull" : "None"
                 },
-                "kind": "Output",
-                "size": 1,
-                "ty": {
-                  "DefPort": {
-                    "symbol": {
-                      "Port": {
-                        "nodeId": 5,
-                        "unqualifiedName": "P"
+                "kind" : "Output",
+                "size" : 1,
+                "ty" : {
+                  "DefPort" : {
+                    "symbol" : {
+                      "Port" : {
+                        "nodeId" : 5,
+                        "unqualifiedName" : "P"
                       }
                     }
                   }
                 },
-                "importNodeIds": []
+                "importNodeIds" : [
+                ]
               }
             }
           },
           {
-            "componentInstance": {
-              "aNode": {
-                "astNodeId": 24
+            "componentInstance" : {
+              "aNode" : {
+                "astNodeId" : 24
               },
-              "qualifiedName": {
-                "qualifier": [],
-                "base": "c1"
+              "qualifiedName" : {
+                "qualifier" : [
+                ],
+                "base" : "c1"
               },
-              "component": {
-                "astNodeId": 20
+              "component" : {
+                "astNodeId" : 20
               },
-              "baseId": 256,
-              "maxId": 256,
-              "file": "None",
-              "queueSize": "None",
-              "stackSize": "None",
-              "priority": "None",
-              "cpu": "None",
-              "initSpecifierMap": {}
-            },
-            "portInstance": {
-              "Special": {
-                "aNode": {
-                  "astNodeId": 13
-                },
-                "specifier": {
-                  "inputKind": "None",
-                  "kind": {
-                    "TimeGet": {}
-                  },
-                  "name": "timeGetOut",
-                  "priority": "None",
-                  "queueFull": "None"
-                },
-                "symbol": {
-                  "Port": {
-                    "nodeId": 3,
-                    "unqualifiedName": "Time"
-                  }
-                },
-                "priority": "None",
-                "queueFull": "None",
-                "importNodeIds": []
+              "baseId" : 256,
+              "maxId" : 256,
+              "file" : "None",
+              "queueSize" : "None",
+              "stackSize" : "None",
+              "priority" : "None",
+              "cpu" : "None",
+              "initSpecifierMap" : {
+                
               }
-            }
-          },
-          {
-            "componentInstance": {
-              "aNode": {
-                "astNodeId": 28
-              },
-              "qualifiedName": {
-                "qualifier": [],
-                "base": "c2"
-              },
-              "component": {
-                "astNodeId": 20
-              },
-              "baseId": 512,
-              "maxId": 512,
-              "file": "None",
-              "queueSize": "None",
-              "stackSize": "None",
-              "priority": "None",
-              "cpu": "None",
-              "initSpecifierMap": {}
             },
-            "portInstance": {
-              "Special": {
-                "aNode": {
-                  "astNodeId": 12
+            "portInstance" : {
+              "Special" : {
+                "aNode" : {
+                  "astNodeId" : 13
                 },
-                "specifier": {
-                  "inputKind": "None",
-                  "kind": {
-                    "Telemetry": {}
-                  },
-                  "name": "tlmOut",
-                  "priority": "None",
-                  "queueFull": "None"
-                },
-                "symbol": {
-                  "Port": {
-                    "nodeId": 0,
-                    "unqualifiedName": "Tlm"
-                  }
-                },
-                "priority": "None",
-                "queueFull": "None",
-                "importNodeIds": []
-              }
-            }
-          },
-          {
-            "componentInstance": {
-              "aNode": {
-                "astNodeId": 24
-              },
-              "qualifiedName": {
-                "qualifier": [],
-                "base": "c1"
-              },
-              "component": {
-                "astNodeId": 20
-              },
-              "baseId": 256,
-              "maxId": 256,
-              "file": "None",
-              "queueSize": "None",
-              "stackSize": "None",
-              "priority": "None",
-              "cpu": "None",
-              "initSpecifierMap": {}
-            },
-            "portInstance": {
-              "Special": {
-                "aNode": {
-                  "astNodeId": 12
-                },
-                "specifier": {
-                  "inputKind": "None",
-                  "kind": {
-                    "Telemetry": {}
-                  },
-                  "name": "tlmOut",
-                  "priority": "None",
-                  "queueFull": "None"
-                },
-                "symbol": {
-                  "Port": {
-                    "nodeId": 0,
-                    "unqualifiedName": "Tlm"
-                  }
-                },
-                "priority": "None",
-                "queueFull": "None",
-                "importNodeIds": []
-              }
-            }
-          },
-          {
-            "componentInstance": {
-              "aNode": {
-                "astNodeId": 24
-              },
-              "qualifiedName": {
-                "qualifier": [],
-                "base": "c1"
-              },
-              "component": {
-                "astNodeId": 20
-              },
-              "baseId": 256,
-              "maxId": 256,
-              "file": "None",
-              "queueSize": "None",
-              "stackSize": "None",
-              "priority": "None",
-              "cpu": "None",
-              "initSpecifierMap": {}
-            },
-            "portInstance": {
-              "General": {
-                "aNode": {
-                  "astNodeId": 8
-                },
-                "specifier": {
-                  "kind": {
-                    "SyncInput": {}
-                  },
-                  "name": "pIn",
-                  "size": "None",
-                  "port": {
-                    "Some": {
-                      "astNodeId": 7
+                "specifier" : {
+                  "inputKind" : "None",
+                  "kind" : {
+                    "TimeGet" : {
+                      
                     }
                   },
-                  "priority": "None",
-                  "queueFull": "None"
+                  "name" : "timeGetOut",
+                  "priority" : "None",
+                  "queueFull" : "None"
                 },
-                "kind": "SyncInput",
-                "size": 1,
-                "ty": {
-                  "DefPort": {
-                    "symbol": {
-                      "Port": {
-                        "nodeId": 5,
-                        "unqualifiedName": "P"
+                "symbol" : {
+                  "Port" : {
+                    "nodeId" : 3,
+                    "unqualifiedName" : "Time"
+                  }
+                },
+                "priority" : "None",
+                "queueFull" : "None",
+                "importNodeIds" : [
+                ]
+              }
+            }
+          },
+          {
+            "componentInstance" : {
+              "aNode" : {
+                "astNodeId" : 28
+              },
+              "qualifiedName" : {
+                "qualifier" : [
+                ],
+                "base" : "c2"
+              },
+              "component" : {
+                "astNodeId" : 20
+              },
+              "baseId" : 512,
+              "maxId" : 512,
+              "file" : "None",
+              "queueSize" : "None",
+              "stackSize" : "None",
+              "priority" : "None",
+              "cpu" : "None",
+              "initSpecifierMap" : {
+                
+              }
+            },
+            "portInstance" : {
+              "Special" : {
+                "aNode" : {
+                  "astNodeId" : 12
+                },
+                "specifier" : {
+                  "inputKind" : "None",
+                  "kind" : {
+                    "Telemetry" : {
+                      
+                    }
+                  },
+                  "name" : "tlmOut",
+                  "priority" : "None",
+                  "queueFull" : "None"
+                },
+                "symbol" : {
+                  "Port" : {
+                    "nodeId" : 0,
+                    "unqualifiedName" : "Tlm"
+                  }
+                },
+                "priority" : "None",
+                "queueFull" : "None",
+                "importNodeIds" : [
+                ]
+              }
+            }
+          },
+          {
+            "componentInstance" : {
+              "aNode" : {
+                "astNodeId" : 24
+              },
+              "qualifiedName" : {
+                "qualifier" : [
+                ],
+                "base" : "c1"
+              },
+              "component" : {
+                "astNodeId" : 20
+              },
+              "baseId" : 256,
+              "maxId" : 256,
+              "file" : "None",
+              "queueSize" : "None",
+              "stackSize" : "None",
+              "priority" : "None",
+              "cpu" : "None",
+              "initSpecifierMap" : {
+                
+              }
+            },
+            "portInstance" : {
+              "Special" : {
+                "aNode" : {
+                  "astNodeId" : 12
+                },
+                "specifier" : {
+                  "inputKind" : "None",
+                  "kind" : {
+                    "Telemetry" : {
+                      
+                    }
+                  },
+                  "name" : "tlmOut",
+                  "priority" : "None",
+                  "queueFull" : "None"
+                },
+                "symbol" : {
+                  "Port" : {
+                    "nodeId" : 0,
+                    "unqualifiedName" : "Tlm"
+                  }
+                },
+                "priority" : "None",
+                "queueFull" : "None",
+                "importNodeIds" : [
+                ]
+              }
+            }
+          },
+          {
+            "componentInstance" : {
+              "aNode" : {
+                "astNodeId" : 24
+              },
+              "qualifiedName" : {
+                "qualifier" : [
+                ],
+                "base" : "c1"
+              },
+              "component" : {
+                "astNodeId" : 20
+              },
+              "baseId" : 256,
+              "maxId" : 256,
+              "file" : "None",
+              "queueSize" : "None",
+              "stackSize" : "None",
+              "priority" : "None",
+              "cpu" : "None",
+              "initSpecifierMap" : {
+                
+              }
+            },
+            "portInstance" : {
+              "General" : {
+                "aNode" : {
+                  "astNodeId" : 8
+                },
+                "specifier" : {
+                  "kind" : {
+                    "SyncInput" : {
+                      
+                    }
+                  },
+                  "name" : "pIn",
+                  "size" : "None",
+                  "port" : {
+                    "Some" : {
+                      "astNodeId" : 7
+                    }
+                  },
+                  "priority" : "None",
+                  "queueFull" : "None"
+                },
+                "kind" : "SyncInput",
+                "size" : 1,
+                "ty" : {
+                  "DefPort" : {
+                    "symbol" : {
+                      "Port" : {
+                        "nodeId" : 5,
+                        "unqualifiedName" : "P"
                       }
                     }
                   }
                 },
-                "importNodeIds": []
+                "importNodeIds" : [
+                ]
               }
             }
           },
           {
-            "componentInstance": {
-              "aNode": {
-                "astNodeId": 28
+            "componentInstance" : {
+              "aNode" : {
+                "astNodeId" : 28
               },
-              "qualifiedName": {
-                "qualifier": [],
-                "base": "c2"
+              "qualifiedName" : {
+                "qualifier" : [
+                ],
+                "base" : "c2"
               },
-              "component": {
-                "astNodeId": 20
+              "component" : {
+                "astNodeId" : 20
               },
-              "baseId": 512,
-              "maxId": 512,
-              "file": "None",
-              "queueSize": "None",
-              "stackSize": "None",
-              "priority": "None",
-              "cpu": "None",
-              "initSpecifierMap": {}
+              "baseId" : 512,
+              "maxId" : 512,
+              "file" : "None",
+              "queueSize" : "None",
+              "stackSize" : "None",
+              "priority" : "None",
+              "cpu" : "None",
+              "initSpecifierMap" : {
+                
+              }
             },
-            "portInstance": {
-              "Special": {
-                "aNode": {
-                  "astNodeId": 13
+            "portInstance" : {
+              "Special" : {
+                "aNode" : {
+                  "astNodeId" : 13
                 },
-                "specifier": {
-                  "inputKind": "None",
-                  "kind": {
-                    "TimeGet": {}
+                "specifier" : {
+                  "inputKind" : "None",
+                  "kind" : {
+                    "TimeGet" : {
+                      
+                    }
                   },
-                  "name": "timeGetOut",
-                  "priority": "None",
-                  "queueFull": "None"
+                  "name" : "timeGetOut",
+                  "priority" : "None",
+                  "queueFull" : "None"
                 },
-                "symbol": {
-                  "Port": {
-                    "nodeId": 3,
-                    "unqualifiedName": "Time"
+                "symbol" : {
+                  "Port" : {
+                    "nodeId" : 3,
+                    "unqualifiedName" : "Time"
                   }
                 },
-                "priority": "None",
-                "queueFull": "None",
-                "importNodeIds": []
+                "priority" : "None",
+                "queueFull" : "None",
+                "importNodeIds" : [
+                ]
               }
             }
           }
         ]
       }
     },
-    "typeMap": {
-      "23": {
-        "Int": {
-          "Integer": {}
+    "typeMap" : {
+      "23" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "102": {
-        "Int": {
-          "Integer": {}
+      "102" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "27": {
-        "Int": {
-          "Integer": {}
+      "27" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "18": {
-        "Int": {
-          "PrimitiveInt": {
-            "kind": {
-              "U32": {}
+      "18" : {
+        "Int" : {
+          "PrimitiveInt" : {
+            "kind" : {
+              "U32" : {
+                
+              }
             }
           }
         }
       },
-      "101": {
-        "Int": {
-          "Integer": {}
+      "101" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       }
     },
-    "useDefMap": {
-      "12": {
-        "Port": {
-          "nodeId": 0,
-          "unqualifiedName": "Tlm"
+    "useDefMap" : {
+      "12" : {
+        "Port" : {
+          "nodeId" : 0,
+          "unqualifiedName" : "Tlm"
         }
       },
-      "110": {
-        "ComponentInstance": {
-          "nodeId": 28,
-          "unqualifiedName": "c2"
+      "110" : {
+        "ComponentInstance" : {
+          "nodeId" : 28,
+          "unqualifiedName" : "c2"
         }
       },
-      "33": {
-        "ComponentInstance": {
-          "nodeId": 28,
-          "unqualifiedName": "c2"
+      "33" : {
+        "ComponentInstance" : {
+          "nodeId" : 28,
+          "unqualifiedName" : "c2"
         }
       },
-      "22": {
-        "Component": {
-          "nodeId": 20,
-          "unqualifiedName": "C"
+      "22" : {
+        "Component" : {
+          "nodeId" : 20,
+          "unqualifiedName" : "C"
         }
       },
-      "26": {
-        "Component": {
-          "nodeId": 20,
-          "unqualifiedName": "C"
+      "26" : {
+        "Component" : {
+          "nodeId" : 20,
+          "unqualifiedName" : "C"
         }
       },
-      "13": {
-        "Port": {
-          "nodeId": 3,
-          "unqualifiedName": "Time"
+      "13" : {
+        "Port" : {
+          "nodeId" : 3,
+          "unqualifiedName" : "Time"
         }
       },
-      "10": {
-        "Port": {
-          "nodeId": 5,
-          "unqualifiedName": "P"
+      "10" : {
+        "Port" : {
+          "nodeId" : 5,
+          "unqualifiedName" : "P"
         }
       },
-      "105": {
-        "ComponentInstance": {
-          "nodeId": 24,
-          "unqualifiedName": "c1"
+      "105" : {
+        "ComponentInstance" : {
+          "nodeId" : 24,
+          "unqualifiedName" : "c1"
         }
       },
-      "30": {
-        "ComponentInstance": {
-          "nodeId": 24,
-          "unqualifiedName": "c1"
+      "30" : {
+        "ComponentInstance" : {
+          "nodeId" : 24,
+          "unqualifiedName" : "c1"
         }
       },
-      "7": {
-        "Port": {
-          "nodeId": 5,
-          "unqualifiedName": "P"
+      "7" : {
+        "Port" : {
+          "nodeId" : 5,
+          "unqualifiedName" : "P"
         }
       }
     },
-    "valueMap": {
-      "23": {
-        "Integer": {
-          "value": 256
+    "valueMap" : {
+      "23" : {
+        "Integer" : {
+          "value" : 256
         }
       },
-      "27": {
-        "Integer": {
-          "value": 512
+      "27" : {
+        "Integer" : {
+          "value" : 512
         }
       },
-      "101": {
-        "Integer": {
-          "value": 0
+      "101" : {
+        "Integer" : {
+          "value" : 0
         }
       },
-      "102": {
-        "Integer": {
-          "value": 0
+      "102" : {
+        "Integer" : {
+          "value" : 0
         }
       }
     },
-    "stateMachineMap": {},
-    "dictionarySymbolSet": [],
-    "interfaceMap": {}
+    "stateMachineMap" : {
+      
+    },
+    "dictionarySymbolSet" : [
+    ],
+    "interfaceMap" : {
+      
+    }
   }
 }

--- a/tests/telemetry_packets/telemetry_packets_ast.json
+++ b/tests/telemetry_packets/telemetry_packets_ast.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion": "[ fpp version ]",
+  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
   "ast": [
     {
       "members": [

--- a/tests/telemetry_packets/telemetry_packets_ast.json
+++ b/tests/telemetry_packets/telemetry_packets_ast.json
@@ -1,523 +1,581 @@
 {
-  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
-  "ast": [
+  "fppVersion" : "v3.1.0a10-54-g11243e778",
+  "ast" : [
     {
-      "members": [
+      "members" : [
         [
-          [],
+          [
+          ],
           {
-            "DefModule": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "Fw",
-                    "members": [
+            "DefModule" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "Fw",
+                    "members" : [
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "DefPort": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "name": "Tlm",
-                                  "params": [],
-                                  "returnType": "None"
+                          "DefPort" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "name" : "Tlm",
+                                  "params" : [
+                                  ],
+                                  "returnType" : "None"
                                 },
-                                "id": 0
+                                "id" : 0
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "DefPort": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "name": "Time",
-                                  "params": [],
-                                  "returnType": "None"
+                          "DefPort" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "name" : "Time",
+                                  "params" : [
+                                  ],
+                                  "returnType" : "None"
                                 },
-                                "id": 3
+                                "id" : 3
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ]
                     ]
                   },
-                  "id": 4
+                  "id" : 4
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          [],
+          [
+          ],
           {
-            "DefPort": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "P",
-                    "params": [],
-                    "returnType": "None"
+            "DefPort" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "P",
+                    "params" : [
+                    ],
+                    "returnType" : "None"
                   },
-                  "id": 5
+                  "id" : 5
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          [],
+          [
+          ],
           {
-            "DefComponent": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "kind": {
-                      "Passive": {}
+            "DefComponent" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "kind" : {
+                      "Passive" : {
+                        
+                      }
                     },
-                    "name": "C",
-                    "members": [
+                    "name" : "C",
+                    "members" : [
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "SpecPortInstance": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "General": {
-                                    "kind": {
-                                      "SyncInput": {}
+                          "SpecPortInstance" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "General" : {
+                                    "kind" : {
+                                      "SyncInput" : {
+                                        
+                                      }
                                     },
-                                    "name": "pIn",
-                                    "size": "None",
-                                    "port": {
-                                      "Some": {
-                                        "AstNode": {
-                                          "data": {
-                                            "Unqualified": {
-                                              "name": "P"
+                                    "name" : "pIn",
+                                    "size" : "None",
+                                    "port" : {
+                                      "Some" : {
+                                        "AstNode" : {
+                                          "data" : {
+                                            "Unqualified" : {
+                                              "name" : "P"
                                             }
                                           },
-                                          "id": 7
+                                          "id" : 7
                                         }
                                       }
                                     },
-                                    "priority": "None",
-                                    "queueFull": "None"
+                                    "priority" : "None",
+                                    "queueFull" : "None"
                                   }
                                 },
-                                "id": 8
+                                "id" : 8
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "SpecPortInstance": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "General": {
-                                    "kind": {
-                                      "Output": {}
+                          "SpecPortInstance" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "General" : {
+                                    "kind" : {
+                                      "Output" : {
+                                        
+                                      }
                                     },
-                                    "name": "pOut",
-                                    "size": "None",
-                                    "port": {
-                                      "Some": {
-                                        "AstNode": {
-                                          "data": {
-                                            "Unqualified": {
-                                              "name": "P"
+                                    "name" : "pOut",
+                                    "size" : "None",
+                                    "port" : {
+                                      "Some" : {
+                                        "AstNode" : {
+                                          "data" : {
+                                            "Unqualified" : {
+                                              "name" : "P"
                                             }
                                           },
-                                          "id": 10
+                                          "id" : 10
                                         }
                                       }
                                     },
-                                    "priority": "None",
-                                    "queueFull": "None"
+                                    "priority" : "None",
+                                    "queueFull" : "None"
                                   }
                                 },
-                                "id": 11
+                                "id" : 11
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "SpecPortInstance": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "Special": {
-                                    "inputKind": "None",
-                                    "kind": {
-                                      "Telemetry": {}
+                          "SpecPortInstance" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "Special" : {
+                                    "inputKind" : "None",
+                                    "kind" : {
+                                      "Telemetry" : {
+                                        
+                                      }
                                     },
-                                    "name": "tlmOut",
-                                    "priority": "None",
-                                    "queueFull": "None"
+                                    "name" : "tlmOut",
+                                    "priority" : "None",
+                                    "queueFull" : "None"
                                   }
                                 },
-                                "id": 12
+                                "id" : 12
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "SpecPortInstance": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "Special": {
-                                    "inputKind": "None",
-                                    "kind": {
-                                      "TimeGet": {}
+                          "SpecPortInstance" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "Special" : {
+                                    "inputKind" : "None",
+                                    "kind" : {
+                                      "TimeGet" : {
+                                        
+                                      }
                                     },
-                                    "name": "timeGetOut",
-                                    "priority": "None",
-                                    "queueFull": "None"
+                                    "name" : "timeGetOut",
+                                    "priority" : "None",
+                                    "queueFull" : "None"
                                   }
                                 },
-                                "id": 13
+                                "id" : 13
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "SpecTlmChannel": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "name": "T",
-                                  "typeName": {
-                                    "AstNode": {
-                                      "data": {
-                                        "TypeNameInt": {
-                                          "name": {
-                                            "U32": {}
+                          "SpecTlmChannel" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "name" : "T",
+                                  "typeName" : {
+                                    "AstNode" : {
+                                      "data" : {
+                                        "TypeNameInt" : {
+                                          "name" : {
+                                            "U32" : {
+                                              
+                                            }
                                           }
                                         }
                                       },
-                                      "id": 18
+                                      "id" : 18
                                     }
                                   },
-                                  "id": "None",
-                                  "update": "None",
-                                  "format": "None",
-                                  "low": [],
-                                  "high": []
+                                  "id" : "None",
+                                  "update" : "None",
+                                  "format" : "None",
+                                  "low" : [
+                                  ],
+                                  "high" : [
+                                  ]
                                 },
-                                "id": 19
+                                "id" : 19
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ]
                     ]
                   },
-                  "id": 20
+                  "id" : 20
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          [],
+          [
+          ],
           {
-            "DefComponentInstance": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "c1",
-                    "component": {
-                      "AstNode": {
-                        "data": {
-                          "Unqualified": {
-                            "name": "C"
+            "DefComponentInstance" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "c1",
+                    "component" : {
+                      "AstNode" : {
+                        "data" : {
+                          "Unqualified" : {
+                            "name" : "C"
                           }
                         },
-                        "id": 22
+                        "id" : 22
                       }
                     },
-                    "baseId": {
-                      "AstNode": {
-                        "data": {
-                          "ExprLiteralInt": {
-                            "value": "0x100"
+                    "baseId" : {
+                      "AstNode" : {
+                        "data" : {
+                          "ExprLiteralInt" : {
+                            "value" : "0x100"
                           }
                         },
-                        "id": 23
+                        "id" : 23
                       }
                     },
-                    "implType": "None",
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecs": []
+                    "implType" : "None",
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecs" : [
+                    ]
                   },
-                  "id": 24
+                  "id" : 24
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          [],
+          [
+          ],
           {
-            "DefComponentInstance": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "c2",
-                    "component": {
-                      "AstNode": {
-                        "data": {
-                          "Unqualified": {
-                            "name": "C"
+            "DefComponentInstance" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "c2",
+                    "component" : {
+                      "AstNode" : {
+                        "data" : {
+                          "Unqualified" : {
+                            "name" : "C"
                           }
                         },
-                        "id": 26
+                        "id" : 26
                       }
                     },
-                    "baseId": {
-                      "AstNode": {
-                        "data": {
-                          "ExprLiteralInt": {
-                            "value": "0x200"
+                    "baseId" : {
+                      "AstNode" : {
+                        "data" : {
+                          "ExprLiteralInt" : {
+                            "value" : "0x200"
                           }
                         },
-                        "id": 27
+                        "id" : 27
                       }
                     },
-                    "implType": "None",
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecs": []
+                    "implType" : "None",
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecs" : [
+                    ]
                   },
-                  "id": 28
+                  "id" : 28
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          ["A topology with telemetry packets"],
+          [
+            "A topology with telemetry packets"
+          ],
           {
-            "DefTopology": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "TelemetryPackets",
-                    "members": [
+            "DefTopology" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "TelemetryPackets",
+                    "members" : [
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "SpecCompInstance": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "visibility": {
-                                    "Public": {}
+                          "SpecCompInstance" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "visibility" : {
+                                    "Public" : {
+                                      
+                                    }
                                   },
-                                  "instance": {
-                                    "AstNode": {
-                                      "data": {
-                                        "Unqualified": {
-                                          "name": "c1"
+                                  "instance" : {
+                                    "AstNode" : {
+                                      "data" : {
+                                        "Unqualified" : {
+                                          "name" : "c1"
                                         }
                                       },
-                                      "id": 30
+                                      "id" : 30
                                     }
                                   }
                                 },
-                                "id": 31
+                                "id" : 31
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "SpecCompInstance": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "visibility": {
-                                    "Public": {}
+                          "SpecCompInstance" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "visibility" : {
+                                    "Public" : {
+                                      
+                                    }
                                   },
-                                  "instance": {
-                                    "AstNode": {
-                                      "data": {
-                                        "Unqualified": {
-                                          "name": "c2"
+                                  "instance" : {
+                                    "AstNode" : {
+                                      "data" : {
+                                        "Unqualified" : {
+                                          "name" : "c2"
                                         }
                                       },
-                                      "id": 33
+                                      "id" : 33
                                     }
                                   }
                                 },
-                                "id": 34
+                                "id" : 34
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "SpecTlmPacketSet": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "name": "P",
-                                  "members": [
+                          "SpecTlmPacketSet" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "name" : "P",
+                                  "members" : [
                                     [
-                                      [],
+                                      [
+                                      ],
                                       {
-                                        "SpecTlmPacket": {
-                                          "node": {
-                                            "AstNode": {
-                                              "data": {
-                                                "name": "P1",
-                                                "id": {
-                                                  "Some": {
-                                                    "AstNode": {
-                                                      "data": {
-                                                        "ExprLiteralInt": {
-                                                          "value": "0"
+                                        "SpecTlmPacket" : {
+                                          "node" : {
+                                            "AstNode" : {
+                                              "data" : {
+                                                "name" : "P1",
+                                                "id" : {
+                                                  "Some" : {
+                                                    "AstNode" : {
+                                                      "data" : {
+                                                        "ExprLiteralInt" : {
+                                                          "value" : "0"
                                                         }
                                                       },
-                                                      "id": 101
+                                                      "id" : 101
                                                     }
                                                   }
                                                 },
-                                                "group": {
-                                                  "AstNode": {
-                                                    "data": {
-                                                      "ExprLiteralInt": {
-                                                        "value": "0"
+                                                "group" : {
+                                                  "AstNode" : {
+                                                    "data" : {
+                                                      "ExprLiteralInt" : {
+                                                        "value" : "0"
                                                       }
                                                     },
-                                                    "id": 102
+                                                    "id" : 102
                                                   }
                                                 },
-                                                "members": [
+                                                "members" : [
                                                   {
-                                                    "TlmChannelIdentifier": {
-                                                      "node": {
-                                                        "AstNode": {
-                                                          "data": {
-                                                            "componentInstance": {
-                                                              "AstNode": {
-                                                                "data": {
-                                                                  "Unqualified": {
-                                                                    "name": "c1"
+                                                    "TlmChannelIdentifier" : {
+                                                      "node" : {
+                                                        "AstNode" : {
+                                                          "data" : {
+                                                            "componentInstance" : {
+                                                              "AstNode" : {
+                                                                "data" : {
+                                                                  "Unqualified" : {
+                                                                    "name" : "c1"
                                                                   }
                                                                 },
-                                                                "id": 105
+                                                                "id" : 105
                                                               }
                                                             },
-                                                            "channelName": {
-                                                              "AstNode": {
-                                                                "data": "T",
-                                                                "id": 104
+                                                            "channelName" : {
+                                                              "AstNode" : {
+                                                                "data" : "T",
+                                                                "id" : 104
                                                               }
                                                             }
                                                           },
-                                                          "id": 106
+                                                          "id" : 106
                                                         }
                                                       }
                                                     }
                                                   }
                                                 ]
                                               },
-                                              "id": 107
+                                              "id" : 107
                                             }
                                           }
                                         }
                                       },
-                                      []
+                                      [
+                                      ]
                                     ]
                                   ],
-                                  "omitted": [
+                                  "omitted" : [
                                     {
-                                      "AstNode": {
-                                        "data": {
-                                          "componentInstance": {
-                                            "AstNode": {
-                                              "data": {
-                                                "Unqualified": {
-                                                  "name": "c2"
+                                      "AstNode" : {
+                                        "data" : {
+                                          "componentInstance" : {
+                                            "AstNode" : {
+                                              "data" : {
+                                                "Unqualified" : {
+                                                  "name" : "c2"
                                                 }
                                               },
-                                              "id": 110
+                                              "id" : 110
                                             }
                                           },
-                                          "channelName": {
-                                            "AstNode": {
-                                              "data": "T",
-                                              "id": 109
+                                          "channelName" : {
+                                            "AstNode" : {
+                                              "data" : "T",
+                                              "id" : 109
                                             }
                                           }
                                         },
-                                        "id": 111
+                                        "id" : 111
                                       }
                                     }
                                   ]
                                 },
-                                "id": 112
+                                "id" : 112
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ]
                     ]
                   },
-                  "id": 113
+                  "id" : 113
                 }
               }
             }
           },
-          []
+          [
+          ]
         ]
       ]
     }

--- a/tests/telemetry_packets/telemetry_packets_locations.json
+++ b/tests/telemetry_packets/telemetry_packets_locations.json
@@ -1,575 +1,575 @@
 {
-  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
-  "locationMap": {
-    "0": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "2.3",
-      "includingLoc": "None"
-    },
-    "1": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "3.3",
-      "includingLoc": "None"
-    },
-    "2": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "3.3",
-      "includingLoc": "None"
-    },
-    "3": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "3.3",
-      "includingLoc": "None"
-    },
-    "4": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "1.1",
-      "includingLoc": "None"
-    },
-    "5": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "6.1",
-      "includingLoc": "None"
-    },
-    "6": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "9.24",
-      "includingLoc": "None"
-    },
-    "7": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "9.24",
-      "includingLoc": "None"
-    },
-    "8": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "9.3",
-      "includingLoc": "None"
-    },
-    "9": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "10.21",
-      "includingLoc": "None"
-    },
-    "10": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "10.21",
-      "includingLoc": "None"
-    },
-    "11": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "10.3",
-      "includingLoc": "None"
-    },
-    "12": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "11.3",
-      "includingLoc": "None"
-    },
-    "13": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "12.3",
-      "includingLoc": "None"
-    },
-    "14": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "13.16",
-      "includingLoc": "None"
-    },
-    "15": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "13.3",
-      "includingLoc": "None"
-    },
-    "16": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "13.16",
-      "includingLoc": "None"
-    },
-    "17": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "13.3",
-      "includingLoc": "None"
-    },
-    "18": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "13.16",
-      "includingLoc": "None"
-    },
-    "19": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "13.3",
-      "includingLoc": "None"
-    },
-    "20": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "8.1",
-      "includingLoc": "None"
-    },
-    "21": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "16.14",
-      "includingLoc": "None"
-    },
-    "22": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "16.14",
-      "includingLoc": "None"
-    },
-    "23": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "16.24",
-      "includingLoc": "None"
-    },
-    "24": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "16.1",
-      "includingLoc": "None"
-    },
-    "25": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "17.14",
-      "includingLoc": "None"
-    },
-    "26": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "17.14",
-      "includingLoc": "None"
-    },
-    "27": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "17.24",
-      "includingLoc": "None"
-    },
-    "28": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "17.1",
-      "includingLoc": "None"
-    },
-    "29": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "22.12",
-      "includingLoc": "None"
-    },
-    "30": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "22.12",
-      "includingLoc": "None"
-    },
-    "31": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "22.3",
-      "includingLoc": "None"
-    },
-    "32": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "23.12",
-      "includingLoc": "None"
-    },
-    "33": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "23.12",
-      "includingLoc": "None"
-    },
-    "34": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "23.3",
-      "includingLoc": "None"
-    },
-    "35": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "27.18",
-      "includingLoc": "None"
-    },
-    "36": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "27.26",
-      "includingLoc": "None"
-    },
-    "37": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "28.7",
-      "includingLoc": "None"
-    },
-    "38": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "28.10",
-      "includingLoc": "None"
-    },
-    "39": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "28.7",
-      "includingLoc": "None"
-    },
-    "40": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "28.7",
-      "includingLoc": "None"
-    },
-    "41": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "27.5",
-      "includingLoc": "None"
-    },
-    "42": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "27.18",
-      "includingLoc": "None"
-    },
-    "43": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "27.26",
-      "includingLoc": "None"
-    },
-    "44": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "28.7",
-      "includingLoc": "None"
-    },
-    "45": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "28.10",
-      "includingLoc": "None"
-    },
-    "46": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "28.7",
-      "includingLoc": "None"
-    },
-    "47": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "28.7",
-      "includingLoc": "None"
-    },
-    "48": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "27.5",
-      "includingLoc": "None"
-    },
-    "49": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "27.18",
-      "includingLoc": "None"
-    },
-    "50": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "27.26",
-      "includingLoc": "None"
-    },
-    "51": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "28.7",
-      "includingLoc": "None"
-    },
-    "52": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "28.10",
-      "includingLoc": "None"
-    },
-    "53": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "28.7",
-      "includingLoc": "None"
-    },
-    "54": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "28.7",
-      "includingLoc": "None"
-    },
-    "55": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "27.5",
-      "includingLoc": "None"
-    },
-    "56": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "32.5",
-      "includingLoc": "None"
-    },
-    "57": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "32.8",
-      "includingLoc": "None"
-    },
-    "58": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "32.5",
-      "includingLoc": "None"
-    },
-    "59": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "32.5",
-      "includingLoc": "None"
-    },
-    "60": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "25.3",
-      "includingLoc": "None"
-    },
-    "61": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "27.18",
-      "includingLoc": "None"
-    },
-    "62": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "27.26",
-      "includingLoc": "None"
-    },
-    "63": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "28.7",
-      "includingLoc": "None"
-    },
-    "64": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "28.10",
-      "includingLoc": "None"
-    },
-    "65": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "28.7",
-      "includingLoc": "None"
-    },
-    "66": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "28.7",
-      "includingLoc": "None"
-    },
-    "67": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "27.5",
-      "includingLoc": "None"
-    },
-    "68": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "27.18",
-      "includingLoc": "None"
-    },
-    "69": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "27.26",
-      "includingLoc": "None"
-    },
-    "70": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "28.7",
-      "includingLoc": "None"
-    },
-    "71": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "28.10",
-      "includingLoc": "None"
-    },
-    "72": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "28.7",
-      "includingLoc": "None"
-    },
-    "73": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "28.7",
-      "includingLoc": "None"
-    },
-    "74": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "27.5",
-      "includingLoc": "None"
-    },
-    "75": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "27.18",
-      "includingLoc": "None"
-    },
-    "76": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "27.26",
-      "includingLoc": "None"
-    },
-    "77": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "28.7",
-      "includingLoc": "None"
-    },
-    "78": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "28.10",
-      "includingLoc": "None"
-    },
-    "79": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "28.7",
-      "includingLoc": "None"
-    },
-    "80": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "28.7",
-      "includingLoc": "None"
-    },
-    "81": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "27.5",
-      "includingLoc": "None"
-    },
-    "82": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "32.5",
-      "includingLoc": "None"
-    },
-    "83": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "32.8",
-      "includingLoc": "None"
-    },
-    "84": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "32.5",
-      "includingLoc": "None"
-    },
-    "85": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "32.5",
-      "includingLoc": "None"
-    },
-    "86": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "25.3",
-      "includingLoc": "None"
-    },
-    "87": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "27.18",
-      "includingLoc": "None"
-    },
-    "88": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "27.26",
-      "includingLoc": "None"
-    },
-    "89": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "28.7",
-      "includingLoc": "None"
-    },
-    "90": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "28.10",
-      "includingLoc": "None"
-    },
-    "91": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "28.7",
-      "includingLoc": "None"
-    },
-    "92": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "28.7",
-      "includingLoc": "None"
-    },
-    "93": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "27.5",
-      "includingLoc": "None"
-    },
-    "94": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "27.18",
-      "includingLoc": "None"
-    },
-    "95": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "27.26",
-      "includingLoc": "None"
-    },
-    "96": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "28.7",
-      "includingLoc": "None"
-    },
-    "97": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "28.10",
-      "includingLoc": "None"
-    },
-    "98": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "28.7",
-      "includingLoc": "None"
-    },
-    "99": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "28.7",
-      "includingLoc": "None"
-    },
-    "100": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "27.5",
-      "includingLoc": "None"
-    },
-    "101": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "27.18",
-      "includingLoc": "None"
-    },
-    "102": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "27.26",
-      "includingLoc": "None"
-    },
-    "103": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "28.7",
-      "includingLoc": "None"
-    },
-    "104": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "28.10",
-      "includingLoc": "None"
-    },
-    "105": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "28.7",
-      "includingLoc": "None"
-    },
-    "106": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "28.7",
-      "includingLoc": "None"
-    },
-    "107": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "27.5",
-      "includingLoc": "None"
-    },
-    "108": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "32.5",
-      "includingLoc": "None"
-    },
-    "109": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "32.8",
-      "includingLoc": "None"
-    },
-    "110": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "32.5",
-      "includingLoc": "None"
-    },
-    "111": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "32.5",
-      "includingLoc": "None"
-    },
-    "112": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "25.3",
-      "includingLoc": "None"
-    },
-    "113": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
-      "pos": "20.1",
-      "includingLoc": "None"
+  "fppVersion" : "v3.1.0a10-54-g11243e778",
+  "locationMap" : {
+    "0" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "2.3",
+      "includingLoc" : "None"
+    },
+    "1" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "3.3",
+      "includingLoc" : "None"
+    },
+    "2" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "3.3",
+      "includingLoc" : "None"
+    },
+    "3" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "3.3",
+      "includingLoc" : "None"
+    },
+    "4" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "1.1",
+      "includingLoc" : "None"
+    },
+    "5" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "6.1",
+      "includingLoc" : "None"
+    },
+    "6" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "9.24",
+      "includingLoc" : "None"
+    },
+    "7" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "9.24",
+      "includingLoc" : "None"
+    },
+    "8" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "9.3",
+      "includingLoc" : "None"
+    },
+    "9" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "10.21",
+      "includingLoc" : "None"
+    },
+    "10" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "10.21",
+      "includingLoc" : "None"
+    },
+    "11" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "10.3",
+      "includingLoc" : "None"
+    },
+    "12" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "11.3",
+      "includingLoc" : "None"
+    },
+    "13" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "12.3",
+      "includingLoc" : "None"
+    },
+    "14" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "13.16",
+      "includingLoc" : "None"
+    },
+    "15" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "13.3",
+      "includingLoc" : "None"
+    },
+    "16" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "13.16",
+      "includingLoc" : "None"
+    },
+    "17" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "13.3",
+      "includingLoc" : "None"
+    },
+    "18" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "13.16",
+      "includingLoc" : "None"
+    },
+    "19" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "13.3",
+      "includingLoc" : "None"
+    },
+    "20" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "8.1",
+      "includingLoc" : "None"
+    },
+    "21" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "16.14",
+      "includingLoc" : "None"
+    },
+    "22" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "16.14",
+      "includingLoc" : "None"
+    },
+    "23" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "16.24",
+      "includingLoc" : "None"
+    },
+    "24" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "16.1",
+      "includingLoc" : "None"
+    },
+    "25" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "17.14",
+      "includingLoc" : "None"
+    },
+    "26" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "17.14",
+      "includingLoc" : "None"
+    },
+    "27" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "17.24",
+      "includingLoc" : "None"
+    },
+    "28" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "17.1",
+      "includingLoc" : "None"
+    },
+    "29" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "22.12",
+      "includingLoc" : "None"
+    },
+    "30" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "22.12",
+      "includingLoc" : "None"
+    },
+    "31" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "22.3",
+      "includingLoc" : "None"
+    },
+    "32" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "23.12",
+      "includingLoc" : "None"
+    },
+    "33" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "23.12",
+      "includingLoc" : "None"
+    },
+    "34" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "23.3",
+      "includingLoc" : "None"
+    },
+    "35" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "27.18",
+      "includingLoc" : "None"
+    },
+    "36" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "27.26",
+      "includingLoc" : "None"
+    },
+    "37" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "28.7",
+      "includingLoc" : "None"
+    },
+    "38" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "28.10",
+      "includingLoc" : "None"
+    },
+    "39" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "28.7",
+      "includingLoc" : "None"
+    },
+    "40" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "28.7",
+      "includingLoc" : "None"
+    },
+    "41" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "27.5",
+      "includingLoc" : "None"
+    },
+    "42" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "27.18",
+      "includingLoc" : "None"
+    },
+    "43" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "27.26",
+      "includingLoc" : "None"
+    },
+    "44" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "28.7",
+      "includingLoc" : "None"
+    },
+    "45" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "28.10",
+      "includingLoc" : "None"
+    },
+    "46" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "28.7",
+      "includingLoc" : "None"
+    },
+    "47" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "28.7",
+      "includingLoc" : "None"
+    },
+    "48" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "27.5",
+      "includingLoc" : "None"
+    },
+    "49" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "27.18",
+      "includingLoc" : "None"
+    },
+    "50" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "27.26",
+      "includingLoc" : "None"
+    },
+    "51" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "28.7",
+      "includingLoc" : "None"
+    },
+    "52" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "28.10",
+      "includingLoc" : "None"
+    },
+    "53" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "28.7",
+      "includingLoc" : "None"
+    },
+    "54" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "28.7",
+      "includingLoc" : "None"
+    },
+    "55" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "27.5",
+      "includingLoc" : "None"
+    },
+    "56" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "32.5",
+      "includingLoc" : "None"
+    },
+    "57" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "32.8",
+      "includingLoc" : "None"
+    },
+    "58" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "32.5",
+      "includingLoc" : "None"
+    },
+    "59" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "32.5",
+      "includingLoc" : "None"
+    },
+    "60" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "25.3",
+      "includingLoc" : "None"
+    },
+    "61" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "27.18",
+      "includingLoc" : "None"
+    },
+    "62" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "27.26",
+      "includingLoc" : "None"
+    },
+    "63" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "28.7",
+      "includingLoc" : "None"
+    },
+    "64" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "28.10",
+      "includingLoc" : "None"
+    },
+    "65" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "28.7",
+      "includingLoc" : "None"
+    },
+    "66" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "28.7",
+      "includingLoc" : "None"
+    },
+    "67" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "27.5",
+      "includingLoc" : "None"
+    },
+    "68" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "27.18",
+      "includingLoc" : "None"
+    },
+    "69" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "27.26",
+      "includingLoc" : "None"
+    },
+    "70" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "28.7",
+      "includingLoc" : "None"
+    },
+    "71" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "28.10",
+      "includingLoc" : "None"
+    },
+    "72" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "28.7",
+      "includingLoc" : "None"
+    },
+    "73" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "28.7",
+      "includingLoc" : "None"
+    },
+    "74" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "27.5",
+      "includingLoc" : "None"
+    },
+    "75" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "27.18",
+      "includingLoc" : "None"
+    },
+    "76" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "27.26",
+      "includingLoc" : "None"
+    },
+    "77" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "28.7",
+      "includingLoc" : "None"
+    },
+    "78" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "28.10",
+      "includingLoc" : "None"
+    },
+    "79" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "28.7",
+      "includingLoc" : "None"
+    },
+    "80" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "28.7",
+      "includingLoc" : "None"
+    },
+    "81" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "27.5",
+      "includingLoc" : "None"
+    },
+    "82" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "32.5",
+      "includingLoc" : "None"
+    },
+    "83" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "32.8",
+      "includingLoc" : "None"
+    },
+    "84" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "32.5",
+      "includingLoc" : "None"
+    },
+    "85" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "32.5",
+      "includingLoc" : "None"
+    },
+    "86" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "25.3",
+      "includingLoc" : "None"
+    },
+    "87" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "27.18",
+      "includingLoc" : "None"
+    },
+    "88" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "27.26",
+      "includingLoc" : "None"
+    },
+    "89" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "28.7",
+      "includingLoc" : "None"
+    },
+    "90" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "28.10",
+      "includingLoc" : "None"
+    },
+    "91" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "28.7",
+      "includingLoc" : "None"
+    },
+    "92" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "28.7",
+      "includingLoc" : "None"
+    },
+    "93" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "27.5",
+      "includingLoc" : "None"
+    },
+    "94" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "27.18",
+      "includingLoc" : "None"
+    },
+    "95" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "27.26",
+      "includingLoc" : "None"
+    },
+    "96" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "28.7",
+      "includingLoc" : "None"
+    },
+    "97" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "28.10",
+      "includingLoc" : "None"
+    },
+    "98" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "28.7",
+      "includingLoc" : "None"
+    },
+    "99" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "28.7",
+      "includingLoc" : "None"
+    },
+    "100" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "27.5",
+      "includingLoc" : "None"
+    },
+    "101" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "27.18",
+      "includingLoc" : "None"
+    },
+    "102" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "27.26",
+      "includingLoc" : "None"
+    },
+    "103" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "28.7",
+      "includingLoc" : "None"
+    },
+    "104" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "28.10",
+      "includingLoc" : "None"
+    },
+    "105" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "28.7",
+      "includingLoc" : "None"
+    },
+    "106" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "28.7",
+      "includingLoc" : "None"
+    },
+    "107" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "27.5",
+      "includingLoc" : "None"
+    },
+    "108" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "32.5",
+      "includingLoc" : "None"
+    },
+    "109" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "32.8",
+      "includingLoc" : "None"
+    },
+    "110" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "32.5",
+      "includingLoc" : "None"
+    },
+    "111" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "32.5",
+      "includingLoc" : "None"
+    },
+    "112" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "25.3",
+      "includingLoc" : "None"
+    },
+    "113" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",
+      "pos" : "20.1",
+      "includingLoc" : "None"
     }
   }
 }

--- a/tests/telemetry_packets/telemetry_packets_locations.json
+++ b/tests/telemetry_packets/telemetry_packets_locations.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion": "[ fpp version ]",
+  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
   "locationMap": {
     "0": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",

--- a/tests/test_ast.py
+++ b/tests/test_ast.py
@@ -38,10 +38,10 @@ def test_ast():
 
             # Save FPP Writer output to txt file and diff against reference FPP
             out_file = os.path.join(test_path, f"{test}.out.txt")
-            with open(out_file, "w") as f:
+            with open(out_file, "w") as out:
                 for l in fpp_lines:
                     for line in l.lines:
-                        f.write(str(line) + "\n")
+                        out.write(str(line) + "\n")
 
             result = subprocess.run(["diff", fpp_ref_file, out_file])
             assert result.returncode == 0

--- a/tests/test_ast.py
+++ b/tests/test_ast.py
@@ -1,13 +1,14 @@
 from fprime_python_model.model import FprimePythonModel
 from fprime_python_model.utils.fpp_writer import FppWriter
 from fprime_python_model.utils.line_utils import Lines
+from generate_ref_files import test_name_map, additional_tests
 from typing import List
 import subprocess
 import os
-import pytest
 
 
 def test_ast():
+    all_tests = list(test_name_map.keys()) + list(additional_tests.keys())
     # Get location of test directory
     test_dir = os.path.dirname(os.path.abspath(__file__))
 
@@ -15,7 +16,7 @@ def test_ast():
     # Iterate through all test cases
     for test in os.listdir(test_dir):
         test_path = os.path.join(test_dir, test)
-        if os.path.isdir(test_path) and "pycache" not in test_path.lower():
+        if os.path.isdir(test_path) and test in all_tests:
             print(f"Test Case: {test}")
             fpp_ref_file = os.path.join(test_path, f"{test}.fpp")
             ast_file = os.path.join(test_path, f"{test}_ast.json")

--- a/tests/topology/topology_analysis.json
+++ b/tests/topology/topology_analysis.json
@@ -1,2162 +1,2393 @@
 {
-  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
-  "analysis": {
-    "componentInstanceMap": {
-      "17": {
-        "aNode": {
-          "astNodeId": 17
+  "fppVersion" : "v3.1.0a10-54-g11243e778",
+  "analysis" : {
+    "componentInstanceMap" : {
+      "17" : {
+        "aNode" : {
+          "astNodeId" : 17
         },
-        "qualifiedName": {
-          "qualifier": [],
-          "base": "c1"
+        "qualifiedName" : {
+          "qualifier" : [
+          ],
+          "base" : "c1"
         },
-        "component": {
-          "astNodeId": 13
+        "component" : {
+          "astNodeId" : 13
         },
-        "baseId": 256,
-        "maxId": 255,
-        "file": "None",
-        "queueSize": "None",
-        "stackSize": "None",
-        "priority": "None",
-        "cpu": "None",
-        "initSpecifierMap": {}
+        "baseId" : 256,
+        "maxId" : 255,
+        "file" : "None",
+        "queueSize" : "None",
+        "stackSize" : "None",
+        "priority" : "None",
+        "cpu" : "None",
+        "initSpecifierMap" : {
+          
+        }
       },
-      "21": {
-        "aNode": {
-          "astNodeId": 21
+      "21" : {
+        "aNode" : {
+          "astNodeId" : 21
         },
-        "qualifiedName": {
-          "qualifier": [],
-          "base": "c2"
+        "qualifiedName" : {
+          "qualifier" : [
+          ],
+          "base" : "c2"
         },
-        "component": {
-          "astNodeId": 13
+        "component" : {
+          "astNodeId" : 13
         },
-        "baseId": 512,
-        "maxId": 511,
-        "file": "None",
-        "queueSize": "None",
-        "stackSize": "None",
-        "priority": "None",
-        "cpu": "None",
-        "initSpecifierMap": {}
+        "baseId" : 512,
+        "maxId" : 511,
+        "file" : "None",
+        "queueSize" : "None",
+        "stackSize" : "None",
+        "priority" : "None",
+        "cpu" : "None",
+        "initSpecifierMap" : {
+          
+        }
       }
     },
-    "componentMap": {
-      "13": {
-        "aNode": {
-          "astNodeId": 13
+    "componentMap" : {
+      "13" : {
+        "aNode" : {
+          "astNodeId" : 13
         },
-        "portMap": {
-          "pIn": {
-            "General": {
-              "aNode": {
-                "astNodeId": 3
+        "portMap" : {
+          "pIn" : {
+            "General" : {
+              "aNode" : {
+                "astNodeId" : 3
               },
-              "specifier": {
-                "kind": {
-                  "SyncInput": {}
-                },
-                "name": "pIn",
-                "size": "None",
-                "port": {
-                  "Some": {
-                    "astNodeId": 2
+              "specifier" : {
+                "kind" : {
+                  "SyncInput" : {
+                    
                   }
                 },
-                "priority": "None",
-                "queueFull": "None"
+                "name" : "pIn",
+                "size" : "None",
+                "port" : {
+                  "Some" : {
+                    "astNodeId" : 2
+                  }
+                },
+                "priority" : "None",
+                "queueFull" : "None"
               },
-              "kind": "SyncInput",
-              "size": 1,
-              "ty": {
-                "DefPort": {
-                  "symbol": {
-                    "Port": {
-                      "nodeId": 0,
-                      "unqualifiedName": "P"
+              "kind" : "SyncInput",
+              "size" : 1,
+              "ty" : {
+                "DefPort" : {
+                  "symbol" : {
+                    "Port" : {
+                      "nodeId" : 0,
+                      "unqualifiedName" : "P"
                     }
                   }
                 }
               },
-              "importNodeIds": []
+              "importNodeIds" : [
+              ]
             }
           },
-          "pOut": {
-            "General": {
-              "aNode": {
-                "astNodeId": 12
+          "pOut" : {
+            "General" : {
+              "aNode" : {
+                "astNodeId" : 12
               },
-              "specifier": {
-                "kind": {
-                  "Output": {}
-                },
-                "name": "pOut",
-                "size": "None",
-                "port": {
-                  "Some": {
-                    "astNodeId": 11
+              "specifier" : {
+                "kind" : {
+                  "Output" : {
+                    
                   }
                 },
-                "priority": "None",
-                "queueFull": "None"
+                "name" : "pOut",
+                "size" : "None",
+                "port" : {
+                  "Some" : {
+                    "astNodeId" : 11
+                  }
+                },
+                "priority" : "None",
+                "queueFull" : "None"
               },
-              "kind": "Output",
-              "size": 1,
-              "ty": {
-                "DefPort": {
-                  "symbol": {
-                    "Port": {
-                      "nodeId": 0,
-                      "unqualifiedName": "P"
+              "kind" : "Output",
+              "size" : 1,
+              "ty" : {
+                "DefPort" : {
+                  "symbol" : {
+                    "Port" : {
+                      "nodeId" : 0,
+                      "unqualifiedName" : "P"
                     }
                   }
                 }
               },
-              "importNodeIds": []
+              "importNodeIds" : [
+              ]
             }
           }
         },
-        "specialPortMap": {},
-        "commandMap": {},
-        "defaultOpcode": 0,
-        "tlmChannelMap": {},
-        "tlmChannelNameMap": {},
-        "defaultTlmChannelId": 0,
-        "eventMap": {},
-        "defaultEventId": 0,
-        "paramMap": {},
-        "specPortMatchingList": [],
-        "stateMachineInstanceMap": {},
-        "portMatchingList": [],
-        "defaultParamId": 0,
-        "containerMap": {},
-        "defaultContainerId": 0,
-        "recordMap": {},
-        "defaultRecordId": 0
+        "specialPortMap" : {
+          
+        },
+        "commandMap" : {
+          
+        },
+        "defaultOpcode" : 0,
+        "tlmChannelMap" : {
+          
+        },
+        "tlmChannelNameMap" : {
+          
+        },
+        "defaultTlmChannelId" : 0,
+        "eventMap" : {
+          
+        },
+        "defaultEventId" : 0,
+        "paramMap" : {
+          
+        },
+        "specPortMatchingList" : [
+        ],
+        "stateMachineInstanceMap" : {
+          
+        },
+        "portMatchingList" : [
+        ],
+        "defaultParamId" : 0,
+        "containerMap" : {
+          
+        },
+        "defaultContainerId" : 0,
+        "recordMap" : {
+          
+        },
+        "defaultRecordId" : 0
       }
     },
-    "includedFileSet": [],
-    "inputFileSet": [
+    "includedFileSet" : [
+    ],
+    "inputFileSet" : [
       "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp"
     ],
-    "locationSpecifierMap": [],
-    "parentSymbolMap": {},
-    "symbolScopeMap": {
-      "13": {
-        "map": {}
+    "locationSpecifierMap" : [
+    ],
+    "parentSymbolMap" : {
+      
+    },
+    "symbolScopeMap" : {
+      "13" : {
+        "map" : {
+          
+        }
       }
     },
-    "topologyMap": {
-      "64": {
-        "aNode": {
-          "astNodeId": 64
+    "topologyMap" : {
+      "64" : {
+        "aNode" : {
+          "astNodeId" : 64
         },
-        "directImportMap": {},
-        "transitiveImportSet": [],
-        "instanceMap": [
+        "directImportMap" : {
+          
+        },
+        "transitiveImportSet" : [
+        ],
+        "instanceMap" : [
           [
             {
-              "aNode": {
-                "astNodeId": 17
+              "aNode" : {
+                "astNodeId" : 17
               },
-              "qualifiedName": {
-                "qualifier": [],
-                "base": "c1"
+              "qualifiedName" : {
+                "qualifier" : [
+                ],
+                "base" : "c1"
               },
-              "component": {
-                "astNodeId": 13
+              "component" : {
+                "astNodeId" : 13
               },
-              "baseId": 256,
-              "maxId": 255,
-              "file": "None",
-              "queueSize": "None",
-              "stackSize": "None",
-              "priority": "None",
-              "cpu": "None",
-              "initSpecifierMap": {}
+              "baseId" : 256,
+              "maxId" : 255,
+              "file" : "None",
+              "queueSize" : "None",
+              "stackSize" : "None",
+              "priority" : "None",
+              "cpu" : "None",
+              "initSpecifierMap" : {
+                
+              }
             },
             [
               {
-                "Public": {}
+                "Public" : {
+                  
+                }
               },
               {
-                "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-                "pos": "15.3",
-                "includingLoc": "None"
+                "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+                "pos" : "15.3",
+                "includingLoc" : "None"
               }
             ]
           ],
           [
             {
-              "aNode": {
-                "astNodeId": 21
+              "aNode" : {
+                "astNodeId" : 21
               },
-              "qualifiedName": {
-                "qualifier": [],
-                "base": "c2"
+              "qualifiedName" : {
+                "qualifier" : [
+                ],
+                "base" : "c2"
               },
-              "component": {
-                "astNodeId": 13
+              "component" : {
+                "astNodeId" : 13
               },
-              "baseId": 512,
-              "maxId": 511,
-              "file": "None",
-              "queueSize": "None",
-              "stackSize": "None",
-              "priority": "None",
-              "cpu": "None",
-              "initSpecifierMap": {}
+              "baseId" : 512,
+              "maxId" : 511,
+              "file" : "None",
+              "queueSize" : "None",
+              "stackSize" : "None",
+              "priority" : "None",
+              "cpu" : "None",
+              "initSpecifierMap" : {
+                
+              }
             },
             [
               {
-                "Public": {}
+                "Public" : {
+                  
+                }
               },
               {
-                "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-                "pos": "17.3",
-                "includingLoc": "None"
+                "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+                "pos" : "17.3",
+                "includingLoc" : "None"
               }
             ]
           ]
         ],
-        "patternMap": {},
-        "connectionMap": {
-          "C1": [
-            {
-              "from": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-                  "pos": "21.5",
-                  "includingLoc": "None"
-                },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 17
-                    },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c1"
-                    },
-                    "component": {
-                      "astNodeId": 13
-                    },
-                    "baseId": 256,
-                    "maxId": 255,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
-                  },
-                  "portInstance": {
-                    "General": {
-                      "aNode": {
-                        "astNodeId": 12
-                      },
-                      "specifier": {
-                        "kind": {
-                          "Output": {}
-                        },
-                        "name": "pOut",
-                        "size": "None",
-                        "port": {
-                          "Some": {
-                            "astNodeId": 11
-                          }
-                        },
-                        "priority": "None",
-                        "queueFull": "None"
-                      },
-                      "kind": "Output",
-                      "size": 1,
-                      "ty": {
-                        "DefPort": {
-                          "symbol": {
-                            "Port": {
-                              "nodeId": 0,
-                              "unqualifiedName": "P"
-                            }
-                          }
-                        }
-                      },
-                      "importNodeIds": []
-                    }
-                  }
-                },
-                "portNumber": "None"
-              },
-              "to": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-                  "pos": "21.16",
-                  "includingLoc": "None"
-                },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 21
-                    },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c2"
-                    },
-                    "component": {
-                      "astNodeId": 13
-                    },
-                    "baseId": 512,
-                    "maxId": 511,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
-                  },
-                  "portInstance": {
-                    "General": {
-                      "aNode": {
-                        "astNodeId": 3
-                      },
-                      "specifier": {
-                        "kind": {
-                          "SyncInput": {}
-                        },
-                        "name": "pIn",
-                        "size": "None",
-                        "port": {
-                          "Some": {
-                            "astNodeId": 2
-                          }
-                        },
-                        "priority": "None",
-                        "queueFull": "None"
-                      },
-                      "kind": "SyncInput",
-                      "size": 1,
-                      "ty": {
-                        "DefPort": {
-                          "symbol": {
-                            "Port": {
-                              "nodeId": 0,
-                              "unqualifiedName": "P"
-                            }
-                          }
-                        }
-                      },
-                      "importNodeIds": []
-                    }
-                  }
-                },
-                "portNumber": "None"
-              },
-              "isUnmatched": false
-            }
-          ],
-          "C2": [
-            {
-              "from": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-                  "pos": "26.5",
-                  "includingLoc": "None"
-                },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 21
-                    },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c2"
-                    },
-                    "component": {
-                      "astNodeId": 13
-                    },
-                    "baseId": 512,
-                    "maxId": 511,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
-                  },
-                  "portInstance": {
-                    "General": {
-                      "aNode": {
-                        "astNodeId": 12
-                      },
-                      "specifier": {
-                        "kind": {
-                          "Output": {}
-                        },
-                        "name": "pOut",
-                        "size": "None",
-                        "port": {
-                          "Some": {
-                            "astNodeId": 11
-                          }
-                        },
-                        "priority": "None",
-                        "queueFull": "None"
-                      },
-                      "kind": "Output",
-                      "size": 1,
-                      "ty": {
-                        "DefPort": {
-                          "symbol": {
-                            "Port": {
-                              "nodeId": 0,
-                              "unqualifiedName": "P"
-                            }
-                          }
-                        }
-                      },
-                      "importNodeIds": []
-                    }
-                  }
-                },
-                "portNumber": "None"
-              },
-              "to": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-                  "pos": "26.16",
-                  "includingLoc": "None"
-                },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 17
-                    },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c1"
-                    },
-                    "component": {
-                      "astNodeId": 13
-                    },
-                    "baseId": 256,
-                    "maxId": 255,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
-                  },
-                  "portInstance": {
-                    "General": {
-                      "aNode": {
-                        "astNodeId": 3
-                      },
-                      "specifier": {
-                        "kind": {
-                          "SyncInput": {}
-                        },
-                        "name": "pIn",
-                        "size": "None",
-                        "port": {
-                          "Some": {
-                            "astNodeId": 2
-                          }
-                        },
-                        "priority": "None",
-                        "queueFull": "None"
-                      },
-                      "kind": "SyncInput",
-                      "size": 1,
-                      "ty": {
-                        "DefPort": {
-                          "symbol": {
-                            "Port": {
-                              "nodeId": 0,
-                              "unqualifiedName": "P"
-                            }
-                          }
-                        }
-                      },
-                      "importNodeIds": []
-                    }
-                  }
-                },
-                "portNumber": "None"
-              },
-              "isUnmatched": false
-            }
-          ]
+        "patternMap" : {
+          
         },
-        "localConnectionMap": {
-          "C1": [
+        "connectionMap" : {
+          "C1" : [
             {
-              "from": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-                  "pos": "21.5",
-                  "includingLoc": "None"
+              "from" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+                  "pos" : "21.5",
+                  "includingLoc" : "None"
                 },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 17
+                "port" : {
+                  "componentInstance" : {
+                    "aNode" : {
+                      "astNodeId" : 17
                     },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c1"
+                    "qualifiedName" : {
+                      "qualifier" : [
+                      ],
+                      "base" : "c1"
                     },
-                    "component": {
-                      "astNodeId": 13
+                    "component" : {
+                      "astNodeId" : 13
                     },
-                    "baseId": 256,
-                    "maxId": 255,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
+                    "baseId" : 256,
+                    "maxId" : 255,
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecifierMap" : {
+                      
+                    }
                   },
-                  "portInstance": {
-                    "General": {
-                      "aNode": {
-                        "astNodeId": 12
+                  "portInstance" : {
+                    "General" : {
+                      "aNode" : {
+                        "astNodeId" : 12
                       },
-                      "specifier": {
-                        "kind": {
-                          "Output": {}
-                        },
-                        "name": "pOut",
-                        "size": "None",
-                        "port": {
-                          "Some": {
-                            "astNodeId": 11
+                      "specifier" : {
+                        "kind" : {
+                          "Output" : {
+                            
                           }
                         },
-                        "priority": "None",
-                        "queueFull": "None"
+                        "name" : "pOut",
+                        "size" : "None",
+                        "port" : {
+                          "Some" : {
+                            "astNodeId" : 11
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None"
                       },
-                      "kind": "Output",
-                      "size": 1,
-                      "ty": {
-                        "DefPort": {
-                          "symbol": {
-                            "Port": {
-                              "nodeId": 0,
-                              "unqualifiedName": "P"
+                      "kind" : "Output",
+                      "size" : 1,
+                      "ty" : {
+                        "DefPort" : {
+                          "symbol" : {
+                            "Port" : {
+                              "nodeId" : 0,
+                              "unqualifiedName" : "P"
                             }
                           }
                         }
                       },
-                      "importNodeIds": []
+                      "importNodeIds" : [
+                      ]
                     }
                   }
                 },
-                "portNumber": "None"
+                "portNumber" : "None"
               },
-              "to": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-                  "pos": "21.16",
-                  "includingLoc": "None"
+              "to" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+                  "pos" : "21.16",
+                  "includingLoc" : "None"
                 },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 21
+                "port" : {
+                  "componentInstance" : {
+                    "aNode" : {
+                      "astNodeId" : 21
                     },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c2"
+                    "qualifiedName" : {
+                      "qualifier" : [
+                      ],
+                      "base" : "c2"
                     },
-                    "component": {
-                      "astNodeId": 13
+                    "component" : {
+                      "astNodeId" : 13
                     },
-                    "baseId": 512,
-                    "maxId": 511,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
+                    "baseId" : 512,
+                    "maxId" : 511,
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecifierMap" : {
+                      
+                    }
                   },
-                  "portInstance": {
-                    "General": {
-                      "aNode": {
-                        "astNodeId": 3
+                  "portInstance" : {
+                    "General" : {
+                      "aNode" : {
+                        "astNodeId" : 3
                       },
-                      "specifier": {
-                        "kind": {
-                          "SyncInput": {}
-                        },
-                        "name": "pIn",
-                        "size": "None",
-                        "port": {
-                          "Some": {
-                            "astNodeId": 2
+                      "specifier" : {
+                        "kind" : {
+                          "SyncInput" : {
+                            
                           }
                         },
-                        "priority": "None",
-                        "queueFull": "None"
+                        "name" : "pIn",
+                        "size" : "None",
+                        "port" : {
+                          "Some" : {
+                            "astNodeId" : 2
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None"
                       },
-                      "kind": "SyncInput",
-                      "size": 1,
-                      "ty": {
-                        "DefPort": {
-                          "symbol": {
-                            "Port": {
-                              "nodeId": 0,
-                              "unqualifiedName": "P"
+                      "kind" : "SyncInput",
+                      "size" : 1,
+                      "ty" : {
+                        "DefPort" : {
+                          "symbol" : {
+                            "Port" : {
+                              "nodeId" : 0,
+                              "unqualifiedName" : "P"
                             }
                           }
                         }
                       },
-                      "importNodeIds": []
+                      "importNodeIds" : [
+                      ]
                     }
                   }
                 },
-                "portNumber": "None"
+                "portNumber" : "None"
               },
-              "isUnmatched": false
+              "isUnmatched" : false
             }
           ],
-          "C2": [
+          "C2" : [
             {
-              "from": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-                  "pos": "26.5",
-                  "includingLoc": "None"
+              "from" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+                  "pos" : "26.5",
+                  "includingLoc" : "None"
                 },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 21
+                "port" : {
+                  "componentInstance" : {
+                    "aNode" : {
+                      "astNodeId" : 21
                     },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c2"
+                    "qualifiedName" : {
+                      "qualifier" : [
+                      ],
+                      "base" : "c2"
                     },
-                    "component": {
-                      "astNodeId": 13
+                    "component" : {
+                      "astNodeId" : 13
                     },
-                    "baseId": 512,
-                    "maxId": 511,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
+                    "baseId" : 512,
+                    "maxId" : 511,
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecifierMap" : {
+                      
+                    }
                   },
-                  "portInstance": {
-                    "General": {
-                      "aNode": {
-                        "astNodeId": 12
+                  "portInstance" : {
+                    "General" : {
+                      "aNode" : {
+                        "astNodeId" : 12
                       },
-                      "specifier": {
-                        "kind": {
-                          "Output": {}
-                        },
-                        "name": "pOut",
-                        "size": "None",
-                        "port": {
-                          "Some": {
-                            "astNodeId": 11
+                      "specifier" : {
+                        "kind" : {
+                          "Output" : {
+                            
                           }
                         },
-                        "priority": "None",
-                        "queueFull": "None"
+                        "name" : "pOut",
+                        "size" : "None",
+                        "port" : {
+                          "Some" : {
+                            "astNodeId" : 11
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None"
                       },
-                      "kind": "Output",
-                      "size": 1,
-                      "ty": {
-                        "DefPort": {
-                          "symbol": {
-                            "Port": {
-                              "nodeId": 0,
-                              "unqualifiedName": "P"
+                      "kind" : "Output",
+                      "size" : 1,
+                      "ty" : {
+                        "DefPort" : {
+                          "symbol" : {
+                            "Port" : {
+                              "nodeId" : 0,
+                              "unqualifiedName" : "P"
                             }
                           }
                         }
                       },
-                      "importNodeIds": []
+                      "importNodeIds" : [
+                      ]
                     }
                   }
                 },
-                "portNumber": "None"
+                "portNumber" : "None"
               },
-              "to": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-                  "pos": "26.16",
-                  "includingLoc": "None"
+              "to" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+                  "pos" : "26.16",
+                  "includingLoc" : "None"
                 },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 17
+                "port" : {
+                  "componentInstance" : {
+                    "aNode" : {
+                      "astNodeId" : 17
                     },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c1"
+                    "qualifiedName" : {
+                      "qualifier" : [
+                      ],
+                      "base" : "c1"
                     },
-                    "component": {
-                      "astNodeId": 13
+                    "component" : {
+                      "astNodeId" : 13
                     },
-                    "baseId": 256,
-                    "maxId": 255,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
+                    "baseId" : 256,
+                    "maxId" : 255,
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecifierMap" : {
+                      
+                    }
                   },
-                  "portInstance": {
-                    "General": {
-                      "aNode": {
-                        "astNodeId": 3
+                  "portInstance" : {
+                    "General" : {
+                      "aNode" : {
+                        "astNodeId" : 3
                       },
-                      "specifier": {
-                        "kind": {
-                          "SyncInput": {}
-                        },
-                        "name": "pIn",
-                        "size": "None",
-                        "port": {
-                          "Some": {
-                            "astNodeId": 2
+                      "specifier" : {
+                        "kind" : {
+                          "SyncInput" : {
+                            
                           }
                         },
-                        "priority": "None",
-                        "queueFull": "None"
+                        "name" : "pIn",
+                        "size" : "None",
+                        "port" : {
+                          "Some" : {
+                            "astNodeId" : 2
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None"
                       },
-                      "kind": "SyncInput",
-                      "size": 1,
-                      "ty": {
-                        "DefPort": {
-                          "symbol": {
-                            "Port": {
-                              "nodeId": 0,
-                              "unqualifiedName": "P"
+                      "kind" : "SyncInput",
+                      "size" : 1,
+                      "ty" : {
+                        "DefPort" : {
+                          "symbol" : {
+                            "Port" : {
+                              "nodeId" : 0,
+                              "unqualifiedName" : "P"
                             }
                           }
                         }
                       },
-                      "importNodeIds": []
+                      "importNodeIds" : [
+                      ]
                     }
                   }
                 },
-                "portNumber": "None"
+                "portNumber" : "None"
               },
-              "isUnmatched": false
+              "isUnmatched" : false
             }
           ]
         },
-        "outputConnectionMap": [
+        "localConnectionMap" : {
+          "C1" : [
+            {
+              "from" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+                  "pos" : "21.5",
+                  "includingLoc" : "None"
+                },
+                "port" : {
+                  "componentInstance" : {
+                    "aNode" : {
+                      "astNodeId" : 17
+                    },
+                    "qualifiedName" : {
+                      "qualifier" : [
+                      ],
+                      "base" : "c1"
+                    },
+                    "component" : {
+                      "astNodeId" : 13
+                    },
+                    "baseId" : 256,
+                    "maxId" : 255,
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecifierMap" : {
+                      
+                    }
+                  },
+                  "portInstance" : {
+                    "General" : {
+                      "aNode" : {
+                        "astNodeId" : 12
+                      },
+                      "specifier" : {
+                        "kind" : {
+                          "Output" : {
+                            
+                          }
+                        },
+                        "name" : "pOut",
+                        "size" : "None",
+                        "port" : {
+                          "Some" : {
+                            "astNodeId" : 11
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None"
+                      },
+                      "kind" : "Output",
+                      "size" : 1,
+                      "ty" : {
+                        "DefPort" : {
+                          "symbol" : {
+                            "Port" : {
+                              "nodeId" : 0,
+                              "unqualifiedName" : "P"
+                            }
+                          }
+                        }
+                      },
+                      "importNodeIds" : [
+                      ]
+                    }
+                  }
+                },
+                "portNumber" : "None"
+              },
+              "to" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+                  "pos" : "21.16",
+                  "includingLoc" : "None"
+                },
+                "port" : {
+                  "componentInstance" : {
+                    "aNode" : {
+                      "astNodeId" : 21
+                    },
+                    "qualifiedName" : {
+                      "qualifier" : [
+                      ],
+                      "base" : "c2"
+                    },
+                    "component" : {
+                      "astNodeId" : 13
+                    },
+                    "baseId" : 512,
+                    "maxId" : 511,
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecifierMap" : {
+                      
+                    }
+                  },
+                  "portInstance" : {
+                    "General" : {
+                      "aNode" : {
+                        "astNodeId" : 3
+                      },
+                      "specifier" : {
+                        "kind" : {
+                          "SyncInput" : {
+                            
+                          }
+                        },
+                        "name" : "pIn",
+                        "size" : "None",
+                        "port" : {
+                          "Some" : {
+                            "astNodeId" : 2
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None"
+                      },
+                      "kind" : "SyncInput",
+                      "size" : 1,
+                      "ty" : {
+                        "DefPort" : {
+                          "symbol" : {
+                            "Port" : {
+                              "nodeId" : 0,
+                              "unqualifiedName" : "P"
+                            }
+                          }
+                        }
+                      },
+                      "importNodeIds" : [
+                      ]
+                    }
+                  }
+                },
+                "portNumber" : "None"
+              },
+              "isUnmatched" : false
+            }
+          ],
+          "C2" : [
+            {
+              "from" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+                  "pos" : "26.5",
+                  "includingLoc" : "None"
+                },
+                "port" : {
+                  "componentInstance" : {
+                    "aNode" : {
+                      "astNodeId" : 21
+                    },
+                    "qualifiedName" : {
+                      "qualifier" : [
+                      ],
+                      "base" : "c2"
+                    },
+                    "component" : {
+                      "astNodeId" : 13
+                    },
+                    "baseId" : 512,
+                    "maxId" : 511,
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecifierMap" : {
+                      
+                    }
+                  },
+                  "portInstance" : {
+                    "General" : {
+                      "aNode" : {
+                        "astNodeId" : 12
+                      },
+                      "specifier" : {
+                        "kind" : {
+                          "Output" : {
+                            
+                          }
+                        },
+                        "name" : "pOut",
+                        "size" : "None",
+                        "port" : {
+                          "Some" : {
+                            "astNodeId" : 11
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None"
+                      },
+                      "kind" : "Output",
+                      "size" : 1,
+                      "ty" : {
+                        "DefPort" : {
+                          "symbol" : {
+                            "Port" : {
+                              "nodeId" : 0,
+                              "unqualifiedName" : "P"
+                            }
+                          }
+                        }
+                      },
+                      "importNodeIds" : [
+                      ]
+                    }
+                  }
+                },
+                "portNumber" : "None"
+              },
+              "to" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+                  "pos" : "26.16",
+                  "includingLoc" : "None"
+                },
+                "port" : {
+                  "componentInstance" : {
+                    "aNode" : {
+                      "astNodeId" : 17
+                    },
+                    "qualifiedName" : {
+                      "qualifier" : [
+                      ],
+                      "base" : "c1"
+                    },
+                    "component" : {
+                      "astNodeId" : 13
+                    },
+                    "baseId" : 256,
+                    "maxId" : 255,
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecifierMap" : {
+                      
+                    }
+                  },
+                  "portInstance" : {
+                    "General" : {
+                      "aNode" : {
+                        "astNodeId" : 3
+                      },
+                      "specifier" : {
+                        "kind" : {
+                          "SyncInput" : {
+                            
+                          }
+                        },
+                        "name" : "pIn",
+                        "size" : "None",
+                        "port" : {
+                          "Some" : {
+                            "astNodeId" : 2
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None"
+                      },
+                      "kind" : "SyncInput",
+                      "size" : 1,
+                      "ty" : {
+                        "DefPort" : {
+                          "symbol" : {
+                            "Port" : {
+                              "nodeId" : 0,
+                              "unqualifiedName" : "P"
+                            }
+                          }
+                        }
+                      },
+                      "importNodeIds" : [
+                      ]
+                    }
+                  }
+                },
+                "portNumber" : "None"
+              },
+              "isUnmatched" : false
+            }
+          ]
+        },
+        "outputConnectionMap" : [
           [
             {
-              "componentInstance": {
-                "aNode": {
-                  "astNodeId": 17
+              "componentInstance" : {
+                "aNode" : {
+                  "astNodeId" : 17
                 },
-                "qualifiedName": {
-                  "qualifier": [],
-                  "base": "c1"
+                "qualifiedName" : {
+                  "qualifier" : [
+                  ],
+                  "base" : "c1"
                 },
-                "component": {
-                  "astNodeId": 13
+                "component" : {
+                  "astNodeId" : 13
                 },
-                "baseId": 256,
-                "maxId": 255,
-                "file": "None",
-                "queueSize": "None",
-                "stackSize": "None",
-                "priority": "None",
-                "cpu": "None",
-                "initSpecifierMap": {}
+                "baseId" : 256,
+                "maxId" : 255,
+                "file" : "None",
+                "queueSize" : "None",
+                "stackSize" : "None",
+                "priority" : "None",
+                "cpu" : "None",
+                "initSpecifierMap" : {
+                  
+                }
               },
-              "portInstance": {
-                "General": {
-                  "aNode": {
-                    "astNodeId": 12
+              "portInstance" : {
+                "General" : {
+                  "aNode" : {
+                    "astNodeId" : 12
                   },
-                  "specifier": {
-                    "kind": {
-                      "Output": {}
-                    },
-                    "name": "pOut",
-                    "size": "None",
-                    "port": {
-                      "Some": {
-                        "astNodeId": 11
+                  "specifier" : {
+                    "kind" : {
+                      "Output" : {
+                        
                       }
                     },
-                    "priority": "None",
-                    "queueFull": "None"
+                    "name" : "pOut",
+                    "size" : "None",
+                    "port" : {
+                      "Some" : {
+                        "astNodeId" : 11
+                      }
+                    },
+                    "priority" : "None",
+                    "queueFull" : "None"
                   },
-                  "kind": "Output",
-                  "size": 1,
-                  "ty": {
-                    "DefPort": {
-                      "symbol": {
-                        "Port": {
-                          "nodeId": 0,
-                          "unqualifiedName": "P"
+                  "kind" : "Output",
+                  "size" : 1,
+                  "ty" : {
+                    "DefPort" : {
+                      "symbol" : {
+                        "Port" : {
+                          "nodeId" : 0,
+                          "unqualifiedName" : "P"
                         }
                       }
                     }
                   },
-                  "importNodeIds": []
+                  "importNodeIds" : [
+                  ]
                 }
               }
             },
             [
               {
-                "from": {
-                  "loc": {
-                    "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-                    "pos": "21.5",
-                    "includingLoc": "None"
+                "from" : {
+                  "loc" : {
+                    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+                    "pos" : "21.5",
+                    "includingLoc" : "None"
                   },
-                  "port": {
-                    "componentInstance": {
-                      "aNode": {
-                        "astNodeId": 17
+                  "port" : {
+                    "componentInstance" : {
+                      "aNode" : {
+                        "astNodeId" : 17
                       },
-                      "qualifiedName": {
-                        "qualifier": [],
-                        "base": "c1"
+                      "qualifiedName" : {
+                        "qualifier" : [
+                        ],
+                        "base" : "c1"
                       },
-                      "component": {
-                        "astNodeId": 13
+                      "component" : {
+                        "astNodeId" : 13
                       },
-                      "baseId": 256,
-                      "maxId": 255,
-                      "file": "None",
-                      "queueSize": "None",
-                      "stackSize": "None",
-                      "priority": "None",
-                      "cpu": "None",
-                      "initSpecifierMap": {}
+                      "baseId" : 256,
+                      "maxId" : 255,
+                      "file" : "None",
+                      "queueSize" : "None",
+                      "stackSize" : "None",
+                      "priority" : "None",
+                      "cpu" : "None",
+                      "initSpecifierMap" : {
+                        
+                      }
                     },
-                    "portInstance": {
-                      "General": {
-                        "aNode": {
-                          "astNodeId": 12
+                    "portInstance" : {
+                      "General" : {
+                        "aNode" : {
+                          "astNodeId" : 12
                         },
-                        "specifier": {
-                          "kind": {
-                            "Output": {}
-                          },
-                          "name": "pOut",
-                          "size": "None",
-                          "port": {
-                            "Some": {
-                              "astNodeId": 11
+                        "specifier" : {
+                          "kind" : {
+                            "Output" : {
+                              
                             }
                           },
-                          "priority": "None",
-                          "queueFull": "None"
+                          "name" : "pOut",
+                          "size" : "None",
+                          "port" : {
+                            "Some" : {
+                              "astNodeId" : 11
+                            }
+                          },
+                          "priority" : "None",
+                          "queueFull" : "None"
                         },
-                        "kind": "Output",
-                        "size": 1,
-                        "ty": {
-                          "DefPort": {
-                            "symbol": {
-                              "Port": {
-                                "nodeId": 0,
-                                "unqualifiedName": "P"
+                        "kind" : "Output",
+                        "size" : 1,
+                        "ty" : {
+                          "DefPort" : {
+                            "symbol" : {
+                              "Port" : {
+                                "nodeId" : 0,
+                                "unqualifiedName" : "P"
                               }
                             }
                           }
                         },
-                        "importNodeIds": []
+                        "importNodeIds" : [
+                        ]
                       }
                     }
                   },
-                  "portNumber": "None"
+                  "portNumber" : "None"
                 },
-                "to": {
-                  "loc": {
-                    "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-                    "pos": "21.16",
-                    "includingLoc": "None"
+                "to" : {
+                  "loc" : {
+                    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+                    "pos" : "21.16",
+                    "includingLoc" : "None"
                   },
-                  "port": {
-                    "componentInstance": {
-                      "aNode": {
-                        "astNodeId": 21
+                  "port" : {
+                    "componentInstance" : {
+                      "aNode" : {
+                        "astNodeId" : 21
                       },
-                      "qualifiedName": {
-                        "qualifier": [],
-                        "base": "c2"
+                      "qualifiedName" : {
+                        "qualifier" : [
+                        ],
+                        "base" : "c2"
                       },
-                      "component": {
-                        "astNodeId": 13
+                      "component" : {
+                        "astNodeId" : 13
                       },
-                      "baseId": 512,
-                      "maxId": 511,
-                      "file": "None",
-                      "queueSize": "None",
-                      "stackSize": "None",
-                      "priority": "None",
-                      "cpu": "None",
-                      "initSpecifierMap": {}
+                      "baseId" : 512,
+                      "maxId" : 511,
+                      "file" : "None",
+                      "queueSize" : "None",
+                      "stackSize" : "None",
+                      "priority" : "None",
+                      "cpu" : "None",
+                      "initSpecifierMap" : {
+                        
+                      }
                     },
-                    "portInstance": {
-                      "General": {
-                        "aNode": {
-                          "astNodeId": 3
+                    "portInstance" : {
+                      "General" : {
+                        "aNode" : {
+                          "astNodeId" : 3
                         },
-                        "specifier": {
-                          "kind": {
-                            "SyncInput": {}
-                          },
-                          "name": "pIn",
-                          "size": "None",
-                          "port": {
-                            "Some": {
-                              "astNodeId": 2
+                        "specifier" : {
+                          "kind" : {
+                            "SyncInput" : {
+                              
                             }
                           },
-                          "priority": "None",
-                          "queueFull": "None"
+                          "name" : "pIn",
+                          "size" : "None",
+                          "port" : {
+                            "Some" : {
+                              "astNodeId" : 2
+                            }
+                          },
+                          "priority" : "None",
+                          "queueFull" : "None"
                         },
-                        "kind": "SyncInput",
-                        "size": 1,
-                        "ty": {
-                          "DefPort": {
-                            "symbol": {
-                              "Port": {
-                                "nodeId": 0,
-                                "unqualifiedName": "P"
+                        "kind" : "SyncInput",
+                        "size" : 1,
+                        "ty" : {
+                          "DefPort" : {
+                            "symbol" : {
+                              "Port" : {
+                                "nodeId" : 0,
+                                "unqualifiedName" : "P"
                               }
                             }
                           }
                         },
-                        "importNodeIds": []
+                        "importNodeIds" : [
+                        ]
                       }
                     }
                   },
-                  "portNumber": "None"
+                  "portNumber" : "None"
                 },
-                "isUnmatched": false
+                "isUnmatched" : false
               }
             ]
           ],
           [
             {
-              "componentInstance": {
-                "aNode": {
-                  "astNodeId": 21
+              "componentInstance" : {
+                "aNode" : {
+                  "astNodeId" : 21
                 },
-                "qualifiedName": {
-                  "qualifier": [],
-                  "base": "c2"
+                "qualifiedName" : {
+                  "qualifier" : [
+                  ],
+                  "base" : "c2"
                 },
-                "component": {
-                  "astNodeId": 13
+                "component" : {
+                  "astNodeId" : 13
                 },
-                "baseId": 512,
-                "maxId": 511,
-                "file": "None",
-                "queueSize": "None",
-                "stackSize": "None",
-                "priority": "None",
-                "cpu": "None",
-                "initSpecifierMap": {}
+                "baseId" : 512,
+                "maxId" : 511,
+                "file" : "None",
+                "queueSize" : "None",
+                "stackSize" : "None",
+                "priority" : "None",
+                "cpu" : "None",
+                "initSpecifierMap" : {
+                  
+                }
               },
-              "portInstance": {
-                "General": {
-                  "aNode": {
-                    "astNodeId": 12
+              "portInstance" : {
+                "General" : {
+                  "aNode" : {
+                    "astNodeId" : 12
                   },
-                  "specifier": {
-                    "kind": {
-                      "Output": {}
-                    },
-                    "name": "pOut",
-                    "size": "None",
-                    "port": {
-                      "Some": {
-                        "astNodeId": 11
+                  "specifier" : {
+                    "kind" : {
+                      "Output" : {
+                        
                       }
                     },
-                    "priority": "None",
-                    "queueFull": "None"
+                    "name" : "pOut",
+                    "size" : "None",
+                    "port" : {
+                      "Some" : {
+                        "astNodeId" : 11
+                      }
+                    },
+                    "priority" : "None",
+                    "queueFull" : "None"
                   },
-                  "kind": "Output",
-                  "size": 1,
-                  "ty": {
-                    "DefPort": {
-                      "symbol": {
-                        "Port": {
-                          "nodeId": 0,
-                          "unqualifiedName": "P"
+                  "kind" : "Output",
+                  "size" : 1,
+                  "ty" : {
+                    "DefPort" : {
+                      "symbol" : {
+                        "Port" : {
+                          "nodeId" : 0,
+                          "unqualifiedName" : "P"
                         }
                       }
                     }
                   },
-                  "importNodeIds": []
+                  "importNodeIds" : [
+                  ]
                 }
               }
             },
             [
               {
-                "from": {
-                  "loc": {
-                    "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-                    "pos": "26.5",
-                    "includingLoc": "None"
+                "from" : {
+                  "loc" : {
+                    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+                    "pos" : "26.5",
+                    "includingLoc" : "None"
                   },
-                  "port": {
-                    "componentInstance": {
-                      "aNode": {
-                        "astNodeId": 21
+                  "port" : {
+                    "componentInstance" : {
+                      "aNode" : {
+                        "astNodeId" : 21
                       },
-                      "qualifiedName": {
-                        "qualifier": [],
-                        "base": "c2"
+                      "qualifiedName" : {
+                        "qualifier" : [
+                        ],
+                        "base" : "c2"
                       },
-                      "component": {
-                        "astNodeId": 13
+                      "component" : {
+                        "astNodeId" : 13
                       },
-                      "baseId": 512,
-                      "maxId": 511,
-                      "file": "None",
-                      "queueSize": "None",
-                      "stackSize": "None",
-                      "priority": "None",
-                      "cpu": "None",
-                      "initSpecifierMap": {}
+                      "baseId" : 512,
+                      "maxId" : 511,
+                      "file" : "None",
+                      "queueSize" : "None",
+                      "stackSize" : "None",
+                      "priority" : "None",
+                      "cpu" : "None",
+                      "initSpecifierMap" : {
+                        
+                      }
                     },
-                    "portInstance": {
-                      "General": {
-                        "aNode": {
-                          "astNodeId": 12
+                    "portInstance" : {
+                      "General" : {
+                        "aNode" : {
+                          "astNodeId" : 12
                         },
-                        "specifier": {
-                          "kind": {
-                            "Output": {}
-                          },
-                          "name": "pOut",
-                          "size": "None",
-                          "port": {
-                            "Some": {
-                              "astNodeId": 11
+                        "specifier" : {
+                          "kind" : {
+                            "Output" : {
+                              
                             }
                           },
-                          "priority": "None",
-                          "queueFull": "None"
+                          "name" : "pOut",
+                          "size" : "None",
+                          "port" : {
+                            "Some" : {
+                              "astNodeId" : 11
+                            }
+                          },
+                          "priority" : "None",
+                          "queueFull" : "None"
                         },
-                        "kind": "Output",
-                        "size": 1,
-                        "ty": {
-                          "DefPort": {
-                            "symbol": {
-                              "Port": {
-                                "nodeId": 0,
-                                "unqualifiedName": "P"
+                        "kind" : "Output",
+                        "size" : 1,
+                        "ty" : {
+                          "DefPort" : {
+                            "symbol" : {
+                              "Port" : {
+                                "nodeId" : 0,
+                                "unqualifiedName" : "P"
                               }
                             }
                           }
                         },
-                        "importNodeIds": []
+                        "importNodeIds" : [
+                        ]
                       }
                     }
                   },
-                  "portNumber": "None"
+                  "portNumber" : "None"
                 },
-                "to": {
-                  "loc": {
-                    "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-                    "pos": "26.16",
-                    "includingLoc": "None"
+                "to" : {
+                  "loc" : {
+                    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+                    "pos" : "26.16",
+                    "includingLoc" : "None"
                   },
-                  "port": {
-                    "componentInstance": {
-                      "aNode": {
-                        "astNodeId": 17
+                  "port" : {
+                    "componentInstance" : {
+                      "aNode" : {
+                        "astNodeId" : 17
                       },
-                      "qualifiedName": {
-                        "qualifier": [],
-                        "base": "c1"
+                      "qualifiedName" : {
+                        "qualifier" : [
+                        ],
+                        "base" : "c1"
                       },
-                      "component": {
-                        "astNodeId": 13
+                      "component" : {
+                        "astNodeId" : 13
                       },
-                      "baseId": 256,
-                      "maxId": 255,
-                      "file": "None",
-                      "queueSize": "None",
-                      "stackSize": "None",
-                      "priority": "None",
-                      "cpu": "None",
-                      "initSpecifierMap": {}
+                      "baseId" : 256,
+                      "maxId" : 255,
+                      "file" : "None",
+                      "queueSize" : "None",
+                      "stackSize" : "None",
+                      "priority" : "None",
+                      "cpu" : "None",
+                      "initSpecifierMap" : {
+                        
+                      }
                     },
-                    "portInstance": {
-                      "General": {
-                        "aNode": {
-                          "astNodeId": 3
+                    "portInstance" : {
+                      "General" : {
+                        "aNode" : {
+                          "astNodeId" : 3
                         },
-                        "specifier": {
-                          "kind": {
-                            "SyncInput": {}
-                          },
-                          "name": "pIn",
-                          "size": "None",
-                          "port": {
-                            "Some": {
-                              "astNodeId": 2
+                        "specifier" : {
+                          "kind" : {
+                            "SyncInput" : {
+                              
                             }
                           },
-                          "priority": "None",
-                          "queueFull": "None"
+                          "name" : "pIn",
+                          "size" : "None",
+                          "port" : {
+                            "Some" : {
+                              "astNodeId" : 2
+                            }
+                          },
+                          "priority" : "None",
+                          "queueFull" : "None"
                         },
-                        "kind": "SyncInput",
-                        "size": 1,
-                        "ty": {
-                          "DefPort": {
-                            "symbol": {
-                              "Port": {
-                                "nodeId": 0,
-                                "unqualifiedName": "P"
+                        "kind" : "SyncInput",
+                        "size" : 1,
+                        "ty" : {
+                          "DefPort" : {
+                            "symbol" : {
+                              "Port" : {
+                                "nodeId" : 0,
+                                "unqualifiedName" : "P"
                               }
                             }
                           }
                         },
-                        "importNodeIds": []
+                        "importNodeIds" : [
+                        ]
                       }
                     }
                   },
-                  "portNumber": "None"
+                  "portNumber" : "None"
                 },
-                "isUnmatched": false
+                "isUnmatched" : false
               }
             ]
           ]
         ],
-        "inputConnectionMap": [
+        "inputConnectionMap" : [
           [
             {
-              "componentInstance": {
-                "aNode": {
-                  "astNodeId": 21
+              "componentInstance" : {
+                "aNode" : {
+                  "astNodeId" : 21
                 },
-                "qualifiedName": {
-                  "qualifier": [],
-                  "base": "c2"
+                "qualifiedName" : {
+                  "qualifier" : [
+                  ],
+                  "base" : "c2"
                 },
-                "component": {
-                  "astNodeId": 13
+                "component" : {
+                  "astNodeId" : 13
                 },
-                "baseId": 512,
-                "maxId": 511,
-                "file": "None",
-                "queueSize": "None",
-                "stackSize": "None",
-                "priority": "None",
-                "cpu": "None",
-                "initSpecifierMap": {}
+                "baseId" : 512,
+                "maxId" : 511,
+                "file" : "None",
+                "queueSize" : "None",
+                "stackSize" : "None",
+                "priority" : "None",
+                "cpu" : "None",
+                "initSpecifierMap" : {
+                  
+                }
               },
-              "portInstance": {
-                "General": {
-                  "aNode": {
-                    "astNodeId": 3
+              "portInstance" : {
+                "General" : {
+                  "aNode" : {
+                    "astNodeId" : 3
                   },
-                  "specifier": {
-                    "kind": {
-                      "SyncInput": {}
-                    },
-                    "name": "pIn",
-                    "size": "None",
-                    "port": {
-                      "Some": {
-                        "astNodeId": 2
+                  "specifier" : {
+                    "kind" : {
+                      "SyncInput" : {
+                        
                       }
                     },
-                    "priority": "None",
-                    "queueFull": "None"
+                    "name" : "pIn",
+                    "size" : "None",
+                    "port" : {
+                      "Some" : {
+                        "astNodeId" : 2
+                      }
+                    },
+                    "priority" : "None",
+                    "queueFull" : "None"
                   },
-                  "kind": "SyncInput",
-                  "size": 1,
-                  "ty": {
-                    "DefPort": {
-                      "symbol": {
-                        "Port": {
-                          "nodeId": 0,
-                          "unqualifiedName": "P"
+                  "kind" : "SyncInput",
+                  "size" : 1,
+                  "ty" : {
+                    "DefPort" : {
+                      "symbol" : {
+                        "Port" : {
+                          "nodeId" : 0,
+                          "unqualifiedName" : "P"
                         }
                       }
                     }
                   },
-                  "importNodeIds": []
+                  "importNodeIds" : [
+                  ]
                 }
               }
             },
             [
               {
-                "from": {
-                  "loc": {
-                    "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-                    "pos": "21.5",
-                    "includingLoc": "None"
+                "from" : {
+                  "loc" : {
+                    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+                    "pos" : "21.5",
+                    "includingLoc" : "None"
                   },
-                  "port": {
-                    "componentInstance": {
-                      "aNode": {
-                        "astNodeId": 17
+                  "port" : {
+                    "componentInstance" : {
+                      "aNode" : {
+                        "astNodeId" : 17
                       },
-                      "qualifiedName": {
-                        "qualifier": [],
-                        "base": "c1"
+                      "qualifiedName" : {
+                        "qualifier" : [
+                        ],
+                        "base" : "c1"
                       },
-                      "component": {
-                        "astNodeId": 13
+                      "component" : {
+                        "astNodeId" : 13
                       },
-                      "baseId": 256,
-                      "maxId": 255,
-                      "file": "None",
-                      "queueSize": "None",
-                      "stackSize": "None",
-                      "priority": "None",
-                      "cpu": "None",
-                      "initSpecifierMap": {}
+                      "baseId" : 256,
+                      "maxId" : 255,
+                      "file" : "None",
+                      "queueSize" : "None",
+                      "stackSize" : "None",
+                      "priority" : "None",
+                      "cpu" : "None",
+                      "initSpecifierMap" : {
+                        
+                      }
                     },
-                    "portInstance": {
-                      "General": {
-                        "aNode": {
-                          "astNodeId": 12
+                    "portInstance" : {
+                      "General" : {
+                        "aNode" : {
+                          "astNodeId" : 12
                         },
-                        "specifier": {
-                          "kind": {
-                            "Output": {}
-                          },
-                          "name": "pOut",
-                          "size": "None",
-                          "port": {
-                            "Some": {
-                              "astNodeId": 11
+                        "specifier" : {
+                          "kind" : {
+                            "Output" : {
+                              
                             }
                           },
-                          "priority": "None",
-                          "queueFull": "None"
+                          "name" : "pOut",
+                          "size" : "None",
+                          "port" : {
+                            "Some" : {
+                              "astNodeId" : 11
+                            }
+                          },
+                          "priority" : "None",
+                          "queueFull" : "None"
                         },
-                        "kind": "Output",
-                        "size": 1,
-                        "ty": {
-                          "DefPort": {
-                            "symbol": {
-                              "Port": {
-                                "nodeId": 0,
-                                "unqualifiedName": "P"
+                        "kind" : "Output",
+                        "size" : 1,
+                        "ty" : {
+                          "DefPort" : {
+                            "symbol" : {
+                              "Port" : {
+                                "nodeId" : 0,
+                                "unqualifiedName" : "P"
                               }
                             }
                           }
                         },
-                        "importNodeIds": []
+                        "importNodeIds" : [
+                        ]
                       }
                     }
                   },
-                  "portNumber": "None"
+                  "portNumber" : "None"
                 },
-                "to": {
-                  "loc": {
-                    "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-                    "pos": "21.16",
-                    "includingLoc": "None"
+                "to" : {
+                  "loc" : {
+                    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+                    "pos" : "21.16",
+                    "includingLoc" : "None"
                   },
-                  "port": {
-                    "componentInstance": {
-                      "aNode": {
-                        "astNodeId": 21
+                  "port" : {
+                    "componentInstance" : {
+                      "aNode" : {
+                        "astNodeId" : 21
                       },
-                      "qualifiedName": {
-                        "qualifier": [],
-                        "base": "c2"
+                      "qualifiedName" : {
+                        "qualifier" : [
+                        ],
+                        "base" : "c2"
                       },
-                      "component": {
-                        "astNodeId": 13
+                      "component" : {
+                        "astNodeId" : 13
                       },
-                      "baseId": 512,
-                      "maxId": 511,
-                      "file": "None",
-                      "queueSize": "None",
-                      "stackSize": "None",
-                      "priority": "None",
-                      "cpu": "None",
-                      "initSpecifierMap": {}
+                      "baseId" : 512,
+                      "maxId" : 511,
+                      "file" : "None",
+                      "queueSize" : "None",
+                      "stackSize" : "None",
+                      "priority" : "None",
+                      "cpu" : "None",
+                      "initSpecifierMap" : {
+                        
+                      }
                     },
-                    "portInstance": {
-                      "General": {
-                        "aNode": {
-                          "astNodeId": 3
+                    "portInstance" : {
+                      "General" : {
+                        "aNode" : {
+                          "astNodeId" : 3
                         },
-                        "specifier": {
-                          "kind": {
-                            "SyncInput": {}
-                          },
-                          "name": "pIn",
-                          "size": "None",
-                          "port": {
-                            "Some": {
-                              "astNodeId": 2
+                        "specifier" : {
+                          "kind" : {
+                            "SyncInput" : {
+                              
                             }
                           },
-                          "priority": "None",
-                          "queueFull": "None"
+                          "name" : "pIn",
+                          "size" : "None",
+                          "port" : {
+                            "Some" : {
+                              "astNodeId" : 2
+                            }
+                          },
+                          "priority" : "None",
+                          "queueFull" : "None"
                         },
-                        "kind": "SyncInput",
-                        "size": 1,
-                        "ty": {
-                          "DefPort": {
-                            "symbol": {
-                              "Port": {
-                                "nodeId": 0,
-                                "unqualifiedName": "P"
+                        "kind" : "SyncInput",
+                        "size" : 1,
+                        "ty" : {
+                          "DefPort" : {
+                            "symbol" : {
+                              "Port" : {
+                                "nodeId" : 0,
+                                "unqualifiedName" : "P"
                               }
                             }
                           }
                         },
-                        "importNodeIds": []
+                        "importNodeIds" : [
+                        ]
                       }
                     }
                   },
-                  "portNumber": "None"
+                  "portNumber" : "None"
                 },
-                "isUnmatched": false
+                "isUnmatched" : false
               }
             ]
           ],
           [
             {
-              "componentInstance": {
-                "aNode": {
-                  "astNodeId": 17
+              "componentInstance" : {
+                "aNode" : {
+                  "astNodeId" : 17
                 },
-                "qualifiedName": {
-                  "qualifier": [],
-                  "base": "c1"
+                "qualifiedName" : {
+                  "qualifier" : [
+                  ],
+                  "base" : "c1"
                 },
-                "component": {
-                  "astNodeId": 13
+                "component" : {
+                  "astNodeId" : 13
                 },
-                "baseId": 256,
-                "maxId": 255,
-                "file": "None",
-                "queueSize": "None",
-                "stackSize": "None",
-                "priority": "None",
-                "cpu": "None",
-                "initSpecifierMap": {}
+                "baseId" : 256,
+                "maxId" : 255,
+                "file" : "None",
+                "queueSize" : "None",
+                "stackSize" : "None",
+                "priority" : "None",
+                "cpu" : "None",
+                "initSpecifierMap" : {
+                  
+                }
               },
-              "portInstance": {
-                "General": {
-                  "aNode": {
-                    "astNodeId": 3
+              "portInstance" : {
+                "General" : {
+                  "aNode" : {
+                    "astNodeId" : 3
                   },
-                  "specifier": {
-                    "kind": {
-                      "SyncInput": {}
-                    },
-                    "name": "pIn",
-                    "size": "None",
-                    "port": {
-                      "Some": {
-                        "astNodeId": 2
+                  "specifier" : {
+                    "kind" : {
+                      "SyncInput" : {
+                        
                       }
                     },
-                    "priority": "None",
-                    "queueFull": "None"
+                    "name" : "pIn",
+                    "size" : "None",
+                    "port" : {
+                      "Some" : {
+                        "astNodeId" : 2
+                      }
+                    },
+                    "priority" : "None",
+                    "queueFull" : "None"
                   },
-                  "kind": "SyncInput",
-                  "size": 1,
-                  "ty": {
-                    "DefPort": {
-                      "symbol": {
-                        "Port": {
-                          "nodeId": 0,
-                          "unqualifiedName": "P"
+                  "kind" : "SyncInput",
+                  "size" : 1,
+                  "ty" : {
+                    "DefPort" : {
+                      "symbol" : {
+                        "Port" : {
+                          "nodeId" : 0,
+                          "unqualifiedName" : "P"
                         }
                       }
                     }
                   },
-                  "importNodeIds": []
+                  "importNodeIds" : [
+                  ]
                 }
               }
             },
             [
               {
-                "from": {
-                  "loc": {
-                    "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-                    "pos": "26.5",
-                    "includingLoc": "None"
+                "from" : {
+                  "loc" : {
+                    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+                    "pos" : "26.5",
+                    "includingLoc" : "None"
                   },
-                  "port": {
-                    "componentInstance": {
-                      "aNode": {
-                        "astNodeId": 21
+                  "port" : {
+                    "componentInstance" : {
+                      "aNode" : {
+                        "astNodeId" : 21
                       },
-                      "qualifiedName": {
-                        "qualifier": [],
-                        "base": "c2"
+                      "qualifiedName" : {
+                        "qualifier" : [
+                        ],
+                        "base" : "c2"
                       },
-                      "component": {
-                        "astNodeId": 13
+                      "component" : {
+                        "astNodeId" : 13
                       },
-                      "baseId": 512,
-                      "maxId": 511,
-                      "file": "None",
-                      "queueSize": "None",
-                      "stackSize": "None",
-                      "priority": "None",
-                      "cpu": "None",
-                      "initSpecifierMap": {}
+                      "baseId" : 512,
+                      "maxId" : 511,
+                      "file" : "None",
+                      "queueSize" : "None",
+                      "stackSize" : "None",
+                      "priority" : "None",
+                      "cpu" : "None",
+                      "initSpecifierMap" : {
+                        
+                      }
                     },
-                    "portInstance": {
-                      "General": {
-                        "aNode": {
-                          "astNodeId": 12
+                    "portInstance" : {
+                      "General" : {
+                        "aNode" : {
+                          "astNodeId" : 12
                         },
-                        "specifier": {
-                          "kind": {
-                            "Output": {}
-                          },
-                          "name": "pOut",
-                          "size": "None",
-                          "port": {
-                            "Some": {
-                              "astNodeId": 11
+                        "specifier" : {
+                          "kind" : {
+                            "Output" : {
+                              
                             }
                           },
-                          "priority": "None",
-                          "queueFull": "None"
+                          "name" : "pOut",
+                          "size" : "None",
+                          "port" : {
+                            "Some" : {
+                              "astNodeId" : 11
+                            }
+                          },
+                          "priority" : "None",
+                          "queueFull" : "None"
                         },
-                        "kind": "Output",
-                        "size": 1,
-                        "ty": {
-                          "DefPort": {
-                            "symbol": {
-                              "Port": {
-                                "nodeId": 0,
-                                "unqualifiedName": "P"
+                        "kind" : "Output",
+                        "size" : 1,
+                        "ty" : {
+                          "DefPort" : {
+                            "symbol" : {
+                              "Port" : {
+                                "nodeId" : 0,
+                                "unqualifiedName" : "P"
                               }
                             }
                           }
                         },
-                        "importNodeIds": []
+                        "importNodeIds" : [
+                        ]
                       }
                     }
                   },
-                  "portNumber": "None"
+                  "portNumber" : "None"
                 },
-                "to": {
-                  "loc": {
-                    "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-                    "pos": "26.16",
-                    "includingLoc": "None"
+                "to" : {
+                  "loc" : {
+                    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+                    "pos" : "26.16",
+                    "includingLoc" : "None"
                   },
-                  "port": {
-                    "componentInstance": {
-                      "aNode": {
-                        "astNodeId": 17
+                  "port" : {
+                    "componentInstance" : {
+                      "aNode" : {
+                        "astNodeId" : 17
                       },
-                      "qualifiedName": {
-                        "qualifier": [],
-                        "base": "c1"
+                      "qualifiedName" : {
+                        "qualifier" : [
+                        ],
+                        "base" : "c1"
                       },
-                      "component": {
-                        "astNodeId": 13
+                      "component" : {
+                        "astNodeId" : 13
                       },
-                      "baseId": 256,
-                      "maxId": 255,
-                      "file": "None",
-                      "queueSize": "None",
-                      "stackSize": "None",
-                      "priority": "None",
-                      "cpu": "None",
-                      "initSpecifierMap": {}
+                      "baseId" : 256,
+                      "maxId" : 255,
+                      "file" : "None",
+                      "queueSize" : "None",
+                      "stackSize" : "None",
+                      "priority" : "None",
+                      "cpu" : "None",
+                      "initSpecifierMap" : {
+                        
+                      }
                     },
-                    "portInstance": {
-                      "General": {
-                        "aNode": {
-                          "astNodeId": 3
+                    "portInstance" : {
+                      "General" : {
+                        "aNode" : {
+                          "astNodeId" : 3
                         },
-                        "specifier": {
-                          "kind": {
-                            "SyncInput": {}
-                          },
-                          "name": "pIn",
-                          "size": "None",
-                          "port": {
-                            "Some": {
-                              "astNodeId": 2
+                        "specifier" : {
+                          "kind" : {
+                            "SyncInput" : {
+                              
                             }
                           },
-                          "priority": "None",
-                          "queueFull": "None"
+                          "name" : "pIn",
+                          "size" : "None",
+                          "port" : {
+                            "Some" : {
+                              "astNodeId" : 2
+                            }
+                          },
+                          "priority" : "None",
+                          "queueFull" : "None"
                         },
-                        "kind": "SyncInput",
-                        "size": 1,
-                        "ty": {
-                          "DefPort": {
-                            "symbol": {
-                              "Port": {
-                                "nodeId": 0,
-                                "unqualifiedName": "P"
+                        "kind" : "SyncInput",
+                        "size" : 1,
+                        "ty" : {
+                          "DefPort" : {
+                            "symbol" : {
+                              "Port" : {
+                                "nodeId" : 0,
+                                "unqualifiedName" : "P"
                               }
                             }
                           }
                         },
-                        "importNodeIds": []
+                        "importNodeIds" : [
+                        ]
                       }
                     }
                   },
-                  "portNumber": "None"
+                  "portNumber" : "None"
                 },
-                "isUnmatched": false
+                "isUnmatched" : false
               }
             ]
           ]
         ],
-        "fromPortNumberMap": [
+        "fromPortNumberMap" : [
           [
             {
-              "from": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-                  "pos": "21.5",
-                  "includingLoc": "None"
+              "from" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+                  "pos" : "21.5",
+                  "includingLoc" : "None"
                 },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 17
+                "port" : {
+                  "componentInstance" : {
+                    "aNode" : {
+                      "astNodeId" : 17
                     },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c1"
+                    "qualifiedName" : {
+                      "qualifier" : [
+                      ],
+                      "base" : "c1"
                     },
-                    "component": {
-                      "astNodeId": 13
+                    "component" : {
+                      "astNodeId" : 13
                     },
-                    "baseId": 256,
-                    "maxId": 255,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
+                    "baseId" : 256,
+                    "maxId" : 255,
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecifierMap" : {
+                      
+                    }
                   },
-                  "portInstance": {
-                    "General": {
-                      "aNode": {
-                        "astNodeId": 12
+                  "portInstance" : {
+                    "General" : {
+                      "aNode" : {
+                        "astNodeId" : 12
                       },
-                      "specifier": {
-                        "kind": {
-                          "Output": {}
-                        },
-                        "name": "pOut",
-                        "size": "None",
-                        "port": {
-                          "Some": {
-                            "astNodeId": 11
+                      "specifier" : {
+                        "kind" : {
+                          "Output" : {
+                            
                           }
                         },
-                        "priority": "None",
-                        "queueFull": "None"
+                        "name" : "pOut",
+                        "size" : "None",
+                        "port" : {
+                          "Some" : {
+                            "astNodeId" : 11
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None"
                       },
-                      "kind": "Output",
-                      "size": 1,
-                      "ty": {
-                        "DefPort": {
-                          "symbol": {
-                            "Port": {
-                              "nodeId": 0,
-                              "unqualifiedName": "P"
+                      "kind" : "Output",
+                      "size" : 1,
+                      "ty" : {
+                        "DefPort" : {
+                          "symbol" : {
+                            "Port" : {
+                              "nodeId" : 0,
+                              "unqualifiedName" : "P"
                             }
                           }
                         }
                       },
-                      "importNodeIds": []
+                      "importNodeIds" : [
+                      ]
                     }
                   }
                 },
-                "portNumber": "None"
+                "portNumber" : "None"
               },
-              "to": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-                  "pos": "21.16",
-                  "includingLoc": "None"
+              "to" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+                  "pos" : "21.16",
+                  "includingLoc" : "None"
                 },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 21
+                "port" : {
+                  "componentInstance" : {
+                    "aNode" : {
+                      "astNodeId" : 21
                     },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c2"
+                    "qualifiedName" : {
+                      "qualifier" : [
+                      ],
+                      "base" : "c2"
                     },
-                    "component": {
-                      "astNodeId": 13
+                    "component" : {
+                      "astNodeId" : 13
                     },
-                    "baseId": 512,
-                    "maxId": 511,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
+                    "baseId" : 512,
+                    "maxId" : 511,
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecifierMap" : {
+                      
+                    }
                   },
-                  "portInstance": {
-                    "General": {
-                      "aNode": {
-                        "astNodeId": 3
+                  "portInstance" : {
+                    "General" : {
+                      "aNode" : {
+                        "astNodeId" : 3
                       },
-                      "specifier": {
-                        "kind": {
-                          "SyncInput": {}
-                        },
-                        "name": "pIn",
-                        "size": "None",
-                        "port": {
-                          "Some": {
-                            "astNodeId": 2
+                      "specifier" : {
+                        "kind" : {
+                          "SyncInput" : {
+                            
                           }
                         },
-                        "priority": "None",
-                        "queueFull": "None"
+                        "name" : "pIn",
+                        "size" : "None",
+                        "port" : {
+                          "Some" : {
+                            "astNodeId" : 2
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None"
                       },
-                      "kind": "SyncInput",
-                      "size": 1,
-                      "ty": {
-                        "DefPort": {
-                          "symbol": {
-                            "Port": {
-                              "nodeId": 0,
-                              "unqualifiedName": "P"
+                      "kind" : "SyncInput",
+                      "size" : 1,
+                      "ty" : {
+                        "DefPort" : {
+                          "symbol" : {
+                            "Port" : {
+                              "nodeId" : 0,
+                              "unqualifiedName" : "P"
                             }
                           }
                         }
                       },
-                      "importNodeIds": []
+                      "importNodeIds" : [
+                      ]
                     }
                   }
                 },
-                "portNumber": "None"
+                "portNumber" : "None"
               },
-              "isUnmatched": false
+              "isUnmatched" : false
             },
             0
           ],
           [
             {
-              "from": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-                  "pos": "26.5",
-                  "includingLoc": "None"
+              "from" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+                  "pos" : "26.5",
+                  "includingLoc" : "None"
                 },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 21
+                "port" : {
+                  "componentInstance" : {
+                    "aNode" : {
+                      "astNodeId" : 21
                     },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c2"
+                    "qualifiedName" : {
+                      "qualifier" : [
+                      ],
+                      "base" : "c2"
                     },
-                    "component": {
-                      "astNodeId": 13
+                    "component" : {
+                      "astNodeId" : 13
                     },
-                    "baseId": 512,
-                    "maxId": 511,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
+                    "baseId" : 512,
+                    "maxId" : 511,
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecifierMap" : {
+                      
+                    }
                   },
-                  "portInstance": {
-                    "General": {
-                      "aNode": {
-                        "astNodeId": 12
+                  "portInstance" : {
+                    "General" : {
+                      "aNode" : {
+                        "astNodeId" : 12
                       },
-                      "specifier": {
-                        "kind": {
-                          "Output": {}
-                        },
-                        "name": "pOut",
-                        "size": "None",
-                        "port": {
-                          "Some": {
-                            "astNodeId": 11
+                      "specifier" : {
+                        "kind" : {
+                          "Output" : {
+                            
                           }
                         },
-                        "priority": "None",
-                        "queueFull": "None"
+                        "name" : "pOut",
+                        "size" : "None",
+                        "port" : {
+                          "Some" : {
+                            "astNodeId" : 11
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None"
                       },
-                      "kind": "Output",
-                      "size": 1,
-                      "ty": {
-                        "DefPort": {
-                          "symbol": {
-                            "Port": {
-                              "nodeId": 0,
-                              "unqualifiedName": "P"
+                      "kind" : "Output",
+                      "size" : 1,
+                      "ty" : {
+                        "DefPort" : {
+                          "symbol" : {
+                            "Port" : {
+                              "nodeId" : 0,
+                              "unqualifiedName" : "P"
                             }
                           }
                         }
                       },
-                      "importNodeIds": []
+                      "importNodeIds" : [
+                      ]
                     }
                   }
                 },
-                "portNumber": "None"
+                "portNumber" : "None"
               },
-              "to": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-                  "pos": "26.16",
-                  "includingLoc": "None"
+              "to" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+                  "pos" : "26.16",
+                  "includingLoc" : "None"
                 },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 17
+                "port" : {
+                  "componentInstance" : {
+                    "aNode" : {
+                      "astNodeId" : 17
                     },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c1"
+                    "qualifiedName" : {
+                      "qualifier" : [
+                      ],
+                      "base" : "c1"
                     },
-                    "component": {
-                      "astNodeId": 13
+                    "component" : {
+                      "astNodeId" : 13
                     },
-                    "baseId": 256,
-                    "maxId": 255,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
+                    "baseId" : 256,
+                    "maxId" : 255,
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecifierMap" : {
+                      
+                    }
                   },
-                  "portInstance": {
-                    "General": {
-                      "aNode": {
-                        "astNodeId": 3
+                  "portInstance" : {
+                    "General" : {
+                      "aNode" : {
+                        "astNodeId" : 3
                       },
-                      "specifier": {
-                        "kind": {
-                          "SyncInput": {}
-                        },
-                        "name": "pIn",
-                        "size": "None",
-                        "port": {
-                          "Some": {
-                            "astNodeId": 2
+                      "specifier" : {
+                        "kind" : {
+                          "SyncInput" : {
+                            
                           }
                         },
-                        "priority": "None",
-                        "queueFull": "None"
+                        "name" : "pIn",
+                        "size" : "None",
+                        "port" : {
+                          "Some" : {
+                            "astNodeId" : 2
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None"
                       },
-                      "kind": "SyncInput",
-                      "size": 1,
-                      "ty": {
-                        "DefPort": {
-                          "symbol": {
-                            "Port": {
-                              "nodeId": 0,
-                              "unqualifiedName": "P"
+                      "kind" : "SyncInput",
+                      "size" : 1,
+                      "ty" : {
+                        "DefPort" : {
+                          "symbol" : {
+                            "Port" : {
+                              "nodeId" : 0,
+                              "unqualifiedName" : "P"
                             }
                           }
                         }
                       },
-                      "importNodeIds": []
+                      "importNodeIds" : [
+                      ]
                     }
                   }
                 },
-                "portNumber": "None"
+                "portNumber" : "None"
               },
-              "isUnmatched": false
+              "isUnmatched" : false
             },
             0
           ]
         ],
-        "toPortNumberMap": [
+        "toPortNumberMap" : [
           [
             {
-              "from": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-                  "pos": "26.5",
-                  "includingLoc": "None"
+              "from" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+                  "pos" : "26.5",
+                  "includingLoc" : "None"
                 },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 21
+                "port" : {
+                  "componentInstance" : {
+                    "aNode" : {
+                      "astNodeId" : 21
                     },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c2"
+                    "qualifiedName" : {
+                      "qualifier" : [
+                      ],
+                      "base" : "c2"
                     },
-                    "component": {
-                      "astNodeId": 13
+                    "component" : {
+                      "astNodeId" : 13
                     },
-                    "baseId": 512,
-                    "maxId": 511,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
+                    "baseId" : 512,
+                    "maxId" : 511,
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecifierMap" : {
+                      
+                    }
                   },
-                  "portInstance": {
-                    "General": {
-                      "aNode": {
-                        "astNodeId": 12
+                  "portInstance" : {
+                    "General" : {
+                      "aNode" : {
+                        "astNodeId" : 12
                       },
-                      "specifier": {
-                        "kind": {
-                          "Output": {}
-                        },
-                        "name": "pOut",
-                        "size": "None",
-                        "port": {
-                          "Some": {
-                            "astNodeId": 11
+                      "specifier" : {
+                        "kind" : {
+                          "Output" : {
+                            
                           }
                         },
-                        "priority": "None",
-                        "queueFull": "None"
+                        "name" : "pOut",
+                        "size" : "None",
+                        "port" : {
+                          "Some" : {
+                            "astNodeId" : 11
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None"
                       },
-                      "kind": "Output",
-                      "size": 1,
-                      "ty": {
-                        "DefPort": {
-                          "symbol": {
-                            "Port": {
-                              "nodeId": 0,
-                              "unqualifiedName": "P"
+                      "kind" : "Output",
+                      "size" : 1,
+                      "ty" : {
+                        "DefPort" : {
+                          "symbol" : {
+                            "Port" : {
+                              "nodeId" : 0,
+                              "unqualifiedName" : "P"
                             }
                           }
                         }
                       },
-                      "importNodeIds": []
+                      "importNodeIds" : [
+                      ]
                     }
                   }
                 },
-                "portNumber": "None"
+                "portNumber" : "None"
               },
-              "to": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-                  "pos": "26.16",
-                  "includingLoc": "None"
+              "to" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+                  "pos" : "26.16",
+                  "includingLoc" : "None"
                 },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 17
+                "port" : {
+                  "componentInstance" : {
+                    "aNode" : {
+                      "astNodeId" : 17
                     },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c1"
+                    "qualifiedName" : {
+                      "qualifier" : [
+                      ],
+                      "base" : "c1"
                     },
-                    "component": {
-                      "astNodeId": 13
+                    "component" : {
+                      "astNodeId" : 13
                     },
-                    "baseId": 256,
-                    "maxId": 255,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
+                    "baseId" : 256,
+                    "maxId" : 255,
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecifierMap" : {
+                      
+                    }
                   },
-                  "portInstance": {
-                    "General": {
-                      "aNode": {
-                        "astNodeId": 3
+                  "portInstance" : {
+                    "General" : {
+                      "aNode" : {
+                        "astNodeId" : 3
                       },
-                      "specifier": {
-                        "kind": {
-                          "SyncInput": {}
-                        },
-                        "name": "pIn",
-                        "size": "None",
-                        "port": {
-                          "Some": {
-                            "astNodeId": 2
+                      "specifier" : {
+                        "kind" : {
+                          "SyncInput" : {
+                            
                           }
                         },
-                        "priority": "None",
-                        "queueFull": "None"
+                        "name" : "pIn",
+                        "size" : "None",
+                        "port" : {
+                          "Some" : {
+                            "astNodeId" : 2
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None"
                       },
-                      "kind": "SyncInput",
-                      "size": 1,
-                      "ty": {
-                        "DefPort": {
-                          "symbol": {
-                            "Port": {
-                              "nodeId": 0,
-                              "unqualifiedName": "P"
+                      "kind" : "SyncInput",
+                      "size" : 1,
+                      "ty" : {
+                        "DefPort" : {
+                          "symbol" : {
+                            "Port" : {
+                              "nodeId" : 0,
+                              "unqualifiedName" : "P"
                             }
                           }
                         }
                       },
-                      "importNodeIds": []
+                      "importNodeIds" : [
+                      ]
                     }
                   }
                 },
-                "portNumber": "None"
+                "portNumber" : "None"
               },
-              "isUnmatched": false
+              "isUnmatched" : false
             },
             0
           ],
           [
             {
-              "from": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-                  "pos": "21.5",
-                  "includingLoc": "None"
+              "from" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+                  "pos" : "21.5",
+                  "includingLoc" : "None"
                 },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 17
+                "port" : {
+                  "componentInstance" : {
+                    "aNode" : {
+                      "astNodeId" : 17
                     },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c1"
+                    "qualifiedName" : {
+                      "qualifier" : [
+                      ],
+                      "base" : "c1"
                     },
-                    "component": {
-                      "astNodeId": 13
+                    "component" : {
+                      "astNodeId" : 13
                     },
-                    "baseId": 256,
-                    "maxId": 255,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
+                    "baseId" : 256,
+                    "maxId" : 255,
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecifierMap" : {
+                      
+                    }
                   },
-                  "portInstance": {
-                    "General": {
-                      "aNode": {
-                        "astNodeId": 12
+                  "portInstance" : {
+                    "General" : {
+                      "aNode" : {
+                        "astNodeId" : 12
                       },
-                      "specifier": {
-                        "kind": {
-                          "Output": {}
-                        },
-                        "name": "pOut",
-                        "size": "None",
-                        "port": {
-                          "Some": {
-                            "astNodeId": 11
+                      "specifier" : {
+                        "kind" : {
+                          "Output" : {
+                            
                           }
                         },
-                        "priority": "None",
-                        "queueFull": "None"
+                        "name" : "pOut",
+                        "size" : "None",
+                        "port" : {
+                          "Some" : {
+                            "astNodeId" : 11
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None"
                       },
-                      "kind": "Output",
-                      "size": 1,
-                      "ty": {
-                        "DefPort": {
-                          "symbol": {
-                            "Port": {
-                              "nodeId": 0,
-                              "unqualifiedName": "P"
+                      "kind" : "Output",
+                      "size" : 1,
+                      "ty" : {
+                        "DefPort" : {
+                          "symbol" : {
+                            "Port" : {
+                              "nodeId" : 0,
+                              "unqualifiedName" : "P"
                             }
                           }
                         }
                       },
-                      "importNodeIds": []
+                      "importNodeIds" : [
+                      ]
                     }
                   }
                 },
-                "portNumber": "None"
+                "portNumber" : "None"
               },
-              "to": {
-                "loc": {
-                  "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-                  "pos": "21.16",
-                  "includingLoc": "None"
+              "to" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+                  "pos" : "21.16",
+                  "includingLoc" : "None"
                 },
-                "port": {
-                  "componentInstance": {
-                    "aNode": {
-                      "astNodeId": 21
+                "port" : {
+                  "componentInstance" : {
+                    "aNode" : {
+                      "astNodeId" : 21
                     },
-                    "qualifiedName": {
-                      "qualifier": [],
-                      "base": "c2"
+                    "qualifiedName" : {
+                      "qualifier" : [
+                      ],
+                      "base" : "c2"
                     },
-                    "component": {
-                      "astNodeId": 13
+                    "component" : {
+                      "astNodeId" : 13
                     },
-                    "baseId": 512,
-                    "maxId": 511,
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecifierMap": {}
+                    "baseId" : 512,
+                    "maxId" : 511,
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecifierMap" : {
+                      
+                    }
                   },
-                  "portInstance": {
-                    "General": {
-                      "aNode": {
-                        "astNodeId": 3
+                  "portInstance" : {
+                    "General" : {
+                      "aNode" : {
+                        "astNodeId" : 3
                       },
-                      "specifier": {
-                        "kind": {
-                          "SyncInput": {}
-                        },
-                        "name": "pIn",
-                        "size": "None",
-                        "port": {
-                          "Some": {
-                            "astNodeId": 2
+                      "specifier" : {
+                        "kind" : {
+                          "SyncInput" : {
+                            
                           }
                         },
-                        "priority": "None",
-                        "queueFull": "None"
+                        "name" : "pIn",
+                        "size" : "None",
+                        "port" : {
+                          "Some" : {
+                            "astNodeId" : 2
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None"
                       },
-                      "kind": "SyncInput",
-                      "size": 1,
-                      "ty": {
-                        "DefPort": {
-                          "symbol": {
-                            "Port": {
-                              "nodeId": 0,
-                              "unqualifiedName": "P"
+                      "kind" : "SyncInput",
+                      "size" : 1,
+                      "ty" : {
+                        "DefPort" : {
+                          "symbol" : {
+                            "Port" : {
+                              "nodeId" : 0,
+                              "unqualifiedName" : "P"
                             }
                           }
                         }
                       },
-                      "importNodeIds": []
+                      "importNodeIds" : [
+                      ]
                     }
                   }
                 },
-                "portNumber": "None"
+                "portNumber" : "None"
               },
-              "isUnmatched": false
+              "isUnmatched" : false
             },
             0
           ]
         ],
-        "unconnectedPortSet": []
+        "unconnectedPortSet" : [
+        ]
       }
     },
-    "typeMap": {
-      "16": {
-        "Int": {
-          "Integer": {}
+    "typeMap" : {
+      "16" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "20": {
-        "Int": {
-          "Integer": {}
-        }
-      }
-    },
-    "useDefMap": {
-      "34": {
-        "ComponentInstance": {
-          "nodeId": 21,
-          "unqualifiedName": "c2"
-        }
-      },
-      "26": {
-        "ComponentInstance": {
-          "nodeId": 21,
-          "unqualifiedName": "c2"
-        }
-      },
-      "61": {
-        "ComponentInstance": {
-          "nodeId": 17,
-          "unqualifiedName": "c1"
-        }
-      },
-      "57": {
-        "ComponentInstance": {
-          "nodeId": 21,
-          "unqualifiedName": "c2"
-        }
-      },
-      "2": {
-        "Port": {
-          "nodeId": 0,
-          "unqualifiedName": "P"
-        }
-      },
-      "30": {
-        "ComponentInstance": {
-          "nodeId": 17,
-          "unqualifiedName": "c1"
-        }
-      },
-      "19": {
-        "Component": {
-          "nodeId": 13,
-          "unqualifiedName": "C"
-        }
-      },
-      "23": {
-        "ComponentInstance": {
-          "nodeId": 17,
-          "unqualifiedName": "c1"
-        }
-      },
-      "15": {
-        "Component": {
-          "nodeId": 13,
-          "unqualifiedName": "C"
-        }
-      },
-      "11": {
-        "Port": {
-          "nodeId": 0,
-          "unqualifiedName": "P"
+      "20" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       }
     },
-    "valueMap": {
-      "16": {
-        "Integer": {
-          "value": 256
+    "useDefMap" : {
+      "34" : {
+        "ComponentInstance" : {
+          "nodeId" : 21,
+          "unqualifiedName" : "c2"
         }
       },
-      "20": {
-        "Integer": {
-          "value": 512
+      "26" : {
+        "ComponentInstance" : {
+          "nodeId" : 21,
+          "unqualifiedName" : "c2"
+        }
+      },
+      "61" : {
+        "ComponentInstance" : {
+          "nodeId" : 17,
+          "unqualifiedName" : "c1"
+        }
+      },
+      "57" : {
+        "ComponentInstance" : {
+          "nodeId" : 21,
+          "unqualifiedName" : "c2"
+        }
+      },
+      "2" : {
+        "Port" : {
+          "nodeId" : 0,
+          "unqualifiedName" : "P"
+        }
+      },
+      "30" : {
+        "ComponentInstance" : {
+          "nodeId" : 17,
+          "unqualifiedName" : "c1"
+        }
+      },
+      "19" : {
+        "Component" : {
+          "nodeId" : 13,
+          "unqualifiedName" : "C"
+        }
+      },
+      "23" : {
+        "ComponentInstance" : {
+          "nodeId" : 17,
+          "unqualifiedName" : "c1"
+        }
+      },
+      "15" : {
+        "Component" : {
+          "nodeId" : 13,
+          "unqualifiedName" : "C"
+        }
+      },
+      "11" : {
+        "Port" : {
+          "nodeId" : 0,
+          "unqualifiedName" : "P"
         }
       }
     },
-    "stateMachineMap": {},
-    "dictionarySymbolSet": [],
-    "interfaceMap": {}
+    "valueMap" : {
+      "16" : {
+        "Integer" : {
+          "value" : 256
+        }
+      },
+      "20" : {
+        "Integer" : {
+          "value" : 512
+        }
+      }
+    },
+    "stateMachineMap" : {
+      
+    },
+    "dictionarySymbolSet" : [
+    ],
+    "interfaceMap" : {
+      
+    }
   }
 }

--- a/tests/topology/topology_analysis.json
+++ b/tests/topology/topology_analysis.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion": "[ fpp version ]",
+  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
   "analysis": {
     "componentInstanceMap": {
       "17": {
@@ -2156,6 +2156,7 @@
       }
     },
     "stateMachineMap": {},
+    "dictionarySymbolSet": [],
     "interfaceMap": {}
   }
 }

--- a/tests/topology/topology_ast.json
+++ b/tests/topology/topology_ast.json
@@ -1,424 +1,460 @@
 {
-  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
-  "ast": [
+  "fppVersion" : "v3.1.0a10-54-g11243e778",
+  "ast" : [
     {
-      "members": [
+      "members" : [
         [
-          [],
+          [
+          ],
           {
-            "DefPort": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "P",
-                    "params": [],
-                    "returnType": "None"
+            "DefPort" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "P",
+                    "params" : [
+                    ],
+                    "returnType" : "None"
                   },
-                  "id": 0
+                  "id" : 0
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          [],
+          [
+          ],
           {
-            "DefComponent": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "kind": {
-                      "Passive": {}
+            "DefComponent" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "kind" : {
+                      "Passive" : {
+                        
+                      }
                     },
-                    "name": "C",
-                    "members": [
+                    "name" : "C",
+                    "members" : [
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "SpecPortInstance": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "General": {
-                                    "kind": {
-                                      "SyncInput": {}
+                          "SpecPortInstance" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "General" : {
+                                    "kind" : {
+                                      "SyncInput" : {
+                                        
+                                      }
                                     },
-                                    "name": "pIn",
-                                    "size": "None",
-                                    "port": {
-                                      "Some": {
-                                        "AstNode": {
-                                          "data": {
-                                            "Unqualified": {
-                                              "name": "P"
+                                    "name" : "pIn",
+                                    "size" : "None",
+                                    "port" : {
+                                      "Some" : {
+                                        "AstNode" : {
+                                          "data" : {
+                                            "Unqualified" : {
+                                              "name" : "P"
                                             }
                                           },
-                                          "id": 2
+                                          "id" : 2
                                         }
                                       }
                                     },
-                                    "priority": "None",
-                                    "queueFull": "None"
+                                    "priority" : "None",
+                                    "queueFull" : "None"
                                   }
                                 },
-                                "id": 3
+                                "id" : 3
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "SpecPortInstance": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "General": {
-                                    "kind": {
-                                      "Output": {}
+                          "SpecPortInstance" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "General" : {
+                                    "kind" : {
+                                      "Output" : {
+                                        
+                                      }
                                     },
-                                    "name": "pOut",
-                                    "size": "None",
-                                    "port": {
-                                      "Some": {
-                                        "AstNode": {
-                                          "data": {
-                                            "Unqualified": {
-                                              "name": "P"
+                                    "name" : "pOut",
+                                    "size" : "None",
+                                    "port" : {
+                                      "Some" : {
+                                        "AstNode" : {
+                                          "data" : {
+                                            "Unqualified" : {
+                                              "name" : "P"
                                             }
                                           },
-                                          "id": 11
+                                          "id" : 11
                                         }
                                       }
                                     },
-                                    "priority": "None",
-                                    "queueFull": "None"
+                                    "priority" : "None",
+                                    "queueFull" : "None"
                                   }
                                 },
-                                "id": 12
+                                "id" : 12
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ]
                     ]
                   },
-                  "id": 13
+                  "id" : 13
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          [],
+          [
+          ],
           {
-            "DefComponentInstance": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "c1",
-                    "component": {
-                      "AstNode": {
-                        "data": {
-                          "Unqualified": {
-                            "name": "C"
+            "DefComponentInstance" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "c1",
+                    "component" : {
+                      "AstNode" : {
+                        "data" : {
+                          "Unqualified" : {
+                            "name" : "C"
                           }
                         },
-                        "id": 15
+                        "id" : 15
                       }
                     },
-                    "baseId": {
-                      "AstNode": {
-                        "data": {
-                          "ExprLiteralInt": {
-                            "value": "0x100"
+                    "baseId" : {
+                      "AstNode" : {
+                        "data" : {
+                          "ExprLiteralInt" : {
+                            "value" : "0x100"
                           }
                         },
-                        "id": 16
+                        "id" : 16
                       }
                     },
-                    "implType": "None",
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecs": []
+                    "implType" : "None",
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecs" : [
+                    ]
                   },
-                  "id": 17
+                  "id" : 17
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          [],
+          [
+          ],
           {
-            "DefComponentInstance": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "c2",
-                    "component": {
-                      "AstNode": {
-                        "data": {
-                          "Unqualified": {
-                            "name": "C"
+            "DefComponentInstance" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "c2",
+                    "component" : {
+                      "AstNode" : {
+                        "data" : {
+                          "Unqualified" : {
+                            "name" : "C"
                           }
                         },
-                        "id": 19
+                        "id" : 19
                       }
                     },
-                    "baseId": {
-                      "AstNode": {
-                        "data": {
-                          "ExprLiteralInt": {
-                            "value": "0x200"
+                    "baseId" : {
+                      "AstNode" : {
+                        "data" : {
+                          "ExprLiteralInt" : {
+                            "value" : "0x200"
                           }
                         },
-                        "id": 20
+                        "id" : 20
                       }
                     },
-                    "implType": "None",
-                    "file": "None",
-                    "queueSize": "None",
-                    "stackSize": "None",
-                    "priority": "None",
-                    "cpu": "None",
-                    "initSpecs": []
+                    "implType" : "None",
+                    "file" : "None",
+                    "queueSize" : "None",
+                    "stackSize" : "None",
+                    "priority" : "None",
+                    "cpu" : "None",
+                    "initSpecs" : [
+                    ]
                   },
-                  "id": 21
+                  "id" : 21
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          ["A simple topology"],
+          [
+            "A simple topology"
+          ],
           {
-            "DefTopology": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "Simple",
-                    "members": [
+            "DefTopology" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "Simple",
+                    "members" : [
                       [
                         [
                           "This specifier says that instance c1 is part of the topology"
                         ],
                         {
-                          "SpecCompInstance": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "visibility": {
-                                    "Public": {}
+                          "SpecCompInstance" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "visibility" : {
+                                    "Public" : {
+                                      
+                                    }
                                   },
-                                  "instance": {
-                                    "AstNode": {
-                                      "data": {
-                                        "Unqualified": {
-                                          "name": "c1"
+                                  "instance" : {
+                                    "AstNode" : {
+                                      "data" : {
+                                        "Unqualified" : {
+                                          "name" : "c1"
                                         }
                                       },
-                                      "id": 23
+                                      "id" : 23
                                     }
                                   }
                                 },
-                                "id": 24
+                                "id" : 24
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
                         [
                           "This specifier says that instance c2 is part of the topology"
                         ],
                         {
-                          "SpecCompInstance": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "visibility": {
-                                    "Public": {}
+                          "SpecCompInstance" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "visibility" : {
+                                    "Public" : {
+                                      
+                                    }
                                   },
-                                  "instance": {
-                                    "AstNode": {
-                                      "data": {
-                                        "Unqualified": {
-                                          "name": "c2"
+                                  "instance" : {
+                                    "AstNode" : {
+                                      "data" : {
+                                        "Unqualified" : {
+                                          "name" : "c2"
                                         }
                                       },
-                                      "id": 26
+                                      "id" : 26
                                     }
                                   }
                                 },
-                                "id": 27
+                                "id" : 27
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        ["This code specifies a connection graph C1"],
+                        [
+                          "This code specifies a connection graph C1"
+                        ],
                         {
-                          "SpecConnectionGraph": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "Direct": {
-                                    "name": "C1",
-                                    "connections": [
+                          "SpecConnectionGraph" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "Direct" : {
+                                    "name" : "C1",
+                                    "connections" : [
                                       {
-                                        "isUnmatched": false,
-                                        "fromPort": {
-                                          "AstNode": {
-                                            "data": {
-                                              "componentInstance": {
-                                                "AstNode": {
-                                                  "data": {
-                                                    "Unqualified": {
-                                                      "name": "c1"
+                                        "isUnmatched" : false,
+                                        "fromPort" : {
+                                          "AstNode" : {
+                                            "data" : {
+                                              "componentInstance" : {
+                                                "AstNode" : {
+                                                  "data" : {
+                                                    "Unqualified" : {
+                                                      "name" : "c1"
                                                     }
                                                   },
-                                                  "id": 30
+                                                  "id" : 30
                                                 }
                                               },
-                                              "portName": {
-                                                "AstNode": {
-                                                  "data": "pOut",
-                                                  "id": 29
+                                              "portName" : {
+                                                "AstNode" : {
+                                                  "data" : "pOut",
+                                                  "id" : 29
                                                 }
                                               }
                                             },
-                                            "id": 31
+                                            "id" : 31
                                           }
                                         },
-                                        "fromIndex": "None",
-                                        "toPort": {
-                                          "AstNode": {
-                                            "data": {
-                                              "componentInstance": {
-                                                "AstNode": {
-                                                  "data": {
-                                                    "Unqualified": {
-                                                      "name": "c2"
+                                        "fromIndex" : "None",
+                                        "toPort" : {
+                                          "AstNode" : {
+                                            "data" : {
+                                              "componentInstance" : {
+                                                "AstNode" : {
+                                                  "data" : {
+                                                    "Unqualified" : {
+                                                      "name" : "c2"
                                                     }
                                                   },
-                                                  "id": 34
+                                                  "id" : 34
                                                 }
                                               },
-                                              "portName": {
-                                                "AstNode": {
-                                                  "data": "pIn",
-                                                  "id": 33
+                                              "portName" : {
+                                                "AstNode" : {
+                                                  "data" : "pIn",
+                                                  "id" : 33
                                                 }
                                               }
                                             },
-                                            "id": 35
+                                            "id" : 35
                                           }
                                         },
-                                        "toIndex": "None"
+                                        "toIndex" : "None"
                                       }
                                     ]
                                   }
                                 },
-                                "id": 36
+                                "id" : 36
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        ["This code specifies a connection graph C2"],
+                        [
+                          "This code specifies a connection graph C2"
+                        ],
                         {
-                          "SpecConnectionGraph": {
-                            "node": {
-                              "AstNode": {
-                                "data": {
-                                  "Direct": {
-                                    "name": "C2",
-                                    "connections": [
+                          "SpecConnectionGraph" : {
+                            "node" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "Direct" : {
+                                    "name" : "C2",
+                                    "connections" : [
                                       {
-                                        "isUnmatched": false,
-                                        "fromPort": {
-                                          "AstNode": {
-                                            "data": {
-                                              "componentInstance": {
-                                                "AstNode": {
-                                                  "data": {
-                                                    "Unqualified": {
-                                                      "name": "c2"
+                                        "isUnmatched" : false,
+                                        "fromPort" : {
+                                          "AstNode" : {
+                                            "data" : {
+                                              "componentInstance" : {
+                                                "AstNode" : {
+                                                  "data" : {
+                                                    "Unqualified" : {
+                                                      "name" : "c2"
                                                     }
                                                   },
-                                                  "id": 57
+                                                  "id" : 57
                                                 }
                                               },
-                                              "portName": {
-                                                "AstNode": {
-                                                  "data": "pOut",
-                                                  "id": 56
+                                              "portName" : {
+                                                "AstNode" : {
+                                                  "data" : "pOut",
+                                                  "id" : 56
                                                 }
                                               }
                                             },
-                                            "id": 58
+                                            "id" : 58
                                           }
                                         },
-                                        "fromIndex": "None",
-                                        "toPort": {
-                                          "AstNode": {
-                                            "data": {
-                                              "componentInstance": {
-                                                "AstNode": {
-                                                  "data": {
-                                                    "Unqualified": {
-                                                      "name": "c1"
+                                        "fromIndex" : "None",
+                                        "toPort" : {
+                                          "AstNode" : {
+                                            "data" : {
+                                              "componentInstance" : {
+                                                "AstNode" : {
+                                                  "data" : {
+                                                    "Unqualified" : {
+                                                      "name" : "c1"
                                                     }
                                                   },
-                                                  "id": 61
+                                                  "id" : 61
                                                 }
                                               },
-                                              "portName": {
-                                                "AstNode": {
-                                                  "data": "pIn",
-                                                  "id": 60
+                                              "portName" : {
+                                                "AstNode" : {
+                                                  "data" : "pIn",
+                                                  "id" : 60
                                                 }
                                               }
                                             },
-                                            "id": 62
+                                            "id" : 62
                                           }
                                         },
-                                        "toIndex": "None"
+                                        "toIndex" : "None"
                                       }
                                     ]
                                   }
                                 },
-                                "id": 63
+                                "id" : 63
                               }
                             }
                           }
                         },
-                        []
+                        [
+                        ]
                       ]
                     ]
                   },
-                  "id": 64
+                  "id" : 64
                 }
               }
             }
           },
-          []
+          [
+          ]
         ]
       ]
     }

--- a/tests/topology/topology_ast.json
+++ b/tests/topology/topology_ast.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion": "[ fpp version ]",
+  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
   "ast": [
     {
       "members": [

--- a/tests/topology/topology_locations.json
+++ b/tests/topology/topology_locations.json
@@ -1,330 +1,330 @@
 {
-  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
-  "locationMap": {
-    "0": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-      "pos": "1.1",
-      "includingLoc": "None"
-    },
-    "1": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-      "pos": "4.24",
-      "includingLoc": "None"
-    },
-    "2": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-      "pos": "4.24",
-      "includingLoc": "None"
-    },
-    "3": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-      "pos": "4.3",
-      "includingLoc": "None"
-    },
-    "4": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-      "pos": "5.21",
-      "includingLoc": "None"
-    },
-    "5": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-      "pos": "5.21",
-      "includingLoc": "None"
-    },
-    "6": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-      "pos": "5.3",
-      "includingLoc": "None"
-    },
-    "7": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-      "pos": "5.21",
-      "includingLoc": "None"
-    },
-    "8": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-      "pos": "5.21",
-      "includingLoc": "None"
-    },
-    "9": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-      "pos": "5.3",
-      "includingLoc": "None"
-    },
-    "10": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-      "pos": "5.21",
-      "includingLoc": "None"
-    },
-    "11": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-      "pos": "5.21",
-      "includingLoc": "None"
-    },
-    "12": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-      "pos": "5.3",
-      "includingLoc": "None"
-    },
-    "13": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-      "pos": "3.1",
-      "includingLoc": "None"
-    },
-    "14": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-      "pos": "8.14",
-      "includingLoc": "None"
-    },
-    "15": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-      "pos": "8.14",
-      "includingLoc": "None"
-    },
-    "16": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-      "pos": "8.24",
-      "includingLoc": "None"
-    },
-    "17": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-      "pos": "8.1",
-      "includingLoc": "None"
-    },
-    "18": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-      "pos": "9.14",
-      "includingLoc": "None"
-    },
-    "19": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-      "pos": "9.14",
-      "includingLoc": "None"
-    },
-    "20": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-      "pos": "9.24",
-      "includingLoc": "None"
-    },
-    "21": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-      "pos": "9.1",
-      "includingLoc": "None"
-    },
-    "22": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-      "pos": "15.12",
-      "includingLoc": "None"
-    },
-    "23": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-      "pos": "15.12",
-      "includingLoc": "None"
-    },
-    "24": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-      "pos": "15.3",
-      "includingLoc": "None"
-    },
-    "25": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-      "pos": "17.12",
-      "includingLoc": "None"
-    },
-    "26": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-      "pos": "17.12",
-      "includingLoc": "None"
-    },
-    "27": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-      "pos": "17.3",
-      "includingLoc": "None"
-    },
-    "28": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-      "pos": "21.5",
-      "includingLoc": "None"
-    },
-    "29": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-      "pos": "21.8",
-      "includingLoc": "None"
-    },
-    "30": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-      "pos": "21.5",
-      "includingLoc": "None"
-    },
-    "31": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-      "pos": "21.5",
-      "includingLoc": "None"
-    },
-    "32": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-      "pos": "21.16",
-      "includingLoc": "None"
-    },
-    "33": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-      "pos": "21.19",
-      "includingLoc": "None"
-    },
-    "34": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-      "pos": "21.16",
-      "includingLoc": "None"
-    },
-    "35": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-      "pos": "21.16",
-      "includingLoc": "None"
-    },
-    "36": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-      "pos": "20.3",
-      "includingLoc": "None"
-    },
-    "37": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-      "pos": "26.5",
-      "includingLoc": "None"
-    },
-    "38": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-      "pos": "26.8",
-      "includingLoc": "None"
-    },
-    "39": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-      "pos": "26.5",
-      "includingLoc": "None"
-    },
-    "40": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-      "pos": "26.5",
-      "includingLoc": "None"
-    },
-    "41": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-      "pos": "26.16",
-      "includingLoc": "None"
-    },
-    "42": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-      "pos": "26.19",
-      "includingLoc": "None"
-    },
-    "43": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-      "pos": "26.16",
-      "includingLoc": "None"
-    },
-    "44": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-      "pos": "26.16",
-      "includingLoc": "None"
-    },
-    "45": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-      "pos": "25.3",
-      "includingLoc": "None"
-    },
-    "46": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-      "pos": "26.5",
-      "includingLoc": "None"
-    },
-    "47": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-      "pos": "26.8",
-      "includingLoc": "None"
-    },
-    "48": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-      "pos": "26.5",
-      "includingLoc": "None"
-    },
-    "49": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-      "pos": "26.5",
-      "includingLoc": "None"
-    },
-    "50": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-      "pos": "26.16",
-      "includingLoc": "None"
-    },
-    "51": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-      "pos": "26.19",
-      "includingLoc": "None"
-    },
-    "52": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-      "pos": "26.16",
-      "includingLoc": "None"
-    },
-    "53": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-      "pos": "26.16",
-      "includingLoc": "None"
-    },
-    "54": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-      "pos": "25.3",
-      "includingLoc": "None"
-    },
-    "55": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-      "pos": "26.5",
-      "includingLoc": "None"
-    },
-    "56": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-      "pos": "26.8",
-      "includingLoc": "None"
-    },
-    "57": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-      "pos": "26.5",
-      "includingLoc": "None"
-    },
-    "58": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-      "pos": "26.5",
-      "includingLoc": "None"
-    },
-    "59": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-      "pos": "26.16",
-      "includingLoc": "None"
-    },
-    "60": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-      "pos": "26.19",
-      "includingLoc": "None"
-    },
-    "61": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-      "pos": "26.16",
-      "includingLoc": "None"
-    },
-    "62": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-      "pos": "26.16",
-      "includingLoc": "None"
-    },
-    "63": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-      "pos": "25.3",
-      "includingLoc": "None"
-    },
-    "64": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-      "pos": "12.1",
-      "includingLoc": "None"
+  "fppVersion" : "v3.1.0a10-54-g11243e778",
+  "locationMap" : {
+    "0" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+      "pos" : "1.1",
+      "includingLoc" : "None"
+    },
+    "1" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+      "pos" : "4.24",
+      "includingLoc" : "None"
+    },
+    "2" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+      "pos" : "4.24",
+      "includingLoc" : "None"
+    },
+    "3" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+      "pos" : "4.3",
+      "includingLoc" : "None"
+    },
+    "4" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+      "pos" : "5.21",
+      "includingLoc" : "None"
+    },
+    "5" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+      "pos" : "5.21",
+      "includingLoc" : "None"
+    },
+    "6" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+      "pos" : "5.3",
+      "includingLoc" : "None"
+    },
+    "7" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+      "pos" : "5.21",
+      "includingLoc" : "None"
+    },
+    "8" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+      "pos" : "5.21",
+      "includingLoc" : "None"
+    },
+    "9" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+      "pos" : "5.3",
+      "includingLoc" : "None"
+    },
+    "10" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+      "pos" : "5.21",
+      "includingLoc" : "None"
+    },
+    "11" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+      "pos" : "5.21",
+      "includingLoc" : "None"
+    },
+    "12" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+      "pos" : "5.3",
+      "includingLoc" : "None"
+    },
+    "13" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+      "pos" : "3.1",
+      "includingLoc" : "None"
+    },
+    "14" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+      "pos" : "8.14",
+      "includingLoc" : "None"
+    },
+    "15" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+      "pos" : "8.14",
+      "includingLoc" : "None"
+    },
+    "16" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+      "pos" : "8.24",
+      "includingLoc" : "None"
+    },
+    "17" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+      "pos" : "8.1",
+      "includingLoc" : "None"
+    },
+    "18" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+      "pos" : "9.14",
+      "includingLoc" : "None"
+    },
+    "19" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+      "pos" : "9.14",
+      "includingLoc" : "None"
+    },
+    "20" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+      "pos" : "9.24",
+      "includingLoc" : "None"
+    },
+    "21" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+      "pos" : "9.1",
+      "includingLoc" : "None"
+    },
+    "22" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+      "pos" : "15.12",
+      "includingLoc" : "None"
+    },
+    "23" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+      "pos" : "15.12",
+      "includingLoc" : "None"
+    },
+    "24" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+      "pos" : "15.3",
+      "includingLoc" : "None"
+    },
+    "25" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+      "pos" : "17.12",
+      "includingLoc" : "None"
+    },
+    "26" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+      "pos" : "17.12",
+      "includingLoc" : "None"
+    },
+    "27" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+      "pos" : "17.3",
+      "includingLoc" : "None"
+    },
+    "28" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+      "pos" : "21.5",
+      "includingLoc" : "None"
+    },
+    "29" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+      "pos" : "21.8",
+      "includingLoc" : "None"
+    },
+    "30" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+      "pos" : "21.5",
+      "includingLoc" : "None"
+    },
+    "31" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+      "pos" : "21.5",
+      "includingLoc" : "None"
+    },
+    "32" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+      "pos" : "21.16",
+      "includingLoc" : "None"
+    },
+    "33" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+      "pos" : "21.19",
+      "includingLoc" : "None"
+    },
+    "34" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+      "pos" : "21.16",
+      "includingLoc" : "None"
+    },
+    "35" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+      "pos" : "21.16",
+      "includingLoc" : "None"
+    },
+    "36" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+      "pos" : "20.3",
+      "includingLoc" : "None"
+    },
+    "37" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+      "pos" : "26.5",
+      "includingLoc" : "None"
+    },
+    "38" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+      "pos" : "26.8",
+      "includingLoc" : "None"
+    },
+    "39" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+      "pos" : "26.5",
+      "includingLoc" : "None"
+    },
+    "40" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+      "pos" : "26.5",
+      "includingLoc" : "None"
+    },
+    "41" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+      "pos" : "26.16",
+      "includingLoc" : "None"
+    },
+    "42" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+      "pos" : "26.19",
+      "includingLoc" : "None"
+    },
+    "43" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+      "pos" : "26.16",
+      "includingLoc" : "None"
+    },
+    "44" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+      "pos" : "26.16",
+      "includingLoc" : "None"
+    },
+    "45" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+      "pos" : "25.3",
+      "includingLoc" : "None"
+    },
+    "46" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+      "pos" : "26.5",
+      "includingLoc" : "None"
+    },
+    "47" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+      "pos" : "26.8",
+      "includingLoc" : "None"
+    },
+    "48" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+      "pos" : "26.5",
+      "includingLoc" : "None"
+    },
+    "49" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+      "pos" : "26.5",
+      "includingLoc" : "None"
+    },
+    "50" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+      "pos" : "26.16",
+      "includingLoc" : "None"
+    },
+    "51" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+      "pos" : "26.19",
+      "includingLoc" : "None"
+    },
+    "52" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+      "pos" : "26.16",
+      "includingLoc" : "None"
+    },
+    "53" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+      "pos" : "26.16",
+      "includingLoc" : "None"
+    },
+    "54" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+      "pos" : "25.3",
+      "includingLoc" : "None"
+    },
+    "55" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+      "pos" : "26.5",
+      "includingLoc" : "None"
+    },
+    "56" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+      "pos" : "26.8",
+      "includingLoc" : "None"
+    },
+    "57" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+      "pos" : "26.5",
+      "includingLoc" : "None"
+    },
+    "58" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+      "pos" : "26.5",
+      "includingLoc" : "None"
+    },
+    "59" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+      "pos" : "26.16",
+      "includingLoc" : "None"
+    },
+    "60" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+      "pos" : "26.19",
+      "includingLoc" : "None"
+    },
+    "61" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+      "pos" : "26.16",
+      "includingLoc" : "None"
+    },
+    "62" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+      "pos" : "26.16",
+      "includingLoc" : "None"
+    },
+    "63" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+      "pos" : "25.3",
+      "includingLoc" : "None"
+    },
+    "64" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+      "pos" : "12.1",
+      "includingLoc" : "None"
     }
   }
 }

--- a/tests/topology/topology_locations.json
+++ b/tests/topology/topology_locations.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion": "[ fpp version ]",
+  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
   "locationMap": {
     "0": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",

--- a/tests/types/types.fpp
+++ b/tests/types/types.fpp
@@ -1,4 +1,4 @@
-constant numElements = 3
+dictionary constant numElements = 3
 
 array A = [numElements] string size 40 default [
                                                  "1"
@@ -35,7 +35,7 @@ type T
 
 array arr = [3] T
 
-struct SignalInfo {
+dictionary struct SignalInfo {
   $type: SignalType
   history: SignalSet
   pairHistory: SignalPairSet
@@ -48,15 +48,15 @@ struct SignalPair {
 
 array SignalPairSet = [4] SignalPair
 
-array SignalSet = [4] F32 format "{f}"
+dictionary array SignalSet = [4] F32 format "{f}"
 
-enum SignalType {
+dictionary enum SignalType {
   TRIANGLE
   SQUARE
   SINE
   NOISE
 }
 
-type Alias1 = U32
+dictionary type Alias1 = U32
 
 type Alias2 = U32

--- a/tests/types/types_analysis.json
+++ b/tests/types/types_analysis.json
@@ -1,66 +1,72 @@
 {
-  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
-  "analysis": {
-    "componentInstanceMap": {},
-    "componentMap": {},
-    "includedFileSet": [],
-    "inputFileSet": [
+  "fppVersion" : "v3.1.0a10-54-g11243e778",
+  "analysis" : {
+    "componentInstanceMap" : {
+      
+    },
+    "componentMap" : {
+      
+    },
+    "includedFileSet" : [
+    ],
+    "inputFileSet" : [
       "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp"
     ],
-    "locationSpecifierMap": [],
-    "parentSymbolMap": {
-      "109": {
-        "Enum": {
-          "nodeId": 115,
-          "unqualifiedName": "SignalType"
+    "locationSpecifierMap" : [
+    ],
+    "parentSymbolMap" : {
+      "109" : {
+        "Enum" : {
+          "nodeId" : 115,
+          "unqualifiedName" : "SignalType"
         }
       },
-      "110": {
-        "Enum": {
-          "nodeId": 115,
-          "unqualifiedName": "SignalType"
+      "110" : {
+        "Enum" : {
+          "nodeId" : 115,
+          "unqualifiedName" : "SignalType"
         }
       },
-      "111": {
-        "Enum": {
-          "nodeId": 115,
-          "unqualifiedName": "SignalType"
+      "111" : {
+        "Enum" : {
+          "nodeId" : 115,
+          "unqualifiedName" : "SignalType"
         }
       },
-      "114": {
-        "Enum": {
-          "nodeId": 115,
-          "unqualifiedName": "SignalType"
+      "114" : {
+        "Enum" : {
+          "nodeId" : 115,
+          "unqualifiedName" : "SignalType"
         }
       }
     },
-    "symbolScopeMap": {
-      "115": {
-        "map": {
-          "Value": {
-            "map": {
-              "TRIANGLE": {
-                "EnumConstant": {
-                  "nodeId": 109,
-                  "unqualifiedName": "TRIANGLE"
+    "symbolScopeMap" : {
+      "115" : {
+        "map" : {
+          "Value" : {
+            "map" : {
+              "TRIANGLE" : {
+                "EnumConstant" : {
+                  "nodeId" : 109,
+                  "unqualifiedName" : "TRIANGLE"
                 }
               },
-              "SQUARE": {
-                "EnumConstant": {
-                  "nodeId": 110,
-                  "unqualifiedName": "SQUARE"
+              "SQUARE" : {
+                "EnumConstant" : {
+                  "nodeId" : 110,
+                  "unqualifiedName" : "SQUARE"
                 }
               },
-              "SINE": {
-                "EnumConstant": {
-                  "nodeId": 111,
-                  "unqualifiedName": "SINE"
+              "SINE" : {
+                "EnumConstant" : {
+                  "nodeId" : 111,
+                  "unqualifiedName" : "SINE"
                 }
               },
-              "NOISE": {
-                "EnumConstant": {
-                  "nodeId": 114,
-                  "unqualifiedName": "NOISE"
+              "NOISE" : {
+                "EnumConstant" : {
+                  "nodeId" : 114,
+                  "unqualifiedName" : "NOISE"
                 }
               }
             }
@@ -68,251 +74,284 @@
         }
       }
     },
-    "topologyMap": {},
-    "typeMap": {
-      "34": {
-        "Int": {
-          "Integer": {}
+    "topologyMap" : {
+      
+    },
+    "typeMap" : {
+      "34" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "100": {
-        "Int": {
-          "Integer": {}
+      "100" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "56": {
-        "String": {
-          "size": "None"
+      "56" : {
+        "String" : {
+          "size" : "None"
         }
       },
-      "106": {
-        "Primitive": {
-          "Float": {
-            "kind": {
-              "F32": {}
+      "106" : {
+        "Primitive" : {
+          "Float" : {
+            "kind" : {
+              "F32" : {
+                
+              }
             }
           }
         }
       },
-      "115": {
-        "Enum": {
-          "node": {
-            "astNodeId": 115
+      "115" : {
+        "Enum" : {
+          "node" : {
+            "astNodeId" : 115
           },
-          "repType": {
-            "kind": {
-              "I32": {}
+          "repType" : {
+            "kind" : {
+              "I32" : {
+                
+              }
             }
           },
-          "default": {
-            "Some": {
-              "value": ["TRIANGLE", 0],
-              "t": {
-                "node": {
-                  "astNodeId": 115
+          "default" : {
+            "Some" : {
+              "value" : [
+                "TRIANGLE",
+                0
+              ],
+              "t" : {
+                "node" : {
+                  "astNodeId" : 115
                 },
-                "repType": {
-                  "kind": {
-                    "I32": {}
+                "repType" : {
+                  "kind" : {
+                    "I32" : {
+                      
+                    }
                   }
                 },
-                "default": "None"
+                "default" : "None"
               }
             }
           }
         }
       },
-      "118": {
-        "Int": {
-          "PrimitiveInt": {
-            "kind": {
-              "U32": {}
+      "118" : {
+        "Int" : {
+          "PrimitiveInt" : {
+            "kind" : {
+              "U32" : {
+                
+              }
             }
           }
         }
       },
-      "119": {
-        "AliasType": {
-          "node": {
-            "astNodeId": 119
+      "119" : {
+        "AliasType" : {
+          "node" : {
+            "astNodeId" : 119
           },
-          "aliasType": {
-            "Int": {
-              "PrimitiveInt": {
-                "kind": {
-                  "U32": {}
+          "aliasType" : {
+            "Int" : {
+              "PrimitiveInt" : {
+                "kind" : {
+                  "U32" : {
+                    
+                  }
                 }
               }
             }
           }
         }
       },
-      "84": {
-        "Array": {
-          "node": {
-            "astNodeId": 104
+      "84" : {
+        "Array" : {
+          "node" : {
+            "astNodeId" : 104
           },
-          "anonArray": {
-            "size": "None",
-            "eltType": {
-              "Struct": {
-                "node": {
-                  "astNodeId": 99
+          "anonArray" : {
+            "size" : "None",
+            "eltType" : {
+              "Struct" : {
+                "node" : {
+                  "astNodeId" : 99
                 },
-                "anonStruct": {
-                  "members": {
-                    "time": {
-                      "Primitive": {
-                        "Float": {
-                          "kind": {
-                            "F32": {}
+                "anonStruct" : {
+                  "members" : {
+                    "time" : {
+                      "Primitive" : {
+                        "Float" : {
+                          "kind" : {
+                            "F32" : {
+                              
+                            }
                           }
                         }
                       }
                     },
-                    "value": {
-                      "Primitive": {
-                        "Float": {
-                          "kind": {
-                            "F32": {}
+                    "value" : {
+                      "Primitive" : {
+                        "Float" : {
+                          "kind" : {
+                            "F32" : {
+                              
+                            }
                           }
                         }
                       }
                     }
                   }
                 },
-                "default": "None",
-                "sizes": {},
-                "formats": {}
+                "default" : "None",
+                "sizes" : {
+                  
+                },
+                "formats" : {
+                  
+                }
               }
             }
           },
-          "default": "None",
-          "format": "None"
+          "default" : "None",
+          "format" : "None"
         }
       },
-      "8": {
-        "AnonArray": {
-          "size": {
-            "Some": 3
+      "8" : {
+        "AnonArray" : {
+          "size" : {
+            "Some" : 3
           },
-          "eltType": {
-            "String": {
-              "size": "None"
+          "eltType" : {
+            "String" : {
+              "size" : "None"
             }
           }
         }
       },
-      "4": {
-        "String": {
-          "size": {
-            "Some": {
-              "astNodeId": 3
+      "4" : {
+        "String" : {
+          "size" : {
+            "Some" : {
+              "astNodeId" : 3
             }
           }
         }
       },
-      "40": {
-        "Int": {
-          "PrimitiveInt": {
-            "kind": {
-              "U8": {}
+      "40" : {
+        "Int" : {
+          "PrimitiveInt" : {
+            "kind" : {
+              "U8" : {
+                
+              }
             }
           }
         }
       },
-      "110": {
-        "Enum": {
-          "node": {
-            "astNodeId": 115
+      "110" : {
+        "Enum" : {
+          "node" : {
+            "astNodeId" : 115
           },
-          "repType": {
-            "kind": {
-              "I32": {}
+          "repType" : {
+            "kind" : {
+              "I32" : {
+                
+              }
             }
           },
-          "default": "None"
+          "default" : "None"
         }
       },
-      "15": {
-        "Array": {
-          "node": {
-            "astNodeId": 15
+      "15" : {
+        "Array" : {
+          "node" : {
+            "astNodeId" : 15
           },
-          "anonArray": {
-            "size": {
-              "Some": 3
+          "anonArray" : {
+            "size" : {
+              "Some" : 3
             },
-            "eltType": {
-              "Array": {
-                "node": {
-                  "astNodeId": 10
+            "eltType" : {
+              "Array" : {
+                "node" : {
+                  "astNodeId" : 10
                 },
-                "anonArray": {
-                  "size": {
-                    "Some": 3
+                "anonArray" : {
+                  "size" : {
+                    "Some" : 3
                   },
-                  "eltType": {
-                    "String": {
-                      "size": {
-                        "Some": {
-                          "astNodeId": 3
+                  "eltType" : {
+                    "String" : {
+                      "size" : {
+                        "Some" : {
+                          "astNodeId" : 3
                         }
                       }
                     }
                   }
                 },
-                "default": {
-                  "Some": {
-                    "anonArray": {
-                      "elements": [
+                "default" : {
+                  "Some" : {
+                    "anonArray" : {
+                      "elements" : [
                         {
-                          "String": {
-                            "value": "1"
+                          "String" : {
+                            "value" : "1"
                           }
                         },
                         {
-                          "String": {
-                            "value": "2"
+                          "String" : {
+                            "value" : "2"
                           }
                         },
                         {
-                          "String": {
-                            "value": "3"
+                          "String" : {
+                            "value" : "3"
                           }
                         }
                       ]
                     },
-                    "t": {
-                      "node": {
-                        "astNodeId": 10
+                    "t" : {
+                      "node" : {
+                        "astNodeId" : 10
                       },
-                      "anonArray": {
-                        "size": {
-                          "Some": 3
+                      "anonArray" : {
+                        "size" : {
+                          "Some" : 3
                         },
-                        "eltType": {
-                          "String": {
-                            "size": {
-                              "Some": {
-                                "astNodeId": 3
+                        "eltType" : {
+                          "String" : {
+                            "size" : {
+                              "Some" : {
+                                "astNodeId" : 3
                               }
                             }
                           }
                         }
                       },
-                      "default": "None",
-                      "format": "None"
+                      "default" : "None",
+                      "format" : "None"
                     }
                   }
                 },
-                "format": {
-                  "Some": {
-                    "prefix": "",
-                    "fields": [
+                "format" : {
+                  "Some" : {
+                    "prefix" : "",
+                    "fields" : [
                       [
                         {
-                          "Default": {}
+                          "Default" : {
+                            
+                          }
                         },
                         " RPM"
                       ]
@@ -322,222 +361,224 @@
               }
             }
           },
-          "default": {
-            "Some": {
-              "anonArray": {
-                "elements": [
+          "default" : {
+            "Some" : {
+              "anonArray" : {
+                "elements" : [
                   {
-                    "Array": {
-                      "anonArray": {
-                        "elements": [
+                    "Array" : {
+                      "anonArray" : {
+                        "elements" : [
                           {
-                            "String": {
-                              "value": "1"
+                            "String" : {
+                              "value" : "1"
                             }
                           },
                           {
-                            "String": {
-                              "value": "2"
+                            "String" : {
+                              "value" : "2"
                             }
                           },
                           {
-                            "String": {
-                              "value": "3"
+                            "String" : {
+                              "value" : "3"
                             }
                           }
                         ]
                       },
-                      "t": {
-                        "node": {
-                          "astNodeId": 10
+                      "t" : {
+                        "node" : {
+                          "astNodeId" : 10
                         },
-                        "anonArray": {
-                          "size": {
-                            "Some": 3
+                        "anonArray" : {
+                          "size" : {
+                            "Some" : 3
                           },
-                          "eltType": {
-                            "String": {
-                              "size": {
-                                "Some": {
-                                  "astNodeId": 3
+                          "eltType" : {
+                            "String" : {
+                              "size" : {
+                                "Some" : {
+                                  "astNodeId" : 3
                                 }
                               }
                             }
                           }
                         },
-                        "default": "None",
-                        "format": "None"
+                        "default" : "None",
+                        "format" : "None"
                       }
                     }
                   },
                   {
-                    "Array": {
-                      "anonArray": {
-                        "elements": [
+                    "Array" : {
+                      "anonArray" : {
+                        "elements" : [
                           {
-                            "String": {
-                              "value": "1"
+                            "String" : {
+                              "value" : "1"
                             }
                           },
                           {
-                            "String": {
-                              "value": "2"
+                            "String" : {
+                              "value" : "2"
                             }
                           },
                           {
-                            "String": {
-                              "value": "3"
+                            "String" : {
+                              "value" : "3"
                             }
                           }
                         ]
                       },
-                      "t": {
-                        "node": {
-                          "astNodeId": 10
+                      "t" : {
+                        "node" : {
+                          "astNodeId" : 10
                         },
-                        "anonArray": {
-                          "size": {
-                            "Some": 3
+                        "anonArray" : {
+                          "size" : {
+                            "Some" : 3
                           },
-                          "eltType": {
-                            "String": {
-                              "size": {
-                                "Some": {
-                                  "astNodeId": 3
+                          "eltType" : {
+                            "String" : {
+                              "size" : {
+                                "Some" : {
+                                  "astNodeId" : 3
                                 }
                               }
                             }
                           }
                         },
-                        "default": "None",
-                        "format": "None"
+                        "default" : "None",
+                        "format" : "None"
                       }
                     }
                   },
                   {
-                    "Array": {
-                      "anonArray": {
-                        "elements": [
+                    "Array" : {
+                      "anonArray" : {
+                        "elements" : [
                           {
-                            "String": {
-                              "value": "1"
+                            "String" : {
+                              "value" : "1"
                             }
                           },
                           {
-                            "String": {
-                              "value": "2"
+                            "String" : {
+                              "value" : "2"
                             }
                           },
                           {
-                            "String": {
-                              "value": "3"
+                            "String" : {
+                              "value" : "3"
                             }
                           }
                         ]
                       },
-                      "t": {
-                        "node": {
-                          "astNodeId": 10
+                      "t" : {
+                        "node" : {
+                          "astNodeId" : 10
                         },
-                        "anonArray": {
-                          "size": {
-                            "Some": 3
+                        "anonArray" : {
+                          "size" : {
+                            "Some" : 3
                           },
-                          "eltType": {
-                            "String": {
-                              "size": {
-                                "Some": {
-                                  "astNodeId": 3
+                          "eltType" : {
+                            "String" : {
+                              "size" : {
+                                "Some" : {
+                                  "astNodeId" : 3
                                 }
                               }
                             }
                           }
                         },
-                        "default": "None",
-                        "format": "None"
+                        "default" : "None",
+                        "format" : "None"
                       }
                     }
                   }
                 ]
               },
-              "t": {
-                "node": {
-                  "astNodeId": 15
+              "t" : {
+                "node" : {
+                  "astNodeId" : 15
                 },
-                "anonArray": {
-                  "size": {
-                    "Some": 3
+                "anonArray" : {
+                  "size" : {
+                    "Some" : 3
                   },
-                  "eltType": {
-                    "Array": {
-                      "node": {
-                        "astNodeId": 10
+                  "eltType" : {
+                    "Array" : {
+                      "node" : {
+                        "astNodeId" : 10
                       },
-                      "anonArray": {
-                        "size": {
-                          "Some": 3
+                      "anonArray" : {
+                        "size" : {
+                          "Some" : 3
                         },
-                        "eltType": {
-                          "String": {
-                            "size": {
-                              "Some": {
-                                "astNodeId": 3
+                        "eltType" : {
+                          "String" : {
+                            "size" : {
+                              "Some" : {
+                                "astNodeId" : 3
                               }
                             }
                           }
                         }
                       },
-                      "default": {
-                        "Some": {
-                          "anonArray": {
-                            "elements": [
+                      "default" : {
+                        "Some" : {
+                          "anonArray" : {
+                            "elements" : [
                               {
-                                "String": {
-                                  "value": "1"
+                                "String" : {
+                                  "value" : "1"
                                 }
                               },
                               {
-                                "String": {
-                                  "value": "2"
+                                "String" : {
+                                  "value" : "2"
                                 }
                               },
                               {
-                                "String": {
-                                  "value": "3"
+                                "String" : {
+                                  "value" : "3"
                                 }
                               }
                             ]
                           },
-                          "t": {
-                            "node": {
-                              "astNodeId": 10
+                          "t" : {
+                            "node" : {
+                              "astNodeId" : 10
                             },
-                            "anonArray": {
-                              "size": {
-                                "Some": 3
+                            "anonArray" : {
+                              "size" : {
+                                "Some" : 3
                               },
-                              "eltType": {
-                                "String": {
-                                  "size": {
-                                    "Some": {
-                                      "astNodeId": 3
+                              "eltType" : {
+                                "String" : {
+                                  "size" : {
+                                    "Some" : {
+                                      "astNodeId" : 3
                                     }
                                   }
                                 }
                               }
                             },
-                            "default": "None",
-                            "format": "None"
+                            "default" : "None",
+                            "format" : "None"
                           }
                         }
                       },
-                      "format": {
-                        "Some": {
-                          "prefix": "",
-                          "fields": [
+                      "format" : {
+                        "Some" : {
+                          "prefix" : "",
+                          "fields" : [
                             [
                               {
-                                "Default": {}
+                                "Default" : {
+                                  
+                                }
                               },
                               " RPM"
                             ]
@@ -547,120 +588,142 @@
                     }
                   }
                 },
-                "default": "None",
-                "format": "None"
+                "default" : "None",
+                "format" : "None"
               }
             }
           },
-          "format": "None"
+          "format" : "None"
         }
       },
-      "11": {
-        "Int": {
-          "Integer": {}
+      "11" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "104": {
-        "Array": {
-          "node": {
-            "astNodeId": 104
+      "104" : {
+        "Array" : {
+          "node" : {
+            "astNodeId" : 104
           },
-          "anonArray": {
-            "size": {
-              "Some": 4
+          "anonArray" : {
+            "size" : {
+              "Some" : 4
             },
-            "eltType": {
-              "Struct": {
-                "node": {
-                  "astNodeId": 99
+            "eltType" : {
+              "Struct" : {
+                "node" : {
+                  "astNodeId" : 99
                 },
-                "anonStruct": {
-                  "members": {
-                    "time": {
-                      "Primitive": {
-                        "Float": {
-                          "kind": {
-                            "F32": {}
+                "anonStruct" : {
+                  "members" : {
+                    "time" : {
+                      "Primitive" : {
+                        "Float" : {
+                          "kind" : {
+                            "F32" : {
+                              
+                            }
                           }
                         }
                       }
                     },
-                    "value": {
-                      "Primitive": {
-                        "Float": {
-                          "kind": {
-                            "F32": {}
+                    "value" : {
+                      "Primitive" : {
+                        "Float" : {
+                          "kind" : {
+                            "F32" : {
+                              
+                            }
                           }
                         }
                       }
                     }
                   }
                 },
-                "default": {
-                  "Some": {
-                    "anonStruct": {
-                      "members": {
-                        "time": {
-                          "Float": {
-                            "value": 0.0,
-                            "kind": {
-                              "F32": {}
+                "default" : {
+                  "Some" : {
+                    "anonStruct" : {
+                      "members" : {
+                        "time" : {
+                          "Float" : {
+                            "value" : 0.0,
+                            "kind" : {
+                              "F32" : {
+                                
+                              }
                             }
                           }
                         },
-                        "value": {
-                          "Float": {
-                            "value": 0.0,
-                            "kind": {
-                              "F32": {}
+                        "value" : {
+                          "Float" : {
+                            "value" : 0.0,
+                            "kind" : {
+                              "F32" : {
+                                
+                              }
                             }
                           }
                         }
                       }
                     },
-                    "t": {
-                      "node": {
-                        "astNodeId": 99
+                    "t" : {
+                      "node" : {
+                        "astNodeId" : 99
                       },
-                      "anonStruct": {
-                        "members": {
-                          "time": {
-                            "Primitive": {
-                              "Float": {
-                                "kind": {
-                                  "F32": {}
+                      "anonStruct" : {
+                        "members" : {
+                          "time" : {
+                            "Primitive" : {
+                              "Float" : {
+                                "kind" : {
+                                  "F32" : {
+                                    
+                                  }
                                 }
                               }
                             }
                           },
-                          "value": {
-                            "Primitive": {
-                              "Float": {
-                                "kind": {
-                                  "F32": {}
+                          "value" : {
+                            "Primitive" : {
+                              "Float" : {
+                                "kind" : {
+                                  "F32" : {
+                                    
+                                  }
                                 }
                               }
                             }
                           }
                         }
                       },
-                      "default": "None",
-                      "sizes": {},
-                      "formats": {}
+                      "default" : "None",
+                      "sizes" : {
+                        
+                      },
+                      "formats" : {
+                        
+                      }
                     }
                   }
                 },
-                "sizes": {},
-                "formats": {
-                  "time": {
-                    "prefix": "",
-                    "fields": [
+                "sizes" : {
+                  
+                },
+                "formats" : {
+                  "time" : {
+                    "prefix" : "",
+                    "fields" : [
                       [
                         {
-                          "Rational": {
-                            "precision": "None",
-                            "t": {
-                              "Fixed": {}
+                          "Rational" : {
+                            "precision" : "None",
+                            "t" : {
+                              "Fixed" : {
+                                
+                              }
                             }
                           }
                         },
@@ -668,15 +731,17 @@
                       ]
                     ]
                   },
-                  "value": {
-                    "prefix": "",
-                    "fields": [
+                  "value" : {
+                    "prefix" : "",
+                    "fields" : [
                       [
                         {
-                          "Rational": {
-                            "precision": "None",
-                            "t": {
-                              "Fixed": {}
+                          "Rational" : {
+                            "precision" : "None",
+                            "t" : {
+                              "Fixed" : {
+                                
+                              }
                             }
                           }
                         },
@@ -688,328 +753,396 @@
               }
             }
           },
-          "default": {
-            "Some": {
-              "anonArray": {
-                "elements": [
+          "default" : {
+            "Some" : {
+              "anonArray" : {
+                "elements" : [
                   {
-                    "Struct": {
-                      "anonStruct": {
-                        "members": {
-                          "time": {
-                            "Float": {
-                              "value": 0.0,
-                              "kind": {
-                                "F32": {}
+                    "Struct" : {
+                      "anonStruct" : {
+                        "members" : {
+                          "time" : {
+                            "Float" : {
+                              "value" : 0.0,
+                              "kind" : {
+                                "F32" : {
+                                  
+                                }
                               }
                             }
                           },
-                          "value": {
-                            "Float": {
-                              "value": 0.0,
-                              "kind": {
-                                "F32": {}
+                          "value" : {
+                            "Float" : {
+                              "value" : 0.0,
+                              "kind" : {
+                                "F32" : {
+                                  
+                                }
                               }
                             }
                           }
                         }
                       },
-                      "t": {
-                        "node": {
-                          "astNodeId": 99
+                      "t" : {
+                        "node" : {
+                          "astNodeId" : 99
                         },
-                        "anonStruct": {
-                          "members": {
-                            "time": {
-                              "Primitive": {
-                                "Float": {
-                                  "kind": {
-                                    "F32": {}
+                        "anonStruct" : {
+                          "members" : {
+                            "time" : {
+                              "Primitive" : {
+                                "Float" : {
+                                  "kind" : {
+                                    "F32" : {
+                                      
+                                    }
                                   }
                                 }
                               }
                             },
-                            "value": {
-                              "Primitive": {
-                                "Float": {
-                                  "kind": {
-                                    "F32": {}
+                            "value" : {
+                              "Primitive" : {
+                                "Float" : {
+                                  "kind" : {
+                                    "F32" : {
+                                      
+                                    }
                                   }
                                 }
                               }
                             }
                           }
                         },
-                        "default": "None",
-                        "sizes": {},
-                        "formats": {}
+                        "default" : "None",
+                        "sizes" : {
+                          
+                        },
+                        "formats" : {
+                          
+                        }
                       }
                     }
                   },
                   {
-                    "Struct": {
-                      "anonStruct": {
-                        "members": {
-                          "time": {
-                            "Float": {
-                              "value": 0.0,
-                              "kind": {
-                                "F32": {}
+                    "Struct" : {
+                      "anonStruct" : {
+                        "members" : {
+                          "time" : {
+                            "Float" : {
+                              "value" : 0.0,
+                              "kind" : {
+                                "F32" : {
+                                  
+                                }
                               }
                             }
                           },
-                          "value": {
-                            "Float": {
-                              "value": 0.0,
-                              "kind": {
-                                "F32": {}
+                          "value" : {
+                            "Float" : {
+                              "value" : 0.0,
+                              "kind" : {
+                                "F32" : {
+                                  
+                                }
                               }
                             }
                           }
                         }
                       },
-                      "t": {
-                        "node": {
-                          "astNodeId": 99
+                      "t" : {
+                        "node" : {
+                          "astNodeId" : 99
                         },
-                        "anonStruct": {
-                          "members": {
-                            "time": {
-                              "Primitive": {
-                                "Float": {
-                                  "kind": {
-                                    "F32": {}
+                        "anonStruct" : {
+                          "members" : {
+                            "time" : {
+                              "Primitive" : {
+                                "Float" : {
+                                  "kind" : {
+                                    "F32" : {
+                                      
+                                    }
                                   }
                                 }
                               }
                             },
-                            "value": {
-                              "Primitive": {
-                                "Float": {
-                                  "kind": {
-                                    "F32": {}
+                            "value" : {
+                              "Primitive" : {
+                                "Float" : {
+                                  "kind" : {
+                                    "F32" : {
+                                      
+                                    }
                                   }
                                 }
                               }
                             }
                           }
                         },
-                        "default": "None",
-                        "sizes": {},
-                        "formats": {}
+                        "default" : "None",
+                        "sizes" : {
+                          
+                        },
+                        "formats" : {
+                          
+                        }
                       }
                     }
                   },
                   {
-                    "Struct": {
-                      "anonStruct": {
-                        "members": {
-                          "time": {
-                            "Float": {
-                              "value": 0.0,
-                              "kind": {
-                                "F32": {}
+                    "Struct" : {
+                      "anonStruct" : {
+                        "members" : {
+                          "time" : {
+                            "Float" : {
+                              "value" : 0.0,
+                              "kind" : {
+                                "F32" : {
+                                  
+                                }
                               }
                             }
                           },
-                          "value": {
-                            "Float": {
-                              "value": 0.0,
-                              "kind": {
-                                "F32": {}
+                          "value" : {
+                            "Float" : {
+                              "value" : 0.0,
+                              "kind" : {
+                                "F32" : {
+                                  
+                                }
                               }
                             }
                           }
                         }
                       },
-                      "t": {
-                        "node": {
-                          "astNodeId": 99
+                      "t" : {
+                        "node" : {
+                          "astNodeId" : 99
                         },
-                        "anonStruct": {
-                          "members": {
-                            "time": {
-                              "Primitive": {
-                                "Float": {
-                                  "kind": {
-                                    "F32": {}
+                        "anonStruct" : {
+                          "members" : {
+                            "time" : {
+                              "Primitive" : {
+                                "Float" : {
+                                  "kind" : {
+                                    "F32" : {
+                                      
+                                    }
                                   }
                                 }
                               }
                             },
-                            "value": {
-                              "Primitive": {
-                                "Float": {
-                                  "kind": {
-                                    "F32": {}
+                            "value" : {
+                              "Primitive" : {
+                                "Float" : {
+                                  "kind" : {
+                                    "F32" : {
+                                      
+                                    }
                                   }
                                 }
                               }
                             }
                           }
                         },
-                        "default": "None",
-                        "sizes": {},
-                        "formats": {}
+                        "default" : "None",
+                        "sizes" : {
+                          
+                        },
+                        "formats" : {
+                          
+                        }
                       }
                     }
                   },
                   {
-                    "Struct": {
-                      "anonStruct": {
-                        "members": {
-                          "time": {
-                            "Float": {
-                              "value": 0.0,
-                              "kind": {
-                                "F32": {}
+                    "Struct" : {
+                      "anonStruct" : {
+                        "members" : {
+                          "time" : {
+                            "Float" : {
+                              "value" : 0.0,
+                              "kind" : {
+                                "F32" : {
+                                  
+                                }
                               }
                             }
                           },
-                          "value": {
-                            "Float": {
-                              "value": 0.0,
-                              "kind": {
-                                "F32": {}
+                          "value" : {
+                            "Float" : {
+                              "value" : 0.0,
+                              "kind" : {
+                                "F32" : {
+                                  
+                                }
                               }
                             }
                           }
                         }
                       },
-                      "t": {
-                        "node": {
-                          "astNodeId": 99
+                      "t" : {
+                        "node" : {
+                          "astNodeId" : 99
                         },
-                        "anonStruct": {
-                          "members": {
-                            "time": {
-                              "Primitive": {
-                                "Float": {
-                                  "kind": {
-                                    "F32": {}
+                        "anonStruct" : {
+                          "members" : {
+                            "time" : {
+                              "Primitive" : {
+                                "Float" : {
+                                  "kind" : {
+                                    "F32" : {
+                                      
+                                    }
                                   }
                                 }
                               }
                             },
-                            "value": {
-                              "Primitive": {
-                                "Float": {
-                                  "kind": {
-                                    "F32": {}
+                            "value" : {
+                              "Primitive" : {
+                                "Float" : {
+                                  "kind" : {
+                                    "F32" : {
+                                      
+                                    }
                                   }
                                 }
                               }
                             }
                           }
                         },
-                        "default": "None",
-                        "sizes": {},
-                        "formats": {}
+                        "default" : "None",
+                        "sizes" : {
+                          
+                        },
+                        "formats" : {
+                          
+                        }
                       }
                     }
                   }
                 ]
               },
-              "t": {
-                "node": {
-                  "astNodeId": 104
+              "t" : {
+                "node" : {
+                  "astNodeId" : 104
                 },
-                "anonArray": {
-                  "size": {
-                    "Some": 4
+                "anonArray" : {
+                  "size" : {
+                    "Some" : 4
                   },
-                  "eltType": {
-                    "Struct": {
-                      "node": {
-                        "astNodeId": 99
+                  "eltType" : {
+                    "Struct" : {
+                      "node" : {
+                        "astNodeId" : 99
                       },
-                      "anonStruct": {
-                        "members": {
-                          "time": {
-                            "Primitive": {
-                              "Float": {
-                                "kind": {
-                                  "F32": {}
+                      "anonStruct" : {
+                        "members" : {
+                          "time" : {
+                            "Primitive" : {
+                              "Float" : {
+                                "kind" : {
+                                  "F32" : {
+                                    
+                                  }
                                 }
                               }
                             }
                           },
-                          "value": {
-                            "Primitive": {
-                              "Float": {
-                                "kind": {
-                                  "F32": {}
+                          "value" : {
+                            "Primitive" : {
+                              "Float" : {
+                                "kind" : {
+                                  "F32" : {
+                                    
+                                  }
                                 }
                               }
                             }
                           }
                         }
                       },
-                      "default": {
-                        "Some": {
-                          "anonStruct": {
-                            "members": {
-                              "time": {
-                                "Float": {
-                                  "value": 0.0,
-                                  "kind": {
-                                    "F32": {}
+                      "default" : {
+                        "Some" : {
+                          "anonStruct" : {
+                            "members" : {
+                              "time" : {
+                                "Float" : {
+                                  "value" : 0.0,
+                                  "kind" : {
+                                    "F32" : {
+                                      
+                                    }
                                   }
                                 }
                               },
-                              "value": {
-                                "Float": {
-                                  "value": 0.0,
-                                  "kind": {
-                                    "F32": {}
+                              "value" : {
+                                "Float" : {
+                                  "value" : 0.0,
+                                  "kind" : {
+                                    "F32" : {
+                                      
+                                    }
                                   }
                                 }
                               }
                             }
                           },
-                          "t": {
-                            "node": {
-                              "astNodeId": 99
+                          "t" : {
+                            "node" : {
+                              "astNodeId" : 99
                             },
-                            "anonStruct": {
-                              "members": {
-                                "time": {
-                                  "Primitive": {
-                                    "Float": {
-                                      "kind": {
-                                        "F32": {}
+                            "anonStruct" : {
+                              "members" : {
+                                "time" : {
+                                  "Primitive" : {
+                                    "Float" : {
+                                      "kind" : {
+                                        "F32" : {
+                                          
+                                        }
                                       }
                                     }
                                   }
                                 },
-                                "value": {
-                                  "Primitive": {
-                                    "Float": {
-                                      "kind": {
-                                        "F32": {}
+                                "value" : {
+                                  "Primitive" : {
+                                    "Float" : {
+                                      "kind" : {
+                                        "F32" : {
+                                          
+                                        }
                                       }
                                     }
                                   }
                                 }
                               }
                             },
-                            "default": "None",
-                            "sizes": {},
-                            "formats": {}
+                            "default" : "None",
+                            "sizes" : {
+                              
+                            },
+                            "formats" : {
+                              
+                            }
                           }
                         }
                       },
-                      "sizes": {},
-                      "formats": {
-                        "time": {
-                          "prefix": "",
-                          "fields": [
+                      "sizes" : {
+                        
+                      },
+                      "formats" : {
+                        "time" : {
+                          "prefix" : "",
+                          "fields" : [
                             [
                               {
-                                "Rational": {
-                                  "precision": "None",
-                                  "t": {
-                                    "Fixed": {}
+                                "Rational" : {
+                                  "precision" : "None",
+                                  "t" : {
+                                    "Fixed" : {
+                                      
+                                    }
                                   }
                                 }
                               },
@@ -1017,15 +1150,17 @@
                             ]
                           ]
                         },
-                        "value": {
-                          "prefix": "",
-                          "fields": [
+                        "value" : {
+                          "prefix" : "",
+                          "fields" : [
                             [
                               {
-                                "Rational": {
-                                  "precision": "None",
-                                  "t": {
-                                    "Fixed": {}
+                                "Rational" : {
+                                  "precision" : "None",
+                                  "t" : {
+                                    "Fixed" : {
+                                      
+                                    }
                                   }
                                 }
                               },
@@ -1037,228 +1172,270 @@
                     }
                   }
                 },
-                "default": "None",
-                "format": "None"
+                "default" : "None",
+                "format" : "None"
               }
             }
           },
-          "format": "None"
+          "format" : "None"
         }
       },
-      "33": {
-        "Struct": {
-          "node": {
-            "astNodeId": 33
+      "33" : {
+        "Struct" : {
+          "node" : {
+            "astNodeId" : 33
           },
-          "anonStruct": {
-            "members": {
-              "x": {
-                "Int": {
-                  "PrimitiveInt": {
-                    "kind": {
-                      "U32": {}
+          "anonStruct" : {
+            "members" : {
+              "x" : {
+                "Int" : {
+                  "PrimitiveInt" : {
+                    "kind" : {
+                      "U32" : {
+                        
+                      }
                     }
                   }
                 }
               },
-              "y": {
-                "String": {
-                  "size": "None"
+              "y" : {
+                "String" : {
+                  "size" : "None"
                 }
               }
             }
           },
-          "default": {
-            "Some": {
-              "anonStruct": {
-                "members": {
-                  "x": {
-                    "PrimitiveInt": {
-                      "value": 0,
-                      "kind": {
-                        "U32": {}
+          "default" : {
+            "Some" : {
+              "anonStruct" : {
+                "members" : {
+                  "x" : {
+                    "PrimitiveInt" : {
+                      "value" : 0,
+                      "kind" : {
+                        "U32" : {
+                          
+                        }
                       }
                     }
                   },
-                  "y": {
-                    "String": {
-                      "value": ""
+                  "y" : {
+                    "String" : {
+                      "value" : ""
                     }
                   }
                 }
               },
-              "t": {
-                "node": {
-                  "astNodeId": 33
+              "t" : {
+                "node" : {
+                  "astNodeId" : 33
                 },
-                "anonStruct": {
-                  "members": {
-                    "x": {
-                      "Int": {
-                        "PrimitiveInt": {
-                          "kind": {
-                            "U32": {}
+                "anonStruct" : {
+                  "members" : {
+                    "x" : {
+                      "Int" : {
+                        "PrimitiveInt" : {
+                          "kind" : {
+                            "U32" : {
+                              
+                            }
                           }
                         }
                       }
                     },
-                    "y": {
-                      "String": {
-                        "size": "None"
+                    "y" : {
+                      "String" : {
+                        "size" : "None"
                       }
                     }
                   }
                 },
-                "default": "None",
-                "sizes": {},
-                "formats": {}
+                "default" : "None",
+                "sizes" : {
+                  
+                },
+                "formats" : {
+                  
+                }
               }
             }
           },
-          "sizes": {},
-          "formats": {}
+          "sizes" : {
+            
+          },
+          "formats" : {
+            
+          }
         }
       },
-      "117": {
-        "AliasType": {
-          "node": {
-            "astNodeId": 117
+      "117" : {
+        "AliasType" : {
+          "node" : {
+            "astNodeId" : 117
           },
-          "aliasType": {
-            "Int": {
-              "PrimitiveInt": {
-                "kind": {
-                  "U32": {}
+          "aliasType" : {
+            "Int" : {
+              "PrimitiveInt" : {
+                "kind" : {
+                  "U32" : {
+                    
+                  }
                 }
               }
             }
           }
         }
       },
-      "50": {
-        "Int": {
-          "PrimitiveInt": {
-            "kind": {
-              "U32": {}
+      "50" : {
+        "Int" : {
+          "PrimitiveInt" : {
+            "kind" : {
+              "U32" : {
+                
+              }
             }
           }
         }
       },
-      "68": {
-        "Enum": {
-          "node": {
-            "astNodeId": 115
+      "68" : {
+        "Enum" : {
+          "node" : {
+            "astNodeId" : 115
           },
-          "repType": {
-            "kind": {
-              "I32": {}
+          "repType" : {
+            "kind" : {
+              "I32" : {
+                
+              }
             }
           },
-          "default": "None"
+          "default" : "None"
         }
       },
-      "61": {
-        "Int": {
-          "Integer": {}
+      "61" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "46": {
-        "String": {
-          "size": "None"
+      "46" : {
+        "String" : {
+          "size" : "None"
         }
       },
-      "99": {
-        "Struct": {
-          "node": {
-            "astNodeId": 99
+      "99" : {
+        "Struct" : {
+          "node" : {
+            "astNodeId" : 99
           },
-          "anonStruct": {
-            "members": {
-              "time": {
-                "Primitive": {
-                  "Float": {
-                    "kind": {
-                      "F32": {}
+          "anonStruct" : {
+            "members" : {
+              "time" : {
+                "Primitive" : {
+                  "Float" : {
+                    "kind" : {
+                      "F32" : {
+                        
+                      }
                     }
                   }
                 }
               },
-              "value": {
-                "Primitive": {
-                  "Float": {
-                    "kind": {
-                      "F32": {}
+              "value" : {
+                "Primitive" : {
+                  "Float" : {
+                    "kind" : {
+                      "F32" : {
+                        
+                      }
                     }
                   }
                 }
               }
             }
           },
-          "default": {
-            "Some": {
-              "anonStruct": {
-                "members": {
-                  "time": {
-                    "Float": {
-                      "value": 0.0,
-                      "kind": {
-                        "F32": {}
+          "default" : {
+            "Some" : {
+              "anonStruct" : {
+                "members" : {
+                  "time" : {
+                    "Float" : {
+                      "value" : 0.0,
+                      "kind" : {
+                        "F32" : {
+                          
+                        }
                       }
                     }
                   },
-                  "value": {
-                    "Float": {
-                      "value": 0.0,
-                      "kind": {
-                        "F32": {}
+                  "value" : {
+                    "Float" : {
+                      "value" : 0.0,
+                      "kind" : {
+                        "F32" : {
+                          
+                        }
                       }
                     }
                   }
                 }
               },
-              "t": {
-                "node": {
-                  "astNodeId": 99
+              "t" : {
+                "node" : {
+                  "astNodeId" : 99
                 },
-                "anonStruct": {
-                  "members": {
-                    "time": {
-                      "Primitive": {
-                        "Float": {
-                          "kind": {
-                            "F32": {}
+                "anonStruct" : {
+                  "members" : {
+                    "time" : {
+                      "Primitive" : {
+                        "Float" : {
+                          "kind" : {
+                            "F32" : {
+                              
+                            }
                           }
                         }
                       }
                     },
-                    "value": {
-                      "Primitive": {
-                        "Float": {
-                          "kind": {
-                            "F32": {}
+                    "value" : {
+                      "Primitive" : {
+                        "Float" : {
+                          "kind" : {
+                            "F32" : {
+                              
+                            }
                           }
                         }
                       }
                     }
                   }
                 },
-                "default": "None",
-                "sizes": {},
-                "formats": {}
+                "default" : "None",
+                "sizes" : {
+                  
+                },
+                "formats" : {
+                  
+                }
               }
             }
           },
-          "sizes": {},
-          "formats": {
-            "time": {
-              "prefix": "",
-              "fields": [
+          "sizes" : {
+            
+          },
+          "formats" : {
+            "time" : {
+              "prefix" : "",
+              "fields" : [
                 [
                   {
-                    "Rational": {
-                      "precision": "None",
-                      "t": {
-                        "Fixed": {}
+                    "Rational" : {
+                      "precision" : "None",
+                      "t" : {
+                        "Fixed" : {
+                          
+                        }
                       }
                     }
                   },
@@ -1266,15 +1443,17 @@
                 ]
               ]
             },
-            "value": {
-              "prefix": "",
-              "fields": [
+            "value" : {
+              "prefix" : "",
+              "fields" : [
                 [
                   {
-                    "Rational": {
-                      "precision": "None",
-                      "t": {
-                        "Fixed": {}
+                    "Rational" : {
+                      "precision" : "None",
+                      "t" : {
+                        "Fixed" : {
+                          
+                        }
                       }
                     }
                   },
@@ -1285,134 +1464,146 @@
           }
         }
       },
-      "5": {
-        "String": {
-          "size": "None"
+      "5" : {
+        "String" : {
+          "size" : "None"
         }
       },
-      "103": {
-        "Struct": {
-          "node": {
-            "astNodeId": 99
+      "103" : {
+        "Struct" : {
+          "node" : {
+            "astNodeId" : 99
           },
-          "anonStruct": {
-            "members": {
-              "time": {
-                "Primitive": {
-                  "Float": {
-                    "kind": {
-                      "F32": {}
+          "anonStruct" : {
+            "members" : {
+              "time" : {
+                "Primitive" : {
+                  "Float" : {
+                    "kind" : {
+                      "F32" : {
+                        
+                      }
                     }
                   }
                 }
               },
-              "value": {
-                "Primitive": {
-                  "Float": {
-                    "kind": {
-                      "F32": {}
+              "value" : {
+                "Primitive" : {
+                  "Float" : {
+                    "kind" : {
+                      "F32" : {
+                        
+                      }
                     }
                   }
                 }
               }
             }
           },
-          "default": "None",
-          "sizes": {},
-          "formats": {}
+          "default" : "None",
+          "sizes" : {
+            
+          },
+          "formats" : {
+            
+          }
         }
       },
-      "72": {
-        "Array": {
-          "node": {
-            "astNodeId": 108
+      "72" : {
+        "Array" : {
+          "node" : {
+            "astNodeId" : 108
           },
-          "anonArray": {
-            "size": "None",
-            "eltType": {
-              "Primitive": {
-                "Float": {
-                  "kind": {
-                    "F32": {}
+          "anonArray" : {
+            "size" : "None",
+            "eltType" : {
+              "Primitive" : {
+                "Float" : {
+                  "kind" : {
+                    "F32" : {
+                      
+                    }
                   }
                 }
               }
             }
           },
-          "default": "None",
-          "format": "None"
+          "default" : "None",
+          "format" : "None"
         }
       },
-      "10": {
-        "Array": {
-          "node": {
-            "astNodeId": 10
+      "10" : {
+        "Array" : {
+          "node" : {
+            "astNodeId" : 10
           },
-          "anonArray": {
-            "size": {
-              "Some": 3
+          "anonArray" : {
+            "size" : {
+              "Some" : 3
             },
-            "eltType": {
-              "String": {
-                "size": {
-                  "Some": {
-                    "astNodeId": 3
+            "eltType" : {
+              "String" : {
+                "size" : {
+                  "Some" : {
+                    "astNodeId" : 3
                   }
                 }
               }
             }
           },
-          "default": {
-            "Some": {
-              "anonArray": {
-                "elements": [
+          "default" : {
+            "Some" : {
+              "anonArray" : {
+                "elements" : [
                   {
-                    "String": {
-                      "value": "1"
+                    "String" : {
+                      "value" : "1"
                     }
                   },
                   {
-                    "String": {
-                      "value": "2"
+                    "String" : {
+                      "value" : "2"
                     }
                   },
                   {
-                    "String": {
-                      "value": "3"
+                    "String" : {
+                      "value" : "3"
                     }
                   }
                 ]
               },
-              "t": {
-                "node": {
-                  "astNodeId": 10
+              "t" : {
+                "node" : {
+                  "astNodeId" : 10
                 },
-                "anonArray": {
-                  "size": {
-                    "Some": 3
+                "anonArray" : {
+                  "size" : {
+                    "Some" : 3
                   },
-                  "eltType": {
-                    "String": {
-                      "size": {
-                        "Some": {
-                          "astNodeId": 3
+                  "eltType" : {
+                    "String" : {
+                      "size" : {
+                        "Some" : {
+                          "astNodeId" : 3
                         }
                       }
                     }
                   }
                 },
-                "default": "None",
-                "format": "None"
+                "default" : "None",
+                "format" : "None"
               }
             }
           },
-          "format": {
-            "Some": {
-              "prefix": "",
-              "fields": [
+          "format" : {
+            "Some" : {
+              "prefix" : "",
+              "fields" : [
                 [
                   {
-                    "Default": {}
+                    "Default" : {
+                      
+                    }
                   },
                   " RPM"
                 ]
@@ -1421,278 +1612,312 @@
           }
         }
       },
-      "59": {
-        "Struct": {
-          "node": {
-            "astNodeId": 59
+      "59" : {
+        "Struct" : {
+          "node" : {
+            "astNodeId" : 59
           },
-          "anonStruct": {
-            "members": {
-              "x": {
-                "Int": {
-                  "PrimitiveInt": {
-                    "kind": {
-                      "U32": {}
+          "anonStruct" : {
+            "members" : {
+              "x" : {
+                "Int" : {
+                  "PrimitiveInt" : {
+                    "kind" : {
+                      "U32" : {
+                        
+                      }
                     }
                   }
                 }
               },
-              "y": {
-                "String": {
-                  "size": "None"
+              "y" : {
+                "String" : {
+                  "size" : "None"
                 }
               }
             }
           },
-          "default": {
-            "Some": {
-              "anonStruct": {
-                "members": {
-                  "x": {
-                    "PrimitiveInt": {
-                      "value": 1,
-                      "kind": {
-                        "U32": {}
+          "default" : {
+            "Some" : {
+              "anonStruct" : {
+                "members" : {
+                  "x" : {
+                    "PrimitiveInt" : {
+                      "value" : 1,
+                      "kind" : {
+                        "U32" : {
+                          
+                        }
                       }
                     }
                   },
-                  "y": {
-                    "String": {
-                      "value": "abc"
+                  "y" : {
+                    "String" : {
+                      "value" : "abc"
                     }
                   }
                 }
               },
-              "t": {
-                "node": {
-                  "astNodeId": 59
+              "t" : {
+                "node" : {
+                  "astNodeId" : 59
                 },
-                "anonStruct": {
-                  "members": {
-                    "x": {
-                      "Int": {
-                        "PrimitiveInt": {
-                          "kind": {
-                            "U32": {}
+                "anonStruct" : {
+                  "members" : {
+                    "x" : {
+                      "Int" : {
+                        "PrimitiveInt" : {
+                          "kind" : {
+                            "U32" : {
+                              
+                            }
                           }
                         }
                       }
                     },
-                    "y": {
-                      "String": {
-                        "size": "None"
+                    "y" : {
+                      "String" : {
+                        "size" : "None"
                       }
                     }
                   }
                 },
-                "default": "None",
-                "sizes": {},
-                "formats": {}
-              }
-            }
-          },
-          "sizes": {},
-          "formats": {}
-        }
-      },
-      "87": {
-        "Primitive": {
-          "Float": {
-            "kind": {
-              "F32": {}
-            }
-          }
-        }
-      },
-      "48": {
-        "AnonStruct": {
-          "members": {
-            "x": {
-              "Int": {
-                "Integer": {}
-              }
-            },
-            "y": {
-              "String": {
-                "size": "None"
-              }
-            }
-          }
-        }
-      },
-      "116": {
-        "Int": {
-          "PrimitiveInt": {
-            "kind": {
-              "U32": {}
-            }
-          }
-        }
-      },
-      "65": {
-        "Array": {
-          "node": {
-            "astNodeId": 65
-          },
-          "anonArray": {
-            "size": {
-              "Some": 3
-            },
-            "eltType": {
-              "AbsType": {
-                "node": {
-                  "astNodeId": 60
+                "default" : "None",
+                "sizes" : {
+                  
+                },
+                "formats" : {
+                  
                 }
               }
             }
           },
-          "default": {
-            "Some": {
-              "anonArray": {
-                "elements": [
+          "sizes" : {
+            
+          },
+          "formats" : {
+            
+          }
+        }
+      },
+      "87" : {
+        "Primitive" : {
+          "Float" : {
+            "kind" : {
+              "F32" : {
+                
+              }
+            }
+          }
+        }
+      },
+      "48" : {
+        "AnonStruct" : {
+          "members" : {
+            "x" : {
+              "Int" : {
+                "Integer" : {
+                  
+                }
+              }
+            },
+            "y" : {
+              "String" : {
+                "size" : "None"
+              }
+            }
+          }
+        }
+      },
+      "116" : {
+        "Int" : {
+          "PrimitiveInt" : {
+            "kind" : {
+              "U32" : {
+                
+              }
+            }
+          }
+        }
+      },
+      "65" : {
+        "Array" : {
+          "node" : {
+            "astNodeId" : 65
+          },
+          "anonArray" : {
+            "size" : {
+              "Some" : 3
+            },
+            "eltType" : {
+              "AbsType" : {
+                "node" : {
+                  "astNodeId" : 60
+                }
+              }
+            }
+          },
+          "default" : {
+            "Some" : {
+              "anonArray" : {
+                "elements" : [
                   {
-                    "AbsType": {
-                      "t": {
-                        "node": {
-                          "astNodeId": 60
+                    "AbsType" : {
+                      "t" : {
+                        "node" : {
+                          "astNodeId" : 60
                         }
                       }
                     }
                   },
                   {
-                    "AbsType": {
-                      "t": {
-                        "node": {
-                          "astNodeId": 60
+                    "AbsType" : {
+                      "t" : {
+                        "node" : {
+                          "astNodeId" : 60
                         }
                       }
                     }
                   },
                   {
-                    "AbsType": {
-                      "t": {
-                        "node": {
-                          "astNodeId": 60
+                    "AbsType" : {
+                      "t" : {
+                        "node" : {
+                          "astNodeId" : 60
                         }
                       }
                     }
                   }
                 ]
               },
-              "t": {
-                "node": {
-                  "astNodeId": 65
+              "t" : {
+                "node" : {
+                  "astNodeId" : 65
                 },
-                "anonArray": {
-                  "size": {
-                    "Some": 3
+                "anonArray" : {
+                  "size" : {
+                    "Some" : 3
                   },
-                  "eltType": {
-                    "AbsType": {
-                      "node": {
-                        "astNodeId": 60
+                  "eltType" : {
+                    "AbsType" : {
+                      "node" : {
+                        "astNodeId" : 60
                       }
                     }
                   }
                 },
-                "default": "None",
-                "format": "None"
+                "default" : "None",
+                "format" : "None"
               }
             }
           },
-          "format": "None"
+          "format" : "None"
         }
       },
-      "108": {
-        "Array": {
-          "node": {
-            "astNodeId": 108
+      "108" : {
+        "Array" : {
+          "node" : {
+            "astNodeId" : 108
           },
-          "anonArray": {
-            "size": {
-              "Some": 4
+          "anonArray" : {
+            "size" : {
+              "Some" : 4
             },
-            "eltType": {
-              "Primitive": {
-                "Float": {
-                  "kind": {
-                    "F32": {}
+            "eltType" : {
+              "Primitive" : {
+                "Float" : {
+                  "kind" : {
+                    "F32" : {
+                      
+                    }
                   }
                 }
               }
             }
           },
-          "default": {
-            "Some": {
-              "anonArray": {
-                "elements": [
+          "default" : {
+            "Some" : {
+              "anonArray" : {
+                "elements" : [
                   {
-                    "Float": {
-                      "value": 0.0,
-                      "kind": {
-                        "F32": {}
+                    "Float" : {
+                      "value" : 0.0,
+                      "kind" : {
+                        "F32" : {
+                          
+                        }
                       }
                     }
                   },
                   {
-                    "Float": {
-                      "value": 0.0,
-                      "kind": {
-                        "F32": {}
+                    "Float" : {
+                      "value" : 0.0,
+                      "kind" : {
+                        "F32" : {
+                          
+                        }
                       }
                     }
                   },
                   {
-                    "Float": {
-                      "value": 0.0,
-                      "kind": {
-                        "F32": {}
+                    "Float" : {
+                      "value" : 0.0,
+                      "kind" : {
+                        "F32" : {
+                          
+                        }
                       }
                     }
                   },
                   {
-                    "Float": {
-                      "value": 0.0,
-                      "kind": {
-                        "F32": {}
+                    "Float" : {
+                      "value" : 0.0,
+                      "kind" : {
+                        "F32" : {
+                          
+                        }
                       }
                     }
                   }
                 ]
               },
-              "t": {
-                "node": {
-                  "astNodeId": 108
+              "t" : {
+                "node" : {
+                  "astNodeId" : 108
                 },
-                "anonArray": {
-                  "size": {
-                    "Some": 4
+                "anonArray" : {
+                  "size" : {
+                    "Some" : 4
                   },
-                  "eltType": {
-                    "Primitive": {
-                      "Float": {
-                        "kind": {
-                          "F32": {}
+                  "eltType" : {
+                    "Primitive" : {
+                      "Float" : {
+                        "kind" : {
+                          "F32" : {
+                            
+                          }
                         }
                       }
                     }
                   }
                 },
-                "default": "None",
-                "format": "None"
+                "default" : "None",
+                "format" : "None"
               }
             }
           },
-          "format": {
-            "Some": {
-              "prefix": "",
-              "fields": [
+          "format" : {
+            "Some" : {
+              "prefix" : "",
+              "fields" : [
                 [
                   {
-                    "Rational": {
-                      "precision": "None",
-                      "t": {
-                        "Fixed": {}
+                    "Rational" : {
+                      "precision" : "None",
+                      "t" : {
+                        "Fixed" : {
+                          
+                        }
                       }
                     }
                   },
@@ -1703,346 +1928,399 @@
           }
         }
       },
-      "49": {
-        "Struct": {
-          "node": {
-            "astNodeId": 49
+      "49" : {
+        "Struct" : {
+          "node" : {
+            "astNodeId" : 49
           },
-          "anonStruct": {
-            "members": {
-              "x": {
-                "Int": {
-                  "PrimitiveInt": {
-                    "kind": {
-                      "U8": {}
-                    }
-                  }
-                }
-              },
-              "y": {
-                "String": {
-                  "size": "None"
-                }
-              }
-            }
-          },
-          "default": {
-            "Some": {
-              "anonStruct": {
-                "members": {
-                  "x": {
-                    "PrimitiveInt": {
-                      "value": 1,
-                      "kind": {
-                        "U8": {}
-                      }
-                    }
-                  },
-                  "y": {
-                    "String": {
-                      "value": "abc"
-                    }
-                  }
-                }
-              },
-              "t": {
-                "node": {
-                  "astNodeId": 49
-                },
-                "anonStruct": {
-                  "members": {
-                    "x": {
-                      "Int": {
-                        "PrimitiveInt": {
-                          "kind": {
-                            "U8": {}
-                          }
-                        }
-                      }
-                    },
-                    "y": {
-                      "String": {
-                        "size": "None"
-                      }
-                    }
-                  }
-                },
-                "default": "None",
-                "sizes": {},
-                "formats": {}
-              }
-            }
-          },
-          "sizes": {},
-          "formats": {}
-        }
-      },
-      "6": {
-        "String": {
-          "size": "None"
-        }
-      },
-      "36": {
-        "String": {
-          "size": "None"
-        }
-      },
-      "1": {
-        "Int": {
-          "Integer": {}
-        }
-      },
-      "39": {
-        "AnonStruct": {
-          "members": {
-            "x": {
-              "Int": {
-                "Integer": {}
-              }
-            },
-            "y": {
-              "String": {
-                "size": "None"
-              }
-            }
-          }
-        }
-      },
-      "60": {
-        "AbsType": {
-          "node": {
-            "astNodeId": 60
-          }
-        }
-      },
-      "14": {
-        "Array": {
-          "node": {
-            "astNodeId": 10
-          },
-          "anonArray": {
-            "size": "None",
-            "eltType": {
-              "String": {
-                "size": {
-                  "Some": {
-                    "astNodeId": 3
-                  }
-                }
-              }
-            }
-          },
-          "default": "None",
-          "format": "None"
-        }
-      },
-      "111": {
-        "Enum": {
-          "node": {
-            "astNodeId": 115
-          },
-          "repType": {
-            "kind": {
-              "I32": {}
-            }
-          },
-          "default": "None"
-        }
-      },
-      "31": {
-        "String": {
-          "size": "None"
-        }
-      },
-      "96": {
-        "Primitive": {
-          "Float": {
-            "kind": {
-              "F32": {}
-            }
-          }
-        }
-      },
-      "58": {
-        "AnonStruct": {
-          "members": {
-            "x": {
-              "Int": {
-                "Integer": {}
-              }
-            },
-            "y": {
-              "String": {
-                "size": "None"
-              }
-            }
-          }
-        }
-      },
-      "64": {
-        "AbsType": {
-          "node": {
-            "astNodeId": 60
-          }
-        }
-      },
-      "109": {
-        "Enum": {
-          "node": {
-            "astNodeId": 115
-          },
-          "repType": {
-            "kind": {
-              "I32": {}
-            }
-          },
-          "default": "None"
-        }
-      },
-      "0": {
-        "Int": {
-          "Integer": {}
-        }
-      },
-      "27": {
-        "Int": {
-          "PrimitiveInt": {
-            "kind": {
-              "U32": {}
-            }
-          }
-        }
-      },
-      "2": {
-        "Int": {
-          "Integer": {}
-        }
-      },
-      "86": {
-        "Struct": {
-          "node": {
-            "astNodeId": 86
-          },
-          "anonStruct": {
-            "members": {
-              "type": {
-                "Enum": {
-                  "node": {
-                    "astNodeId": 115
-                  },
-                  "repType": {
-                    "kind": {
-                      "I32": {}
-                    }
-                  },
-                  "default": {
-                    "Some": {
-                      "value": ["TRIANGLE", 0],
-                      "t": {
-                        "node": {
-                          "astNodeId": 115
-                        },
-                        "repType": {
-                          "kind": {
-                            "I32": {}
-                          }
-                        },
-                        "default": "None"
+          "anonStruct" : {
+            "members" : {
+              "x" : {
+                "Int" : {
+                  "PrimitiveInt" : {
+                    "kind" : {
+                      "U8" : {
+                        
                       }
                     }
                   }
                 }
               },
-              "history": {
-                "Array": {
-                  "node": {
-                    "astNodeId": 108
-                  },
-                  "anonArray": {
-                    "size": {
-                      "Some": 4
-                    },
-                    "eltType": {
-                      "Primitive": {
-                        "Float": {
-                          "kind": {
-                            "F32": {}
-                          }
+              "y" : {
+                "String" : {
+                  "size" : "None"
+                }
+              }
+            }
+          },
+          "default" : {
+            "Some" : {
+              "anonStruct" : {
+                "members" : {
+                  "x" : {
+                    "PrimitiveInt" : {
+                      "value" : 1,
+                      "kind" : {
+                        "U8" : {
+                          
                         }
                       }
                     }
                   },
-                  "default": {
-                    "Some": {
-                      "anonArray": {
-                        "elements": [
+                  "y" : {
+                    "String" : {
+                      "value" : "abc"
+                    }
+                  }
+                }
+              },
+              "t" : {
+                "node" : {
+                  "astNodeId" : 49
+                },
+                "anonStruct" : {
+                  "members" : {
+                    "x" : {
+                      "Int" : {
+                        "PrimitiveInt" : {
+                          "kind" : {
+                            "U8" : {
+                              
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "y" : {
+                      "String" : {
+                        "size" : "None"
+                      }
+                    }
+                  }
+                },
+                "default" : "None",
+                "sizes" : {
+                  
+                },
+                "formats" : {
+                  
+                }
+              }
+            }
+          },
+          "sizes" : {
+            
+          },
+          "formats" : {
+            
+          }
+        }
+      },
+      "6" : {
+        "String" : {
+          "size" : "None"
+        }
+      },
+      "36" : {
+        "String" : {
+          "size" : "None"
+        }
+      },
+      "1" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
+        }
+      },
+      "39" : {
+        "AnonStruct" : {
+          "members" : {
+            "x" : {
+              "Int" : {
+                "Integer" : {
+                  
+                }
+              }
+            },
+            "y" : {
+              "String" : {
+                "size" : "None"
+              }
+            }
+          }
+        }
+      },
+      "60" : {
+        "AbsType" : {
+          "node" : {
+            "astNodeId" : 60
+          }
+        }
+      },
+      "14" : {
+        "Array" : {
+          "node" : {
+            "astNodeId" : 10
+          },
+          "anonArray" : {
+            "size" : "None",
+            "eltType" : {
+              "String" : {
+                "size" : {
+                  "Some" : {
+                    "astNodeId" : 3
+                  }
+                }
+              }
+            }
+          },
+          "default" : "None",
+          "format" : "None"
+        }
+      },
+      "111" : {
+        "Enum" : {
+          "node" : {
+            "astNodeId" : 115
+          },
+          "repType" : {
+            "kind" : {
+              "I32" : {
+                
+              }
+            }
+          },
+          "default" : "None"
+        }
+      },
+      "31" : {
+        "String" : {
+          "size" : "None"
+        }
+      },
+      "96" : {
+        "Primitive" : {
+          "Float" : {
+            "kind" : {
+              "F32" : {
+                
+              }
+            }
+          }
+        }
+      },
+      "58" : {
+        "AnonStruct" : {
+          "members" : {
+            "x" : {
+              "Int" : {
+                "Integer" : {
+                  
+                }
+              }
+            },
+            "y" : {
+              "String" : {
+                "size" : "None"
+              }
+            }
+          }
+        }
+      },
+      "64" : {
+        "AbsType" : {
+          "node" : {
+            "astNodeId" : 60
+          }
+        }
+      },
+      "109" : {
+        "Enum" : {
+          "node" : {
+            "astNodeId" : 115
+          },
+          "repType" : {
+            "kind" : {
+              "I32" : {
+                
+              }
+            }
+          },
+          "default" : "None"
+        }
+      },
+      "0" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
+        }
+      },
+      "27" : {
+        "Int" : {
+          "PrimitiveInt" : {
+            "kind" : {
+              "U32" : {
+                
+              }
+            }
+          }
+        }
+      },
+      "2" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
+        }
+      },
+      "86" : {
+        "Struct" : {
+          "node" : {
+            "astNodeId" : 86
+          },
+          "anonStruct" : {
+            "members" : {
+              "type" : {
+                "Enum" : {
+                  "node" : {
+                    "astNodeId" : 115
+                  },
+                  "repType" : {
+                    "kind" : {
+                      "I32" : {
+                        
+                      }
+                    }
+                  },
+                  "default" : {
+                    "Some" : {
+                      "value" : [
+                        "TRIANGLE",
+                        0
+                      ],
+                      "t" : {
+                        "node" : {
+                          "astNodeId" : 115
+                        },
+                        "repType" : {
+                          "kind" : {
+                            "I32" : {
+                              
+                            }
+                          }
+                        },
+                        "default" : "None"
+                      }
+                    }
+                  }
+                }
+              },
+              "history" : {
+                "Array" : {
+                  "node" : {
+                    "astNodeId" : 108
+                  },
+                  "anonArray" : {
+                    "size" : {
+                      "Some" : 4
+                    },
+                    "eltType" : {
+                      "Primitive" : {
+                        "Float" : {
+                          "kind" : {
+                            "F32" : {
+                              
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "default" : {
+                    "Some" : {
+                      "anonArray" : {
+                        "elements" : [
                           {
-                            "Float": {
-                              "value": 0.0,
-                              "kind": {
-                                "F32": {}
+                            "Float" : {
+                              "value" : 0.0,
+                              "kind" : {
+                                "F32" : {
+                                  
+                                }
                               }
                             }
                           },
                           {
-                            "Float": {
-                              "value": 0.0,
-                              "kind": {
-                                "F32": {}
+                            "Float" : {
+                              "value" : 0.0,
+                              "kind" : {
+                                "F32" : {
+                                  
+                                }
                               }
                             }
                           },
                           {
-                            "Float": {
-                              "value": 0.0,
-                              "kind": {
-                                "F32": {}
+                            "Float" : {
+                              "value" : 0.0,
+                              "kind" : {
+                                "F32" : {
+                                  
+                                }
                               }
                             }
                           },
                           {
-                            "Float": {
-                              "value": 0.0,
-                              "kind": {
-                                "F32": {}
+                            "Float" : {
+                              "value" : 0.0,
+                              "kind" : {
+                                "F32" : {
+                                  
+                                }
                               }
                             }
                           }
                         ]
                       },
-                      "t": {
-                        "node": {
-                          "astNodeId": 108
+                      "t" : {
+                        "node" : {
+                          "astNodeId" : 108
                         },
-                        "anonArray": {
-                          "size": {
-                            "Some": 4
+                        "anonArray" : {
+                          "size" : {
+                            "Some" : 4
                           },
-                          "eltType": {
-                            "Primitive": {
-                              "Float": {
-                                "kind": {
-                                  "F32": {}
+                          "eltType" : {
+                            "Primitive" : {
+                              "Float" : {
+                                "kind" : {
+                                  "F32" : {
+                                    
+                                  }
                                 }
                               }
                             }
                           }
                         },
-                        "default": "None",
-                        "format": "None"
+                        "default" : "None",
+                        "format" : "None"
                       }
                     }
                   },
-                  "format": {
-                    "Some": {
-                      "prefix": "",
-                      "fields": [
+                  "format" : {
+                    "Some" : {
+                      "prefix" : "",
+                      "fields" : [
                         [
                           {
-                            "Rational": {
-                              "precision": "None",
-                              "t": {
-                                "Fixed": {}
+                            "Rational" : {
+                              "precision" : "None",
+                              "t" : {
+                                "Fixed" : {
+                                  
+                                }
                               }
                             }
                           },
@@ -2053,107 +2331,127 @@
                   }
                 }
               },
-              "pairHistory": {
-                "Array": {
-                  "node": {
-                    "astNodeId": 104
+              "pairHistory" : {
+                "Array" : {
+                  "node" : {
+                    "astNodeId" : 104
                   },
-                  "anonArray": {
-                    "size": {
-                      "Some": 4
+                  "anonArray" : {
+                    "size" : {
+                      "Some" : 4
                     },
-                    "eltType": {
-                      "Struct": {
-                        "node": {
-                          "astNodeId": 99
+                    "eltType" : {
+                      "Struct" : {
+                        "node" : {
+                          "astNodeId" : 99
                         },
-                        "anonStruct": {
-                          "members": {
-                            "time": {
-                              "Primitive": {
-                                "Float": {
-                                  "kind": {
-                                    "F32": {}
+                        "anonStruct" : {
+                          "members" : {
+                            "time" : {
+                              "Primitive" : {
+                                "Float" : {
+                                  "kind" : {
+                                    "F32" : {
+                                      
+                                    }
                                   }
                                 }
                               }
                             },
-                            "value": {
-                              "Primitive": {
-                                "Float": {
-                                  "kind": {
-                                    "F32": {}
+                            "value" : {
+                              "Primitive" : {
+                                "Float" : {
+                                  "kind" : {
+                                    "F32" : {
+                                      
+                                    }
                                   }
                                 }
                               }
                             }
                           }
                         },
-                        "default": {
-                          "Some": {
-                            "anonStruct": {
-                              "members": {
-                                "time": {
-                                  "Float": {
-                                    "value": 0.0,
-                                    "kind": {
-                                      "F32": {}
+                        "default" : {
+                          "Some" : {
+                            "anonStruct" : {
+                              "members" : {
+                                "time" : {
+                                  "Float" : {
+                                    "value" : 0.0,
+                                    "kind" : {
+                                      "F32" : {
+                                        
+                                      }
                                     }
                                   }
                                 },
-                                "value": {
-                                  "Float": {
-                                    "value": 0.0,
-                                    "kind": {
-                                      "F32": {}
+                                "value" : {
+                                  "Float" : {
+                                    "value" : 0.0,
+                                    "kind" : {
+                                      "F32" : {
+                                        
+                                      }
                                     }
                                   }
                                 }
                               }
                             },
-                            "t": {
-                              "node": {
-                                "astNodeId": 99
+                            "t" : {
+                              "node" : {
+                                "astNodeId" : 99
                               },
-                              "anonStruct": {
-                                "members": {
-                                  "time": {
-                                    "Primitive": {
-                                      "Float": {
-                                        "kind": {
-                                          "F32": {}
+                              "anonStruct" : {
+                                "members" : {
+                                  "time" : {
+                                    "Primitive" : {
+                                      "Float" : {
+                                        "kind" : {
+                                          "F32" : {
+                                            
+                                          }
                                         }
                                       }
                                     }
                                   },
-                                  "value": {
-                                    "Primitive": {
-                                      "Float": {
-                                        "kind": {
-                                          "F32": {}
+                                  "value" : {
+                                    "Primitive" : {
+                                      "Float" : {
+                                        "kind" : {
+                                          "F32" : {
+                                            
+                                          }
                                         }
                                       }
                                     }
                                   }
                                 }
                               },
-                              "default": "None",
-                              "sizes": {},
-                              "formats": {}
+                              "default" : "None",
+                              "sizes" : {
+                                
+                              },
+                              "formats" : {
+                                
+                              }
                             }
                           }
                         },
-                        "sizes": {},
-                        "formats": {
-                          "time": {
-                            "prefix": "",
-                            "fields": [
+                        "sizes" : {
+                          
+                        },
+                        "formats" : {
+                          "time" : {
+                            "prefix" : "",
+                            "fields" : [
                               [
                                 {
-                                  "Rational": {
-                                    "precision": "None",
-                                    "t": {
-                                      "Fixed": {}
+                                  "Rational" : {
+                                    "precision" : "None",
+                                    "t" : {
+                                      "Fixed" : {
+                                        
+                                      }
                                     }
                                   }
                                 },
@@ -2161,15 +2459,17 @@
                               ]
                             ]
                           },
-                          "value": {
-                            "prefix": "",
-                            "fields": [
+                          "value" : {
+                            "prefix" : "",
+                            "fields" : [
                               [
                                 {
-                                  "Rational": {
-                                    "precision": "None",
-                                    "t": {
-                                      "Fixed": {}
+                                  "Rational" : {
+                                    "precision" : "None",
+                                    "t" : {
+                                      "Fixed" : {
+                                        
+                                      }
                                     }
                                   }
                                 },
@@ -2181,328 +2481,396 @@
                       }
                     }
                   },
-                  "default": {
-                    "Some": {
-                      "anonArray": {
-                        "elements": [
+                  "default" : {
+                    "Some" : {
+                      "anonArray" : {
+                        "elements" : [
                           {
-                            "Struct": {
-                              "anonStruct": {
-                                "members": {
-                                  "time": {
-                                    "Float": {
-                                      "value": 0.0,
-                                      "kind": {
-                                        "F32": {}
+                            "Struct" : {
+                              "anonStruct" : {
+                                "members" : {
+                                  "time" : {
+                                    "Float" : {
+                                      "value" : 0.0,
+                                      "kind" : {
+                                        "F32" : {
+                                          
+                                        }
                                       }
                                     }
                                   },
-                                  "value": {
-                                    "Float": {
-                                      "value": 0.0,
-                                      "kind": {
-                                        "F32": {}
+                                  "value" : {
+                                    "Float" : {
+                                      "value" : 0.0,
+                                      "kind" : {
+                                        "F32" : {
+                                          
+                                        }
                                       }
                                     }
                                   }
                                 }
                               },
-                              "t": {
-                                "node": {
-                                  "astNodeId": 99
+                              "t" : {
+                                "node" : {
+                                  "astNodeId" : 99
                                 },
-                                "anonStruct": {
-                                  "members": {
-                                    "time": {
-                                      "Primitive": {
-                                        "Float": {
-                                          "kind": {
-                                            "F32": {}
+                                "anonStruct" : {
+                                  "members" : {
+                                    "time" : {
+                                      "Primitive" : {
+                                        "Float" : {
+                                          "kind" : {
+                                            "F32" : {
+                                              
+                                            }
                                           }
                                         }
                                       }
                                     },
-                                    "value": {
-                                      "Primitive": {
-                                        "Float": {
-                                          "kind": {
-                                            "F32": {}
+                                    "value" : {
+                                      "Primitive" : {
+                                        "Float" : {
+                                          "kind" : {
+                                            "F32" : {
+                                              
+                                            }
                                           }
                                         }
                                       }
                                     }
                                   }
                                 },
-                                "default": "None",
-                                "sizes": {},
-                                "formats": {}
+                                "default" : "None",
+                                "sizes" : {
+                                  
+                                },
+                                "formats" : {
+                                  
+                                }
                               }
                             }
                           },
                           {
-                            "Struct": {
-                              "anonStruct": {
-                                "members": {
-                                  "time": {
-                                    "Float": {
-                                      "value": 0.0,
-                                      "kind": {
-                                        "F32": {}
+                            "Struct" : {
+                              "anonStruct" : {
+                                "members" : {
+                                  "time" : {
+                                    "Float" : {
+                                      "value" : 0.0,
+                                      "kind" : {
+                                        "F32" : {
+                                          
+                                        }
                                       }
                                     }
                                   },
-                                  "value": {
-                                    "Float": {
-                                      "value": 0.0,
-                                      "kind": {
-                                        "F32": {}
+                                  "value" : {
+                                    "Float" : {
+                                      "value" : 0.0,
+                                      "kind" : {
+                                        "F32" : {
+                                          
+                                        }
                                       }
                                     }
                                   }
                                 }
                               },
-                              "t": {
-                                "node": {
-                                  "astNodeId": 99
+                              "t" : {
+                                "node" : {
+                                  "astNodeId" : 99
                                 },
-                                "anonStruct": {
-                                  "members": {
-                                    "time": {
-                                      "Primitive": {
-                                        "Float": {
-                                          "kind": {
-                                            "F32": {}
+                                "anonStruct" : {
+                                  "members" : {
+                                    "time" : {
+                                      "Primitive" : {
+                                        "Float" : {
+                                          "kind" : {
+                                            "F32" : {
+                                              
+                                            }
                                           }
                                         }
                                       }
                                     },
-                                    "value": {
-                                      "Primitive": {
-                                        "Float": {
-                                          "kind": {
-                                            "F32": {}
+                                    "value" : {
+                                      "Primitive" : {
+                                        "Float" : {
+                                          "kind" : {
+                                            "F32" : {
+                                              
+                                            }
                                           }
                                         }
                                       }
                                     }
                                   }
                                 },
-                                "default": "None",
-                                "sizes": {},
-                                "formats": {}
+                                "default" : "None",
+                                "sizes" : {
+                                  
+                                },
+                                "formats" : {
+                                  
+                                }
                               }
                             }
                           },
                           {
-                            "Struct": {
-                              "anonStruct": {
-                                "members": {
-                                  "time": {
-                                    "Float": {
-                                      "value": 0.0,
-                                      "kind": {
-                                        "F32": {}
+                            "Struct" : {
+                              "anonStruct" : {
+                                "members" : {
+                                  "time" : {
+                                    "Float" : {
+                                      "value" : 0.0,
+                                      "kind" : {
+                                        "F32" : {
+                                          
+                                        }
                                       }
                                     }
                                   },
-                                  "value": {
-                                    "Float": {
-                                      "value": 0.0,
-                                      "kind": {
-                                        "F32": {}
+                                  "value" : {
+                                    "Float" : {
+                                      "value" : 0.0,
+                                      "kind" : {
+                                        "F32" : {
+                                          
+                                        }
                                       }
                                     }
                                   }
                                 }
                               },
-                              "t": {
-                                "node": {
-                                  "astNodeId": 99
+                              "t" : {
+                                "node" : {
+                                  "astNodeId" : 99
                                 },
-                                "anonStruct": {
-                                  "members": {
-                                    "time": {
-                                      "Primitive": {
-                                        "Float": {
-                                          "kind": {
-                                            "F32": {}
+                                "anonStruct" : {
+                                  "members" : {
+                                    "time" : {
+                                      "Primitive" : {
+                                        "Float" : {
+                                          "kind" : {
+                                            "F32" : {
+                                              
+                                            }
                                           }
                                         }
                                       }
                                     },
-                                    "value": {
-                                      "Primitive": {
-                                        "Float": {
-                                          "kind": {
-                                            "F32": {}
+                                    "value" : {
+                                      "Primitive" : {
+                                        "Float" : {
+                                          "kind" : {
+                                            "F32" : {
+                                              
+                                            }
                                           }
                                         }
                                       }
                                     }
                                   }
                                 },
-                                "default": "None",
-                                "sizes": {},
-                                "formats": {}
+                                "default" : "None",
+                                "sizes" : {
+                                  
+                                },
+                                "formats" : {
+                                  
+                                }
                               }
                             }
                           },
                           {
-                            "Struct": {
-                              "anonStruct": {
-                                "members": {
-                                  "time": {
-                                    "Float": {
-                                      "value": 0.0,
-                                      "kind": {
-                                        "F32": {}
+                            "Struct" : {
+                              "anonStruct" : {
+                                "members" : {
+                                  "time" : {
+                                    "Float" : {
+                                      "value" : 0.0,
+                                      "kind" : {
+                                        "F32" : {
+                                          
+                                        }
                                       }
                                     }
                                   },
-                                  "value": {
-                                    "Float": {
-                                      "value": 0.0,
-                                      "kind": {
-                                        "F32": {}
+                                  "value" : {
+                                    "Float" : {
+                                      "value" : 0.0,
+                                      "kind" : {
+                                        "F32" : {
+                                          
+                                        }
                                       }
                                     }
                                   }
                                 }
                               },
-                              "t": {
-                                "node": {
-                                  "astNodeId": 99
+                              "t" : {
+                                "node" : {
+                                  "astNodeId" : 99
                                 },
-                                "anonStruct": {
-                                  "members": {
-                                    "time": {
-                                      "Primitive": {
-                                        "Float": {
-                                          "kind": {
-                                            "F32": {}
+                                "anonStruct" : {
+                                  "members" : {
+                                    "time" : {
+                                      "Primitive" : {
+                                        "Float" : {
+                                          "kind" : {
+                                            "F32" : {
+                                              
+                                            }
                                           }
                                         }
                                       }
                                     },
-                                    "value": {
-                                      "Primitive": {
-                                        "Float": {
-                                          "kind": {
-                                            "F32": {}
+                                    "value" : {
+                                      "Primitive" : {
+                                        "Float" : {
+                                          "kind" : {
+                                            "F32" : {
+                                              
+                                            }
                                           }
                                         }
                                       }
                                     }
                                   }
                                 },
-                                "default": "None",
-                                "sizes": {},
-                                "formats": {}
+                                "default" : "None",
+                                "sizes" : {
+                                  
+                                },
+                                "formats" : {
+                                  
+                                }
                               }
                             }
                           }
                         ]
                       },
-                      "t": {
-                        "node": {
-                          "astNodeId": 104
+                      "t" : {
+                        "node" : {
+                          "astNodeId" : 104
                         },
-                        "anonArray": {
-                          "size": {
-                            "Some": 4
+                        "anonArray" : {
+                          "size" : {
+                            "Some" : 4
                           },
-                          "eltType": {
-                            "Struct": {
-                              "node": {
-                                "astNodeId": 99
+                          "eltType" : {
+                            "Struct" : {
+                              "node" : {
+                                "astNodeId" : 99
                               },
-                              "anonStruct": {
-                                "members": {
-                                  "time": {
-                                    "Primitive": {
-                                      "Float": {
-                                        "kind": {
-                                          "F32": {}
+                              "anonStruct" : {
+                                "members" : {
+                                  "time" : {
+                                    "Primitive" : {
+                                      "Float" : {
+                                        "kind" : {
+                                          "F32" : {
+                                            
+                                          }
                                         }
                                       }
                                     }
                                   },
-                                  "value": {
-                                    "Primitive": {
-                                      "Float": {
-                                        "kind": {
-                                          "F32": {}
+                                  "value" : {
+                                    "Primitive" : {
+                                      "Float" : {
+                                        "kind" : {
+                                          "F32" : {
+                                            
+                                          }
                                         }
                                       }
                                     }
                                   }
                                 }
                               },
-                              "default": {
-                                "Some": {
-                                  "anonStruct": {
-                                    "members": {
-                                      "time": {
-                                        "Float": {
-                                          "value": 0.0,
-                                          "kind": {
-                                            "F32": {}
+                              "default" : {
+                                "Some" : {
+                                  "anonStruct" : {
+                                    "members" : {
+                                      "time" : {
+                                        "Float" : {
+                                          "value" : 0.0,
+                                          "kind" : {
+                                            "F32" : {
+                                              
+                                            }
                                           }
                                         }
                                       },
-                                      "value": {
-                                        "Float": {
-                                          "value": 0.0,
-                                          "kind": {
-                                            "F32": {}
+                                      "value" : {
+                                        "Float" : {
+                                          "value" : 0.0,
+                                          "kind" : {
+                                            "F32" : {
+                                              
+                                            }
                                           }
                                         }
                                       }
                                     }
                                   },
-                                  "t": {
-                                    "node": {
-                                      "astNodeId": 99
+                                  "t" : {
+                                    "node" : {
+                                      "astNodeId" : 99
                                     },
-                                    "anonStruct": {
-                                      "members": {
-                                        "time": {
-                                          "Primitive": {
-                                            "Float": {
-                                              "kind": {
-                                                "F32": {}
+                                    "anonStruct" : {
+                                      "members" : {
+                                        "time" : {
+                                          "Primitive" : {
+                                            "Float" : {
+                                              "kind" : {
+                                                "F32" : {
+                                                  
+                                                }
                                               }
                                             }
                                           }
                                         },
-                                        "value": {
-                                          "Primitive": {
-                                            "Float": {
-                                              "kind": {
-                                                "F32": {}
+                                        "value" : {
+                                          "Primitive" : {
+                                            "Float" : {
+                                              "kind" : {
+                                                "F32" : {
+                                                  
+                                                }
                                               }
                                             }
                                           }
                                         }
                                       }
                                     },
-                                    "default": "None",
-                                    "sizes": {},
-                                    "formats": {}
+                                    "default" : "None",
+                                    "sizes" : {
+                                      
+                                    },
+                                    "formats" : {
+                                      
+                                    }
                                   }
                                 }
                               },
-                              "sizes": {},
-                              "formats": {
-                                "time": {
-                                  "prefix": "",
-                                  "fields": [
+                              "sizes" : {
+                                
+                              },
+                              "formats" : {
+                                "time" : {
+                                  "prefix" : "",
+                                  "fields" : [
                                     [
                                       {
-                                        "Rational": {
-                                          "precision": "None",
-                                          "t": {
-                                            "Fixed": {}
+                                        "Rational" : {
+                                          "precision" : "None",
+                                          "t" : {
+                                            "Fixed" : {
+                                              
+                                            }
                                           }
                                         }
                                       },
@@ -2510,15 +2878,17 @@
                                     ]
                                   ]
                                 },
-                                "value": {
-                                  "prefix": "",
-                                  "fields": [
+                                "value" : {
+                                  "prefix" : "",
+                                  "fields" : [
                                     [
                                       {
-                                        "Rational": {
-                                          "precision": "None",
-                                          "t": {
-                                            "Fixed": {}
+                                        "Rational" : {
+                                          "precision" : "None",
+                                          "t" : {
+                                            "Fixed" : {
+                                              
+                                            }
                                           }
                                         }
                                       },
@@ -2530,419 +2900,502 @@
                             }
                           }
                         },
-                        "default": "None",
-                        "format": "None"
+                        "default" : "None",
+                        "format" : "None"
                       }
                     }
                   },
-                  "format": "None"
+                  "format" : "None"
                 }
               }
             }
           },
-          "default": {
-            "Some": {
-              "anonStruct": {
-                "members": {
-                  "type": {
-                    "EnumConstant": {
-                      "value": ["TRIANGLE", 0],
-                      "t": {
-                        "node": {
-                          "astNodeId": 115
+          "default" : {
+            "Some" : {
+              "anonStruct" : {
+                "members" : {
+                  "type" : {
+                    "EnumConstant" : {
+                      "value" : [
+                        "TRIANGLE",
+                        0
+                      ],
+                      "t" : {
+                        "node" : {
+                          "astNodeId" : 115
                         },
-                        "repType": {
-                          "kind": {
-                            "I32": {}
+                        "repType" : {
+                          "kind" : {
+                            "I32" : {
+                              
+                            }
                           }
                         },
-                        "default": "None"
+                        "default" : "None"
                       }
                     }
                   },
-                  "history": {
-                    "Array": {
-                      "anonArray": {
-                        "elements": [
+                  "history" : {
+                    "Array" : {
+                      "anonArray" : {
+                        "elements" : [
                           {
-                            "Float": {
-                              "value": 0.0,
-                              "kind": {
-                                "F32": {}
+                            "Float" : {
+                              "value" : 0.0,
+                              "kind" : {
+                                "F32" : {
+                                  
+                                }
                               }
                             }
                           },
                           {
-                            "Float": {
-                              "value": 0.0,
-                              "kind": {
-                                "F32": {}
+                            "Float" : {
+                              "value" : 0.0,
+                              "kind" : {
+                                "F32" : {
+                                  
+                                }
                               }
                             }
                           },
                           {
-                            "Float": {
-                              "value": 0.0,
-                              "kind": {
-                                "F32": {}
+                            "Float" : {
+                              "value" : 0.0,
+                              "kind" : {
+                                "F32" : {
+                                  
+                                }
                               }
                             }
                           },
                           {
-                            "Float": {
-                              "value": 0.0,
-                              "kind": {
-                                "F32": {}
+                            "Float" : {
+                              "value" : 0.0,
+                              "kind" : {
+                                "F32" : {
+                                  
+                                }
                               }
                             }
                           }
                         ]
                       },
-                      "t": {
-                        "node": {
-                          "astNodeId": 108
+                      "t" : {
+                        "node" : {
+                          "astNodeId" : 108
                         },
-                        "anonArray": {
-                          "size": {
-                            "Some": 4
+                        "anonArray" : {
+                          "size" : {
+                            "Some" : 4
                           },
-                          "eltType": {
-                            "Primitive": {
-                              "Float": {
-                                "kind": {
-                                  "F32": {}
+                          "eltType" : {
+                            "Primitive" : {
+                              "Float" : {
+                                "kind" : {
+                                  "F32" : {
+                                    
+                                  }
                                 }
                               }
                             }
                           }
                         },
-                        "default": "None",
-                        "format": "None"
+                        "default" : "None",
+                        "format" : "None"
                       }
                     }
                   },
-                  "pairHistory": {
-                    "Array": {
-                      "anonArray": {
-                        "elements": [
+                  "pairHistory" : {
+                    "Array" : {
+                      "anonArray" : {
+                        "elements" : [
                           {
-                            "Struct": {
-                              "anonStruct": {
-                                "members": {
-                                  "time": {
-                                    "Float": {
-                                      "value": 0.0,
-                                      "kind": {
-                                        "F32": {}
+                            "Struct" : {
+                              "anonStruct" : {
+                                "members" : {
+                                  "time" : {
+                                    "Float" : {
+                                      "value" : 0.0,
+                                      "kind" : {
+                                        "F32" : {
+                                          
+                                        }
                                       }
                                     }
                                   },
-                                  "value": {
-                                    "Float": {
-                                      "value": 0.0,
-                                      "kind": {
-                                        "F32": {}
+                                  "value" : {
+                                    "Float" : {
+                                      "value" : 0.0,
+                                      "kind" : {
+                                        "F32" : {
+                                          
+                                        }
                                       }
                                     }
                                   }
                                 }
                               },
-                              "t": {
-                                "node": {
-                                  "astNodeId": 99
+                              "t" : {
+                                "node" : {
+                                  "astNodeId" : 99
                                 },
-                                "anonStruct": {
-                                  "members": {
-                                    "time": {
-                                      "Primitive": {
-                                        "Float": {
-                                          "kind": {
-                                            "F32": {}
+                                "anonStruct" : {
+                                  "members" : {
+                                    "time" : {
+                                      "Primitive" : {
+                                        "Float" : {
+                                          "kind" : {
+                                            "F32" : {
+                                              
+                                            }
                                           }
                                         }
                                       }
                                     },
-                                    "value": {
-                                      "Primitive": {
-                                        "Float": {
-                                          "kind": {
-                                            "F32": {}
+                                    "value" : {
+                                      "Primitive" : {
+                                        "Float" : {
+                                          "kind" : {
+                                            "F32" : {
+                                              
+                                            }
                                           }
                                         }
                                       }
                                     }
                                   }
                                 },
-                                "default": "None",
-                                "sizes": {},
-                                "formats": {}
+                                "default" : "None",
+                                "sizes" : {
+                                  
+                                },
+                                "formats" : {
+                                  
+                                }
                               }
                             }
                           },
                           {
-                            "Struct": {
-                              "anonStruct": {
-                                "members": {
-                                  "time": {
-                                    "Float": {
-                                      "value": 0.0,
-                                      "kind": {
-                                        "F32": {}
+                            "Struct" : {
+                              "anonStruct" : {
+                                "members" : {
+                                  "time" : {
+                                    "Float" : {
+                                      "value" : 0.0,
+                                      "kind" : {
+                                        "F32" : {
+                                          
+                                        }
                                       }
                                     }
                                   },
-                                  "value": {
-                                    "Float": {
-                                      "value": 0.0,
-                                      "kind": {
-                                        "F32": {}
+                                  "value" : {
+                                    "Float" : {
+                                      "value" : 0.0,
+                                      "kind" : {
+                                        "F32" : {
+                                          
+                                        }
                                       }
                                     }
                                   }
                                 }
                               },
-                              "t": {
-                                "node": {
-                                  "astNodeId": 99
+                              "t" : {
+                                "node" : {
+                                  "astNodeId" : 99
                                 },
-                                "anonStruct": {
-                                  "members": {
-                                    "time": {
-                                      "Primitive": {
-                                        "Float": {
-                                          "kind": {
-                                            "F32": {}
+                                "anonStruct" : {
+                                  "members" : {
+                                    "time" : {
+                                      "Primitive" : {
+                                        "Float" : {
+                                          "kind" : {
+                                            "F32" : {
+                                              
+                                            }
                                           }
                                         }
                                       }
                                     },
-                                    "value": {
-                                      "Primitive": {
-                                        "Float": {
-                                          "kind": {
-                                            "F32": {}
+                                    "value" : {
+                                      "Primitive" : {
+                                        "Float" : {
+                                          "kind" : {
+                                            "F32" : {
+                                              
+                                            }
                                           }
                                         }
                                       }
                                     }
                                   }
                                 },
-                                "default": "None",
-                                "sizes": {},
-                                "formats": {}
+                                "default" : "None",
+                                "sizes" : {
+                                  
+                                },
+                                "formats" : {
+                                  
+                                }
                               }
                             }
                           },
                           {
-                            "Struct": {
-                              "anonStruct": {
-                                "members": {
-                                  "time": {
-                                    "Float": {
-                                      "value": 0.0,
-                                      "kind": {
-                                        "F32": {}
+                            "Struct" : {
+                              "anonStruct" : {
+                                "members" : {
+                                  "time" : {
+                                    "Float" : {
+                                      "value" : 0.0,
+                                      "kind" : {
+                                        "F32" : {
+                                          
+                                        }
                                       }
                                     }
                                   },
-                                  "value": {
-                                    "Float": {
-                                      "value": 0.0,
-                                      "kind": {
-                                        "F32": {}
+                                  "value" : {
+                                    "Float" : {
+                                      "value" : 0.0,
+                                      "kind" : {
+                                        "F32" : {
+                                          
+                                        }
                                       }
                                     }
                                   }
                                 }
                               },
-                              "t": {
-                                "node": {
-                                  "astNodeId": 99
+                              "t" : {
+                                "node" : {
+                                  "astNodeId" : 99
                                 },
-                                "anonStruct": {
-                                  "members": {
-                                    "time": {
-                                      "Primitive": {
-                                        "Float": {
-                                          "kind": {
-                                            "F32": {}
+                                "anonStruct" : {
+                                  "members" : {
+                                    "time" : {
+                                      "Primitive" : {
+                                        "Float" : {
+                                          "kind" : {
+                                            "F32" : {
+                                              
+                                            }
                                           }
                                         }
                                       }
                                     },
-                                    "value": {
-                                      "Primitive": {
-                                        "Float": {
-                                          "kind": {
-                                            "F32": {}
+                                    "value" : {
+                                      "Primitive" : {
+                                        "Float" : {
+                                          "kind" : {
+                                            "F32" : {
+                                              
+                                            }
                                           }
                                         }
                                       }
                                     }
                                   }
                                 },
-                                "default": "None",
-                                "sizes": {},
-                                "formats": {}
+                                "default" : "None",
+                                "sizes" : {
+                                  
+                                },
+                                "formats" : {
+                                  
+                                }
                               }
                             }
                           },
                           {
-                            "Struct": {
-                              "anonStruct": {
-                                "members": {
-                                  "time": {
-                                    "Float": {
-                                      "value": 0.0,
-                                      "kind": {
-                                        "F32": {}
+                            "Struct" : {
+                              "anonStruct" : {
+                                "members" : {
+                                  "time" : {
+                                    "Float" : {
+                                      "value" : 0.0,
+                                      "kind" : {
+                                        "F32" : {
+                                          
+                                        }
                                       }
                                     }
                                   },
-                                  "value": {
-                                    "Float": {
-                                      "value": 0.0,
-                                      "kind": {
-                                        "F32": {}
+                                  "value" : {
+                                    "Float" : {
+                                      "value" : 0.0,
+                                      "kind" : {
+                                        "F32" : {
+                                          
+                                        }
                                       }
                                     }
                                   }
                                 }
                               },
-                              "t": {
-                                "node": {
-                                  "astNodeId": 99
+                              "t" : {
+                                "node" : {
+                                  "astNodeId" : 99
                                 },
-                                "anonStruct": {
-                                  "members": {
-                                    "time": {
-                                      "Primitive": {
-                                        "Float": {
-                                          "kind": {
-                                            "F32": {}
+                                "anonStruct" : {
+                                  "members" : {
+                                    "time" : {
+                                      "Primitive" : {
+                                        "Float" : {
+                                          "kind" : {
+                                            "F32" : {
+                                              
+                                            }
                                           }
                                         }
                                       }
                                     },
-                                    "value": {
-                                      "Primitive": {
-                                        "Float": {
-                                          "kind": {
-                                            "F32": {}
+                                    "value" : {
+                                      "Primitive" : {
+                                        "Float" : {
+                                          "kind" : {
+                                            "F32" : {
+                                              
+                                            }
                                           }
                                         }
                                       }
                                     }
                                   }
                                 },
-                                "default": "None",
-                                "sizes": {},
-                                "formats": {}
+                                "default" : "None",
+                                "sizes" : {
+                                  
+                                },
+                                "formats" : {
+                                  
+                                }
                               }
                             }
                           }
                         ]
                       },
-                      "t": {
-                        "node": {
-                          "astNodeId": 104
+                      "t" : {
+                        "node" : {
+                          "astNodeId" : 104
                         },
-                        "anonArray": {
-                          "size": {
-                            "Some": 4
+                        "anonArray" : {
+                          "size" : {
+                            "Some" : 4
                           },
-                          "eltType": {
-                            "Struct": {
-                              "node": {
-                                "astNodeId": 99
+                          "eltType" : {
+                            "Struct" : {
+                              "node" : {
+                                "astNodeId" : 99
                               },
-                              "anonStruct": {
-                                "members": {
-                                  "time": {
-                                    "Primitive": {
-                                      "Float": {
-                                        "kind": {
-                                          "F32": {}
+                              "anonStruct" : {
+                                "members" : {
+                                  "time" : {
+                                    "Primitive" : {
+                                      "Float" : {
+                                        "kind" : {
+                                          "F32" : {
+                                            
+                                          }
                                         }
                                       }
                                     }
                                   },
-                                  "value": {
-                                    "Primitive": {
-                                      "Float": {
-                                        "kind": {
-                                          "F32": {}
+                                  "value" : {
+                                    "Primitive" : {
+                                      "Float" : {
+                                        "kind" : {
+                                          "F32" : {
+                                            
+                                          }
                                         }
                                       }
                                     }
                                   }
                                 }
                               },
-                              "default": {
-                                "Some": {
-                                  "anonStruct": {
-                                    "members": {
-                                      "time": {
-                                        "Float": {
-                                          "value": 0.0,
-                                          "kind": {
-                                            "F32": {}
+                              "default" : {
+                                "Some" : {
+                                  "anonStruct" : {
+                                    "members" : {
+                                      "time" : {
+                                        "Float" : {
+                                          "value" : 0.0,
+                                          "kind" : {
+                                            "F32" : {
+                                              
+                                            }
                                           }
                                         }
                                       },
-                                      "value": {
-                                        "Float": {
-                                          "value": 0.0,
-                                          "kind": {
-                                            "F32": {}
+                                      "value" : {
+                                        "Float" : {
+                                          "value" : 0.0,
+                                          "kind" : {
+                                            "F32" : {
+                                              
+                                            }
                                           }
                                         }
                                       }
                                     }
                                   },
-                                  "t": {
-                                    "node": {
-                                      "astNodeId": 99
+                                  "t" : {
+                                    "node" : {
+                                      "astNodeId" : 99
                                     },
-                                    "anonStruct": {
-                                      "members": {
-                                        "time": {
-                                          "Primitive": {
-                                            "Float": {
-                                              "kind": {
-                                                "F32": {}
+                                    "anonStruct" : {
+                                      "members" : {
+                                        "time" : {
+                                          "Primitive" : {
+                                            "Float" : {
+                                              "kind" : {
+                                                "F32" : {
+                                                  
+                                                }
                                               }
                                             }
                                           }
                                         },
-                                        "value": {
-                                          "Primitive": {
-                                            "Float": {
-                                              "kind": {
-                                                "F32": {}
+                                        "value" : {
+                                          "Primitive" : {
+                                            "Float" : {
+                                              "kind" : {
+                                                "F32" : {
+                                                  
+                                                }
                                               }
                                             }
                                           }
                                         }
                                       }
                                     },
-                                    "default": "None",
-                                    "sizes": {},
-                                    "formats": {}
+                                    "default" : "None",
+                                    "sizes" : {
+                                      
+                                    },
+                                    "formats" : {
+                                      
+                                    }
                                   }
                                 }
                               },
-                              "sizes": {},
-                              "formats": {
-                                "time": {
-                                  "prefix": "",
-                                  "fields": [
+                              "sizes" : {
+                                
+                              },
+                              "formats" : {
+                                "time" : {
+                                  "prefix" : "",
+                                  "fields" : [
                                     [
                                       {
-                                        "Rational": {
-                                          "precision": "None",
-                                          "t": {
-                                            "Fixed": {}
+                                        "Rational" : {
+                                          "precision" : "None",
+                                          "t" : {
+                                            "Fixed" : {
+                                              
+                                            }
                                           }
                                         }
                                       },
@@ -2950,15 +3403,17 @@
                                     ]
                                   ]
                                 },
-                                "value": {
-                                  "prefix": "",
-                                  "fields": [
+                                "value" : {
+                                  "prefix" : "",
+                                  "fields" : [
                                     [
                                       {
-                                        "Rational": {
-                                          "precision": "None",
-                                          "t": {
-                                            "Fixed": {}
+                                        "Rational" : {
+                                          "precision" : "None",
+                                          "t" : {
+                                            "Fixed" : {
+                                              
+                                            }
                                           }
                                         }
                                       },
@@ -2970,137 +3425,158 @@
                             }
                           }
                         },
-                        "default": "None",
-                        "format": "None"
+                        "default" : "None",
+                        "format" : "None"
                       }
                     }
                   }
                 }
               },
-              "t": {
-                "node": {
-                  "astNodeId": 86
+              "t" : {
+                "node" : {
+                  "astNodeId" : 86
                 },
-                "anonStruct": {
-                  "members": {
-                    "type": {
-                      "Enum": {
-                        "node": {
-                          "astNodeId": 115
+                "anonStruct" : {
+                  "members" : {
+                    "type" : {
+                      "Enum" : {
+                        "node" : {
+                          "astNodeId" : 115
                         },
-                        "repType": {
-                          "kind": {
-                            "I32": {}
+                        "repType" : {
+                          "kind" : {
+                            "I32" : {
+                              
+                            }
                           }
                         },
-                        "default": {
-                          "Some": {
-                            "value": ["TRIANGLE", 0],
-                            "t": {
-                              "node": {
-                                "astNodeId": 115
+                        "default" : {
+                          "Some" : {
+                            "value" : [
+                              "TRIANGLE",
+                              0
+                            ],
+                            "t" : {
+                              "node" : {
+                                "astNodeId" : 115
                               },
-                              "repType": {
-                                "kind": {
-                                  "I32": {}
+                              "repType" : {
+                                "kind" : {
+                                  "I32" : {
+                                    
+                                  }
                                 }
                               },
-                              "default": "None"
+                              "default" : "None"
                             }
                           }
                         }
                       }
                     },
-                    "history": {
-                      "Array": {
-                        "node": {
-                          "astNodeId": 108
+                    "history" : {
+                      "Array" : {
+                        "node" : {
+                          "astNodeId" : 108
                         },
-                        "anonArray": {
-                          "size": {
-                            "Some": 4
+                        "anonArray" : {
+                          "size" : {
+                            "Some" : 4
                           },
-                          "eltType": {
-                            "Primitive": {
-                              "Float": {
-                                "kind": {
-                                  "F32": {}
+                          "eltType" : {
+                            "Primitive" : {
+                              "Float" : {
+                                "kind" : {
+                                  "F32" : {
+                                    
+                                  }
                                 }
                               }
                             }
                           }
                         },
-                        "default": {
-                          "Some": {
-                            "anonArray": {
-                              "elements": [
+                        "default" : {
+                          "Some" : {
+                            "anonArray" : {
+                              "elements" : [
                                 {
-                                  "Float": {
-                                    "value": 0.0,
-                                    "kind": {
-                                      "F32": {}
+                                  "Float" : {
+                                    "value" : 0.0,
+                                    "kind" : {
+                                      "F32" : {
+                                        
+                                      }
                                     }
                                   }
                                 },
                                 {
-                                  "Float": {
-                                    "value": 0.0,
-                                    "kind": {
-                                      "F32": {}
+                                  "Float" : {
+                                    "value" : 0.0,
+                                    "kind" : {
+                                      "F32" : {
+                                        
+                                      }
                                     }
                                   }
                                 },
                                 {
-                                  "Float": {
-                                    "value": 0.0,
-                                    "kind": {
-                                      "F32": {}
+                                  "Float" : {
+                                    "value" : 0.0,
+                                    "kind" : {
+                                      "F32" : {
+                                        
+                                      }
                                     }
                                   }
                                 },
                                 {
-                                  "Float": {
-                                    "value": 0.0,
-                                    "kind": {
-                                      "F32": {}
+                                  "Float" : {
+                                    "value" : 0.0,
+                                    "kind" : {
+                                      "F32" : {
+                                        
+                                      }
                                     }
                                   }
                                 }
                               ]
                             },
-                            "t": {
-                              "node": {
-                                "astNodeId": 108
+                            "t" : {
+                              "node" : {
+                                "astNodeId" : 108
                               },
-                              "anonArray": {
-                                "size": {
-                                  "Some": 4
+                              "anonArray" : {
+                                "size" : {
+                                  "Some" : 4
                                 },
-                                "eltType": {
-                                  "Primitive": {
-                                    "Float": {
-                                      "kind": {
-                                        "F32": {}
+                                "eltType" : {
+                                  "Primitive" : {
+                                    "Float" : {
+                                      "kind" : {
+                                        "F32" : {
+                                          
+                                        }
                                       }
                                     }
                                   }
                                 }
                               },
-                              "default": "None",
-                              "format": "None"
+                              "default" : "None",
+                              "format" : "None"
                             }
                           }
                         },
-                        "format": {
-                          "Some": {
-                            "prefix": "",
-                            "fields": [
+                        "format" : {
+                          "Some" : {
+                            "prefix" : "",
+                            "fields" : [
                               [
                                 {
-                                  "Rational": {
-                                    "precision": "None",
-                                    "t": {
-                                      "Fixed": {}
+                                  "Rational" : {
+                                    "precision" : "None",
+                                    "t" : {
+                                      "Fixed" : {
+                                        
+                                      }
                                     }
                                   }
                                 },
@@ -3111,107 +3587,127 @@
                         }
                       }
                     },
-                    "pairHistory": {
-                      "Array": {
-                        "node": {
-                          "astNodeId": 104
+                    "pairHistory" : {
+                      "Array" : {
+                        "node" : {
+                          "astNodeId" : 104
                         },
-                        "anonArray": {
-                          "size": {
-                            "Some": 4
+                        "anonArray" : {
+                          "size" : {
+                            "Some" : 4
                           },
-                          "eltType": {
-                            "Struct": {
-                              "node": {
-                                "astNodeId": 99
+                          "eltType" : {
+                            "Struct" : {
+                              "node" : {
+                                "astNodeId" : 99
                               },
-                              "anonStruct": {
-                                "members": {
-                                  "time": {
-                                    "Primitive": {
-                                      "Float": {
-                                        "kind": {
-                                          "F32": {}
+                              "anonStruct" : {
+                                "members" : {
+                                  "time" : {
+                                    "Primitive" : {
+                                      "Float" : {
+                                        "kind" : {
+                                          "F32" : {
+                                            
+                                          }
                                         }
                                       }
                                     }
                                   },
-                                  "value": {
-                                    "Primitive": {
-                                      "Float": {
-                                        "kind": {
-                                          "F32": {}
+                                  "value" : {
+                                    "Primitive" : {
+                                      "Float" : {
+                                        "kind" : {
+                                          "F32" : {
+                                            
+                                          }
                                         }
                                       }
                                     }
                                   }
                                 }
                               },
-                              "default": {
-                                "Some": {
-                                  "anonStruct": {
-                                    "members": {
-                                      "time": {
-                                        "Float": {
-                                          "value": 0.0,
-                                          "kind": {
-                                            "F32": {}
+                              "default" : {
+                                "Some" : {
+                                  "anonStruct" : {
+                                    "members" : {
+                                      "time" : {
+                                        "Float" : {
+                                          "value" : 0.0,
+                                          "kind" : {
+                                            "F32" : {
+                                              
+                                            }
                                           }
                                         }
                                       },
-                                      "value": {
-                                        "Float": {
-                                          "value": 0.0,
-                                          "kind": {
-                                            "F32": {}
+                                      "value" : {
+                                        "Float" : {
+                                          "value" : 0.0,
+                                          "kind" : {
+                                            "F32" : {
+                                              
+                                            }
                                           }
                                         }
                                       }
                                     }
                                   },
-                                  "t": {
-                                    "node": {
-                                      "astNodeId": 99
+                                  "t" : {
+                                    "node" : {
+                                      "astNodeId" : 99
                                     },
-                                    "anonStruct": {
-                                      "members": {
-                                        "time": {
-                                          "Primitive": {
-                                            "Float": {
-                                              "kind": {
-                                                "F32": {}
+                                    "anonStruct" : {
+                                      "members" : {
+                                        "time" : {
+                                          "Primitive" : {
+                                            "Float" : {
+                                              "kind" : {
+                                                "F32" : {
+                                                  
+                                                }
                                               }
                                             }
                                           }
                                         },
-                                        "value": {
-                                          "Primitive": {
-                                            "Float": {
-                                              "kind": {
-                                                "F32": {}
+                                        "value" : {
+                                          "Primitive" : {
+                                            "Float" : {
+                                              "kind" : {
+                                                "F32" : {
+                                                  
+                                                }
                                               }
                                             }
                                           }
                                         }
                                       }
                                     },
-                                    "default": "None",
-                                    "sizes": {},
-                                    "formats": {}
+                                    "default" : "None",
+                                    "sizes" : {
+                                      
+                                    },
+                                    "formats" : {
+                                      
+                                    }
                                   }
                                 }
                               },
-                              "sizes": {},
-                              "formats": {
-                                "time": {
-                                  "prefix": "",
-                                  "fields": [
+                              "sizes" : {
+                                
+                              },
+                              "formats" : {
+                                "time" : {
+                                  "prefix" : "",
+                                  "fields" : [
                                     [
                                       {
-                                        "Rational": {
-                                          "precision": "None",
-                                          "t": {
-                                            "Fixed": {}
+                                        "Rational" : {
+                                          "precision" : "None",
+                                          "t" : {
+                                            "Fixed" : {
+                                              
+                                            }
                                           }
                                         }
                                       },
@@ -3219,15 +3715,17 @@
                                     ]
                                   ]
                                 },
-                                "value": {
-                                  "prefix": "",
-                                  "fields": [
+                                "value" : {
+                                  "prefix" : "",
+                                  "fields" : [
                                     [
                                       {
-                                        "Rational": {
-                                          "precision": "None",
-                                          "t": {
-                                            "Fixed": {}
+                                        "Rational" : {
+                                          "precision" : "None",
+                                          "t" : {
+                                            "Fixed" : {
+                                              
+                                            }
                                           }
                                         }
                                       },
@@ -3239,328 +3737,396 @@
                             }
                           }
                         },
-                        "default": {
-                          "Some": {
-                            "anonArray": {
-                              "elements": [
+                        "default" : {
+                          "Some" : {
+                            "anonArray" : {
+                              "elements" : [
                                 {
-                                  "Struct": {
-                                    "anonStruct": {
-                                      "members": {
-                                        "time": {
-                                          "Float": {
-                                            "value": 0.0,
-                                            "kind": {
-                                              "F32": {}
+                                  "Struct" : {
+                                    "anonStruct" : {
+                                      "members" : {
+                                        "time" : {
+                                          "Float" : {
+                                            "value" : 0.0,
+                                            "kind" : {
+                                              "F32" : {
+                                                
+                                              }
                                             }
                                           }
                                         },
-                                        "value": {
-                                          "Float": {
-                                            "value": 0.0,
-                                            "kind": {
-                                              "F32": {}
+                                        "value" : {
+                                          "Float" : {
+                                            "value" : 0.0,
+                                            "kind" : {
+                                              "F32" : {
+                                                
+                                              }
                                             }
                                           }
                                         }
                                       }
                                     },
-                                    "t": {
-                                      "node": {
-                                        "astNodeId": 99
+                                    "t" : {
+                                      "node" : {
+                                        "astNodeId" : 99
                                       },
-                                      "anonStruct": {
-                                        "members": {
-                                          "time": {
-                                            "Primitive": {
-                                              "Float": {
-                                                "kind": {
-                                                  "F32": {}
+                                      "anonStruct" : {
+                                        "members" : {
+                                          "time" : {
+                                            "Primitive" : {
+                                              "Float" : {
+                                                "kind" : {
+                                                  "F32" : {
+                                                    
+                                                  }
                                                 }
                                               }
                                             }
                                           },
-                                          "value": {
-                                            "Primitive": {
-                                              "Float": {
-                                                "kind": {
-                                                  "F32": {}
+                                          "value" : {
+                                            "Primitive" : {
+                                              "Float" : {
+                                                "kind" : {
+                                                  "F32" : {
+                                                    
+                                                  }
                                                 }
                                               }
                                             }
                                           }
                                         }
                                       },
-                                      "default": "None",
-                                      "sizes": {},
-                                      "formats": {}
+                                      "default" : "None",
+                                      "sizes" : {
+                                        
+                                      },
+                                      "formats" : {
+                                        
+                                      }
                                     }
                                   }
                                 },
                                 {
-                                  "Struct": {
-                                    "anonStruct": {
-                                      "members": {
-                                        "time": {
-                                          "Float": {
-                                            "value": 0.0,
-                                            "kind": {
-                                              "F32": {}
+                                  "Struct" : {
+                                    "anonStruct" : {
+                                      "members" : {
+                                        "time" : {
+                                          "Float" : {
+                                            "value" : 0.0,
+                                            "kind" : {
+                                              "F32" : {
+                                                
+                                              }
                                             }
                                           }
                                         },
-                                        "value": {
-                                          "Float": {
-                                            "value": 0.0,
-                                            "kind": {
-                                              "F32": {}
+                                        "value" : {
+                                          "Float" : {
+                                            "value" : 0.0,
+                                            "kind" : {
+                                              "F32" : {
+                                                
+                                              }
                                             }
                                           }
                                         }
                                       }
                                     },
-                                    "t": {
-                                      "node": {
-                                        "astNodeId": 99
+                                    "t" : {
+                                      "node" : {
+                                        "astNodeId" : 99
                                       },
-                                      "anonStruct": {
-                                        "members": {
-                                          "time": {
-                                            "Primitive": {
-                                              "Float": {
-                                                "kind": {
-                                                  "F32": {}
+                                      "anonStruct" : {
+                                        "members" : {
+                                          "time" : {
+                                            "Primitive" : {
+                                              "Float" : {
+                                                "kind" : {
+                                                  "F32" : {
+                                                    
+                                                  }
                                                 }
                                               }
                                             }
                                           },
-                                          "value": {
-                                            "Primitive": {
-                                              "Float": {
-                                                "kind": {
-                                                  "F32": {}
+                                          "value" : {
+                                            "Primitive" : {
+                                              "Float" : {
+                                                "kind" : {
+                                                  "F32" : {
+                                                    
+                                                  }
                                                 }
                                               }
                                             }
                                           }
                                         }
                                       },
-                                      "default": "None",
-                                      "sizes": {},
-                                      "formats": {}
+                                      "default" : "None",
+                                      "sizes" : {
+                                        
+                                      },
+                                      "formats" : {
+                                        
+                                      }
                                     }
                                   }
                                 },
                                 {
-                                  "Struct": {
-                                    "anonStruct": {
-                                      "members": {
-                                        "time": {
-                                          "Float": {
-                                            "value": 0.0,
-                                            "kind": {
-                                              "F32": {}
+                                  "Struct" : {
+                                    "anonStruct" : {
+                                      "members" : {
+                                        "time" : {
+                                          "Float" : {
+                                            "value" : 0.0,
+                                            "kind" : {
+                                              "F32" : {
+                                                
+                                              }
                                             }
                                           }
                                         },
-                                        "value": {
-                                          "Float": {
-                                            "value": 0.0,
-                                            "kind": {
-                                              "F32": {}
+                                        "value" : {
+                                          "Float" : {
+                                            "value" : 0.0,
+                                            "kind" : {
+                                              "F32" : {
+                                                
+                                              }
                                             }
                                           }
                                         }
                                       }
                                     },
-                                    "t": {
-                                      "node": {
-                                        "astNodeId": 99
+                                    "t" : {
+                                      "node" : {
+                                        "astNodeId" : 99
                                       },
-                                      "anonStruct": {
-                                        "members": {
-                                          "time": {
-                                            "Primitive": {
-                                              "Float": {
-                                                "kind": {
-                                                  "F32": {}
+                                      "anonStruct" : {
+                                        "members" : {
+                                          "time" : {
+                                            "Primitive" : {
+                                              "Float" : {
+                                                "kind" : {
+                                                  "F32" : {
+                                                    
+                                                  }
                                                 }
                                               }
                                             }
                                           },
-                                          "value": {
-                                            "Primitive": {
-                                              "Float": {
-                                                "kind": {
-                                                  "F32": {}
+                                          "value" : {
+                                            "Primitive" : {
+                                              "Float" : {
+                                                "kind" : {
+                                                  "F32" : {
+                                                    
+                                                  }
                                                 }
                                               }
                                             }
                                           }
                                         }
                                       },
-                                      "default": "None",
-                                      "sizes": {},
-                                      "formats": {}
+                                      "default" : "None",
+                                      "sizes" : {
+                                        
+                                      },
+                                      "formats" : {
+                                        
+                                      }
                                     }
                                   }
                                 },
                                 {
-                                  "Struct": {
-                                    "anonStruct": {
-                                      "members": {
-                                        "time": {
-                                          "Float": {
-                                            "value": 0.0,
-                                            "kind": {
-                                              "F32": {}
+                                  "Struct" : {
+                                    "anonStruct" : {
+                                      "members" : {
+                                        "time" : {
+                                          "Float" : {
+                                            "value" : 0.0,
+                                            "kind" : {
+                                              "F32" : {
+                                                
+                                              }
                                             }
                                           }
                                         },
-                                        "value": {
-                                          "Float": {
-                                            "value": 0.0,
-                                            "kind": {
-                                              "F32": {}
+                                        "value" : {
+                                          "Float" : {
+                                            "value" : 0.0,
+                                            "kind" : {
+                                              "F32" : {
+                                                
+                                              }
                                             }
                                           }
                                         }
                                       }
                                     },
-                                    "t": {
-                                      "node": {
-                                        "astNodeId": 99
+                                    "t" : {
+                                      "node" : {
+                                        "astNodeId" : 99
                                       },
-                                      "anonStruct": {
-                                        "members": {
-                                          "time": {
-                                            "Primitive": {
-                                              "Float": {
-                                                "kind": {
-                                                  "F32": {}
+                                      "anonStruct" : {
+                                        "members" : {
+                                          "time" : {
+                                            "Primitive" : {
+                                              "Float" : {
+                                                "kind" : {
+                                                  "F32" : {
+                                                    
+                                                  }
                                                 }
                                               }
                                             }
                                           },
-                                          "value": {
-                                            "Primitive": {
-                                              "Float": {
-                                                "kind": {
-                                                  "F32": {}
+                                          "value" : {
+                                            "Primitive" : {
+                                              "Float" : {
+                                                "kind" : {
+                                                  "F32" : {
+                                                    
+                                                  }
                                                 }
                                               }
                                             }
                                           }
                                         }
                                       },
-                                      "default": "None",
-                                      "sizes": {},
-                                      "formats": {}
+                                      "default" : "None",
+                                      "sizes" : {
+                                        
+                                      },
+                                      "formats" : {
+                                        
+                                      }
                                     }
                                   }
                                 }
                               ]
                             },
-                            "t": {
-                              "node": {
-                                "astNodeId": 104
+                            "t" : {
+                              "node" : {
+                                "astNodeId" : 104
                               },
-                              "anonArray": {
-                                "size": {
-                                  "Some": 4
+                              "anonArray" : {
+                                "size" : {
+                                  "Some" : 4
                                 },
-                                "eltType": {
-                                  "Struct": {
-                                    "node": {
-                                      "astNodeId": 99
+                                "eltType" : {
+                                  "Struct" : {
+                                    "node" : {
+                                      "astNodeId" : 99
                                     },
-                                    "anonStruct": {
-                                      "members": {
-                                        "time": {
-                                          "Primitive": {
-                                            "Float": {
-                                              "kind": {
-                                                "F32": {}
+                                    "anonStruct" : {
+                                      "members" : {
+                                        "time" : {
+                                          "Primitive" : {
+                                            "Float" : {
+                                              "kind" : {
+                                                "F32" : {
+                                                  
+                                                }
                                               }
                                             }
                                           }
                                         },
-                                        "value": {
-                                          "Primitive": {
-                                            "Float": {
-                                              "kind": {
-                                                "F32": {}
+                                        "value" : {
+                                          "Primitive" : {
+                                            "Float" : {
+                                              "kind" : {
+                                                "F32" : {
+                                                  
+                                                }
                                               }
                                             }
                                           }
                                         }
                                       }
                                     },
-                                    "default": {
-                                      "Some": {
-                                        "anonStruct": {
-                                          "members": {
-                                            "time": {
-                                              "Float": {
-                                                "value": 0.0,
-                                                "kind": {
-                                                  "F32": {}
+                                    "default" : {
+                                      "Some" : {
+                                        "anonStruct" : {
+                                          "members" : {
+                                            "time" : {
+                                              "Float" : {
+                                                "value" : 0.0,
+                                                "kind" : {
+                                                  "F32" : {
+                                                    
+                                                  }
                                                 }
                                               }
                                             },
-                                            "value": {
-                                              "Float": {
-                                                "value": 0.0,
-                                                "kind": {
-                                                  "F32": {}
+                                            "value" : {
+                                              "Float" : {
+                                                "value" : 0.0,
+                                                "kind" : {
+                                                  "F32" : {
+                                                    
+                                                  }
                                                 }
                                               }
                                             }
                                           }
                                         },
-                                        "t": {
-                                          "node": {
-                                            "astNodeId": 99
+                                        "t" : {
+                                          "node" : {
+                                            "astNodeId" : 99
                                           },
-                                          "anonStruct": {
-                                            "members": {
-                                              "time": {
-                                                "Primitive": {
-                                                  "Float": {
-                                                    "kind": {
-                                                      "F32": {}
+                                          "anonStruct" : {
+                                            "members" : {
+                                              "time" : {
+                                                "Primitive" : {
+                                                  "Float" : {
+                                                    "kind" : {
+                                                      "F32" : {
+                                                        
+                                                      }
                                                     }
                                                   }
                                                 }
                                               },
-                                              "value": {
-                                                "Primitive": {
-                                                  "Float": {
-                                                    "kind": {
-                                                      "F32": {}
+                                              "value" : {
+                                                "Primitive" : {
+                                                  "Float" : {
+                                                    "kind" : {
+                                                      "F32" : {
+                                                        
+                                                      }
                                                     }
                                                   }
                                                 }
                                               }
                                             }
                                           },
-                                          "default": "None",
-                                          "sizes": {},
-                                          "formats": {}
+                                          "default" : "None",
+                                          "sizes" : {
+                                            
+                                          },
+                                          "formats" : {
+                                            
+                                          }
                                         }
                                       }
                                     },
-                                    "sizes": {},
-                                    "formats": {
-                                      "time": {
-                                        "prefix": "",
-                                        "fields": [
+                                    "sizes" : {
+                                      
+                                    },
+                                    "formats" : {
+                                      "time" : {
+                                        "prefix" : "",
+                                        "fields" : [
                                           [
                                             {
-                                              "Rational": {
-                                                "precision": "None",
-                                                "t": {
-                                                  "Fixed": {}
+                                              "Rational" : {
+                                                "precision" : "None",
+                                                "t" : {
+                                                  "Fixed" : {
+                                                    
+                                                  }
                                                 }
                                               }
                                             },
@@ -3568,15 +4134,17 @@
                                           ]
                                         ]
                                       },
-                                      "value": {
-                                        "prefix": "",
-                                        "fields": [
+                                      "value" : {
+                                        "prefix" : "",
+                                        "fields" : [
                                           [
                                             {
-                                              "Rational": {
-                                                "precision": "None",
-                                                "t": {
-                                                  "Fixed": {}
+                                              "Rational" : {
+                                                "precision" : "None",
+                                                "t" : {
+                                                  "Fixed" : {
+                                                    
+                                                  }
                                                 }
                                               }
                                             },
@@ -3588,412 +4156,452 @@
                                   }
                                 }
                               },
-                              "default": "None",
-                              "format": "None"
+                              "default" : "None",
+                              "format" : "None"
                             }
                           }
                         },
-                        "format": "None"
+                        "format" : "None"
                       }
                     }
                   }
                 },
-                "default": "None",
-                "sizes": {},
-                "formats": {}
+                "default" : "None",
+                "sizes" : {
+                  
+                },
+                "formats" : {
+                  
+                }
               }
             }
           },
-          "sizes": {},
-          "formats": {}
+          "sizes" : {
+            
+          },
+          "formats" : {
+            
+          }
         }
       },
-      "38": {
-        "AnonStruct": {
-          "members": {
-            "x": {
-              "Int": {
-                "Integer": {}
+      "38" : {
+        "AnonStruct" : {
+          "members" : {
+            "x" : {
+              "Int" : {
+                "Integer" : {
+                  
+                }
               }
             },
-            "y": {
-              "String": {
-                "size": "None"
+            "y" : {
+              "String" : {
+                "size" : "None"
               }
             }
           }
         }
       },
-      "7": {
-        "String": {
-          "size": "None"
+      "7" : {
+        "String" : {
+          "size" : "None"
         }
       },
-      "114": {
-        "Enum": {
-          "node": {
-            "astNodeId": 115
+      "114" : {
+        "Enum" : {
+          "node" : {
+            "astNodeId" : 115
           },
-          "repType": {
-            "kind": {
-              "I32": {}
+          "repType" : {
+            "kind" : {
+              "I32" : {
+                
+              }
             }
           },
-          "default": "None"
+          "default" : "None"
         }
       },
-      "105": {
-        "Int": {
-          "Integer": {}
+      "105" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       },
-      "3": {
-        "Int": {
-          "Integer": {}
+      "3" : {
+        "Int" : {
+          "Integer" : {
+            
+          }
         }
       }
     },
-    "useDefMap": {
-      "67": {
-        "Enum": {
-          "nodeId": 115,
-          "unqualifiedName": "SignalType"
+    "useDefMap" : {
+      "67" : {
+        "Enum" : {
+          "nodeId" : 115,
+          "unqualifiedName" : "SignalType"
         }
       },
-      "84": {
-        "Array": {
-          "nodeId": 104,
-          "unqualifiedName": "SignalPairSet"
+      "84" : {
+        "Array" : {
+          "nodeId" : 104,
+          "unqualifiedName" : "SignalPairSet"
         }
       },
-      "68": {
-        "Enum": {
-          "nodeId": 115,
-          "unqualifiedName": "SignalType"
+      "68" : {
+        "Enum" : {
+          "nodeId" : 115,
+          "unqualifiedName" : "SignalType"
         }
       },
-      "13": {
-        "Array": {
-          "nodeId": 10,
-          "unqualifiedName": "A"
+      "13" : {
+        "Array" : {
+          "nodeId" : 10,
+          "unqualifiedName" : "A"
         }
       },
-      "83": {
-        "Array": {
-          "nodeId": 104,
-          "unqualifiedName": "SignalPairSet"
+      "83" : {
+        "Array" : {
+          "nodeId" : 104,
+          "unqualifiedName" : "SignalPairSet"
         }
       },
-      "48": {
-        "Constant": {
-          "nodeId": 39,
-          "unqualifiedName": "s"
+      "48" : {
+        "Constant" : {
+          "nodeId" : 39,
+          "unqualifiedName" : "s"
         }
       },
-      "71": {
-        "Array": {
-          "nodeId": 108,
-          "unqualifiedName": "SignalSet"
+      "71" : {
+        "Array" : {
+          "nodeId" : 108,
+          "unqualifiedName" : "SignalSet"
         }
       },
-      "14": {
-        "Array": {
-          "nodeId": 10,
-          "unqualifiedName": "A"
+      "14" : {
+        "Array" : {
+          "nodeId" : 10,
+          "unqualifiedName" : "A"
         }
       },
-      "102": {
-        "Struct": {
-          "nodeId": 99,
-          "unqualifiedName": "SignalPair"
+      "102" : {
+        "Struct" : {
+          "nodeId" : 99,
+          "unqualifiedName" : "SignalPair"
         }
       },
-      "2": {
-        "Constant": {
-          "nodeId": 1,
-          "unqualifiedName": "numElements"
+      "2" : {
+        "Constant" : {
+          "nodeId" : 1,
+          "unqualifiedName" : "numElements"
         }
       },
-      "63": {
-        "AbsType": {
-          "nodeId": 60,
-          "unqualifiedName": "T"
+      "63" : {
+        "AbsType" : {
+          "nodeId" : 60,
+          "unqualifiedName" : "T"
         }
       },
-      "103": {
-        "Struct": {
-          "nodeId": 99,
-          "unqualifiedName": "SignalPair"
+      "103" : {
+        "Struct" : {
+          "nodeId" : 99,
+          "unqualifiedName" : "SignalPair"
         }
       },
-      "72": {
-        "Array": {
-          "nodeId": 108,
-          "unqualifiedName": "SignalSet"
+      "72" : {
+        "Array" : {
+          "nodeId" : 108,
+          "unqualifiedName" : "SignalSet"
         }
       },
-      "58": {
-        "Constant": {
-          "nodeId": 39,
-          "unqualifiedName": "s"
+      "58" : {
+        "Constant" : {
+          "nodeId" : 39,
+          "unqualifiedName" : "s"
         }
       },
-      "64": {
-        "AbsType": {
-          "nodeId": 60,
-          "unqualifiedName": "T"
+      "64" : {
+        "AbsType" : {
+          "nodeId" : 60,
+          "unqualifiedName" : "T"
         }
       }
     },
-    "valueMap": {
-      "34": {
-        "Integer": {
-          "value": 1
+    "valueMap" : {
+      "34" : {
+        "Integer" : {
+          "value" : 1
         }
       },
-      "8": {
-        "AnonArray": {
-          "elements": [
+      "8" : {
+        "AnonArray" : {
+          "elements" : [
             {
-              "String": {
-                "value": "1"
+              "String" : {
+                "value" : "1"
               }
             },
             {
-              "String": {
-                "value": "2"
+              "String" : {
+                "value" : "2"
               }
             },
             {
-              "String": {
-                "value": "3"
+              "String" : {
+                "value" : "3"
               }
             }
           ]
         }
       },
-      "100": {
-        "Integer": {
-          "value": 4
+      "100" : {
+        "Integer" : {
+          "value" : 4
         }
       },
-      "110": {
-        "EnumConstant": {
-          "value": ["SQUARE", 1],
-          "t": {
-            "node": {
-              "astNodeId": 115
+      "110" : {
+        "EnumConstant" : {
+          "value" : [
+            "SQUARE",
+            1
+          ],
+          "t" : {
+            "node" : {
+              "astNodeId" : 115
             },
-            "repType": {
-              "kind": {
-                "I32": {}
+            "repType" : {
+              "kind" : {
+                "I32" : {
+                  
+                }
               }
             },
-            "default": "None"
+            "default" : "None"
           }
         }
       },
-      "11": {
-        "Integer": {
-          "value": 3
+      "11" : {
+        "Integer" : {
+          "value" : 3
         }
       },
-      "61": {
-        "Integer": {
-          "value": 3
+      "61" : {
+        "Integer" : {
+          "value" : 3
         }
       },
-      "5": {
-        "String": {
-          "value": "1"
+      "5" : {
+        "String" : {
+          "value" : "1"
         }
       },
-      "48": {
-        "AnonStruct": {
-          "members": {
-            "x": {
-              "Integer": {
-                "value": 1
+      "48" : {
+        "AnonStruct" : {
+          "members" : {
+            "x" : {
+              "Integer" : {
+                "value" : 1
               }
             },
-            "y": {
-              "String": {
-                "value": "abc"
+            "y" : {
+              "String" : {
+                "value" : "abc"
               }
             }
           }
         }
       },
-      "111": {
-        "EnumConstant": {
-          "value": ["SINE", 2],
-          "t": {
-            "node": {
-              "astNodeId": 115
+      "111" : {
+        "EnumConstant" : {
+          "value" : [
+            "SINE",
+            2
+          ],
+          "t" : {
+            "node" : {
+              "astNodeId" : 115
             },
-            "repType": {
-              "kind": {
-                "I32": {}
+            "repType" : {
+              "kind" : {
+                "I32" : {
+                  
+                }
               }
             },
-            "default": "None"
+            "default" : "None"
           }
         }
       },
-      "58": {
-        "AnonStruct": {
-          "members": {
-            "x": {
-              "Integer": {
-                "value": 1
+      "58" : {
+        "AnonStruct" : {
+          "members" : {
+            "x" : {
+              "Integer" : {
+                "value" : 1
               }
             },
-            "y": {
-              "String": {
-                "value": "abc"
+            "y" : {
+              "String" : {
+                "value" : "abc"
               }
             }
           }
         }
       },
-      "6": {
-        "String": {
-          "value": "2"
+      "6" : {
+        "String" : {
+          "value" : "2"
         }
       },
-      "36": {
-        "String": {
-          "value": "abc"
+      "36" : {
+        "String" : {
+          "value" : "abc"
         }
       },
-      "1": {
-        "Integer": {
-          "value": 3
+      "1" : {
+        "Integer" : {
+          "value" : 3
         }
       },
-      "39": {
-        "AnonStruct": {
-          "members": {
-            "x": {
-              "Integer": {
-                "value": 1
+      "39" : {
+        "AnonStruct" : {
+          "members" : {
+            "x" : {
+              "Integer" : {
+                "value" : 1
               }
             },
-            "y": {
-              "String": {
-                "value": "abc"
-              }
-            }
-          }
-        }
-      },
-      "109": {
-        "EnumConstant": {
-          "value": ["TRIANGLE", 0],
-          "t": {
-            "node": {
-              "astNodeId": 115
-            },
-            "repType": {
-              "kind": {
-                "I32": {}
-              }
-            },
-            "default": "None"
-          }
-        }
-      },
-      "0": {
-        "Integer": {
-          "value": 3
-        }
-      },
-      "2": {
-        "Integer": {
-          "value": 3
-        }
-      },
-      "38": {
-        "AnonStruct": {
-          "members": {
-            "x": {
-              "Integer": {
-                "value": 1
-              }
-            },
-            "y": {
-              "String": {
-                "value": "abc"
+            "y" : {
+              "String" : {
+                "value" : "abc"
               }
             }
           }
         }
       },
-      "7": {
-        "String": {
-          "value": "3"
-        }
-      },
-      "114": {
-        "EnumConstant": {
-          "value": ["NOISE", 3],
-          "t": {
-            "node": {
-              "astNodeId": 115
+      "109" : {
+        "EnumConstant" : {
+          "value" : [
+            "TRIANGLE",
+            0
+          ],
+          "t" : {
+            "node" : {
+              "astNodeId" : 115
             },
-            "repType": {
-              "kind": {
-                "I32": {}
+            "repType" : {
+              "kind" : {
+                "I32" : {
+                  
+                }
               }
             },
-            "default": "None"
+            "default" : "None"
           }
         }
       },
-      "105": {
-        "Integer": {
-          "value": 4
+      "0" : {
+        "Integer" : {
+          "value" : 3
         }
       },
-      "3": {
-        "Integer": {
-          "value": 40
+      "2" : {
+        "Integer" : {
+          "value" : 3
+        }
+      },
+      "38" : {
+        "AnonStruct" : {
+          "members" : {
+            "x" : {
+              "Integer" : {
+                "value" : 1
+              }
+            },
+            "y" : {
+              "String" : {
+                "value" : "abc"
+              }
+            }
+          }
+        }
+      },
+      "7" : {
+        "String" : {
+          "value" : "3"
+        }
+      },
+      "114" : {
+        "EnumConstant" : {
+          "value" : [
+            "NOISE",
+            3
+          ],
+          "t" : {
+            "node" : {
+              "astNodeId" : 115
+            },
+            "repType" : {
+              "kind" : {
+                "I32" : {
+                  
+                }
+              }
+            },
+            "default" : "None"
+          }
+        }
+      },
+      "105" : {
+        "Integer" : {
+          "value" : 4
+        }
+      },
+      "3" : {
+        "Integer" : {
+          "value" : 40
         }
       }
     },
-    "stateMachineMap": {},
-    "dictionarySymbolSet": [
+    "stateMachineMap" : {
+      
+    },
+    "dictionarySymbolSet" : [
       {
-        "Constant": {
-          "nodeId": 1,
-          "unqualifiedName": "numElements"
+        "Constant" : {
+          "nodeId" : 1,
+          "unqualifiedName" : "numElements"
         }
       },
       {
-        "Enum": {
-          "nodeId": 115,
-          "unqualifiedName": "SignalType"
+        "Enum" : {
+          "nodeId" : 115,
+          "unqualifiedName" : "SignalType"
         }
       },
       {
-        "AliasType": {
-          "nodeId": 117,
-          "unqualifiedName": "Alias1"
+        "AliasType" : {
+          "nodeId" : 117,
+          "unqualifiedName" : "Alias1"
         }
       },
       {
-        "Struct": {
-          "nodeId": 86,
-          "unqualifiedName": "SignalInfo"
+        "Struct" : {
+          "nodeId" : 86,
+          "unqualifiedName" : "SignalInfo"
         }
       },
       {
-        "Array": {
-          "nodeId": 108,
-          "unqualifiedName": "SignalSet"
+        "Array" : {
+          "nodeId" : 108,
+          "unqualifiedName" : "SignalSet"
         }
       }
     ],
-    "interfaceMap": {}
+    "interfaceMap" : {
+      
+    }
   }
 }

--- a/tests/types/types_analysis.json
+++ b/tests/types/types_analysis.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion": "[ fpp version ]",
+  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
   "analysis": {
     "componentInstanceMap": {},
     "componentMap": {},

--- a/tests/types/types_ast.json
+++ b/tests/types/types_ast.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion": "[ fpp version ]",
+  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
   "ast": [
     {
       "members": [

--- a/tests/types/types_ast.json
+++ b/tests/types/types_ast.json
@@ -1,973 +1,1057 @@
 {
-  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
-  "ast": [
+  "fppVersion" : "v3.1.0a10-54-g11243e778",
+  "ast" : [
     {
-      "members": [
+      "members" : [
         [
-          [],
+          [
+          ],
           {
-            "DefConstant": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "numElements",
-                    "value": {
-                      "AstNode": {
-                        "data": {
-                          "ExprLiteralInt": {
-                            "value": "3"
+            "DefConstant" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "numElements",
+                    "value" : {
+                      "AstNode" : {
+                        "data" : {
+                          "ExprLiteralInt" : {
+                            "value" : "3"
                           }
                         },
-                        "id": 0
+                        "id" : 0
                       }
                     },
-                    "isDictionaryDef": true
+                    "isDictionaryDef" : true
                   },
-                  "id": 1
+                  "id" : 1
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          [],
+          [
+          ],
           {
-            "DefArray": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "A",
-                    "size": {
-                      "AstNode": {
-                        "data": {
-                          "ExprIdent": {
-                            "value": "numElements"
+            "DefArray" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "A",
+                    "size" : {
+                      "AstNode" : {
+                        "data" : {
+                          "ExprIdent" : {
+                            "value" : "numElements"
                           }
                         },
-                        "id": 2
+                        "id" : 2
                       }
                     },
-                    "eltType": {
-                      "AstNode": {
-                        "data": {
-                          "TypeNameString": {
-                            "size": {
-                              "Some": {
-                                "AstNode": {
-                                  "data": {
-                                    "ExprLiteralInt": {
-                                      "value": "40"
+                    "eltType" : {
+                      "AstNode" : {
+                        "data" : {
+                          "TypeNameString" : {
+                            "size" : {
+                              "Some" : {
+                                "AstNode" : {
+                                  "data" : {
+                                    "ExprLiteralInt" : {
+                                      "value" : "40"
                                     }
                                   },
-                                  "id": 3
+                                  "id" : 3
                                 }
                               }
                             }
                           }
                         },
-                        "id": 4
+                        "id" : 4
                       }
                     },
-                    "default": {
-                      "Some": {
-                        "AstNode": {
-                          "data": {
-                            "ExprArray": {
-                              "elts": [
+                    "default" : {
+                      "Some" : {
+                        "AstNode" : {
+                          "data" : {
+                            "ExprArray" : {
+                              "elts" : [
                                 {
-                                  "AstNode": {
-                                    "data": {
-                                      "ExprLiteralString": {
-                                        "value": "1"
+                                  "AstNode" : {
+                                    "data" : {
+                                      "ExprLiteralString" : {
+                                        "value" : "1"
                                       }
                                     },
-                                    "id": 5
+                                    "id" : 5
                                   }
                                 },
                                 {
-                                  "AstNode": {
-                                    "data": {
-                                      "ExprLiteralString": {
-                                        "value": "2"
+                                  "AstNode" : {
+                                    "data" : {
+                                      "ExprLiteralString" : {
+                                        "value" : "2"
                                       }
                                     },
-                                    "id": 6
+                                    "id" : 6
                                   }
                                 },
                                 {
-                                  "AstNode": {
-                                    "data": {
-                                      "ExprLiteralString": {
-                                        "value": "3"
+                                  "AstNode" : {
+                                    "data" : {
+                                      "ExprLiteralString" : {
+                                        "value" : "3"
                                       }
                                     },
-                                    "id": 7
+                                    "id" : 7
                                   }
                                 }
                               ]
                             }
                           },
-                          "id": 8
+                          "id" : 8
                         }
                       }
                     },
-                    "format": {
-                      "Some": {
-                        "AstNode": {
-                          "data": "{} RPM",
-                          "id": 9
+                    "format" : {
+                      "Some" : {
+                        "AstNode" : {
+                          "data" : "{} RPM",
+                          "id" : 9
                         }
                       }
                     },
-                    "isDictionaryDef": false
+                    "isDictionaryDef" : false
                   },
-                  "id": 10
+                  "id" : 10
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          [],
+          [
+          ],
           {
-            "DefArray": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "B",
-                    "size": {
-                      "AstNode": {
-                        "data": {
-                          "ExprLiteralInt": {
-                            "value": "3"
+            "DefArray" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "B",
+                    "size" : {
+                      "AstNode" : {
+                        "data" : {
+                          "ExprLiteralInt" : {
+                            "value" : "3"
                           }
                         },
-                        "id": 11
+                        "id" : 11
                       }
                     },
-                    "eltType": {
-                      "AstNode": {
-                        "data": {
-                          "TypeNameQualIdent": {
-                            "name": {
-                              "AstNode": {
-                                "data": {
-                                  "Unqualified": {
-                                    "name": "A"
+                    "eltType" : {
+                      "AstNode" : {
+                        "data" : {
+                          "TypeNameQualIdent" : {
+                            "name" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "Unqualified" : {
+                                    "name" : "A"
                                   }
                                 },
-                                "id": 13
+                                "id" : 13
                               }
                             }
                           }
                         },
-                        "id": 14
+                        "id" : 14
                       }
                     },
-                    "default": "None",
-                    "format": "None",
-                    "isDictionaryDef": false
+                    "default" : "None",
+                    "format" : "None",
+                    "isDictionaryDef" : false
                   },
-                  "id": 15
+                  "id" : 15
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          ["This is a pre annotation for struct S"],
+          [
+            "This is a pre annotation for struct S"
+          ],
           {
-            "DefStruct": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "S",
-                    "members": [
+            "DefStruct" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "S",
+                    "members" : [
                       [
-                        ["This is a pre annotation for member x"],
+                        [
+                          "This is a pre annotation for member x"
+                        ],
                         {
-                          "AstNode": {
-                            "data": {
-                              "name": "x",
-                              "size": "None",
-                              "typeName": {
-                                "AstNode": {
-                                  "data": {
-                                    "TypeNameInt": {
-                                      "name": {
-                                        "U32": {}
+                          "AstNode" : {
+                            "data" : {
+                              "name" : "x",
+                              "size" : "None",
+                              "typeName" : {
+                                "AstNode" : {
+                                  "data" : {
+                                    "TypeNameInt" : {
+                                      "name" : {
+                                        "U32" : {
+                                          
+                                        }
                                       }
                                     }
                                   },
-                                  "id": 27
+                                  "id" : 27
                                 }
                               },
-                              "format": "None"
+                              "format" : "None"
                             },
-                            "id": 28
+                            "id" : 28
                           }
                         },
-                        ["This is a post annotation for member x"]
+                        [
+                          "This is a post annotation for member x"
+                        ]
                       ],
                       [
-                        ["This is a pre annotation for member y"],
+                        [
+                          "This is a pre annotation for member y"
+                        ],
                         {
-                          "AstNode": {
-                            "data": {
-                              "name": "y",
-                              "size": "None",
-                              "typeName": {
-                                "AstNode": {
-                                  "data": {
-                                    "TypeNameString": {
-                                      "size": "None"
+                          "AstNode" : {
+                            "data" : {
+                              "name" : "y",
+                              "size" : "None",
+                              "typeName" : {
+                                "AstNode" : {
+                                  "data" : {
+                                    "TypeNameString" : {
+                                      "size" : "None"
                                     }
                                   },
-                                  "id": 31
+                                  "id" : 31
                                 }
                               },
-                              "format": "None"
+                              "format" : "None"
                             },
-                            "id": 32
+                            "id" : 32
                           }
                         },
-                        ["This is a post annotation for member y"]
+                        [
+                          "This is a post annotation for member y"
+                        ]
                       ]
                     ],
-                    "default": "None",
-                    "isDictionaryDef": false
+                    "default" : "None",
+                    "isDictionaryDef" : false
                   },
-                  "id": 33
+                  "id" : 33
                 }
               }
             }
           },
-          ["This is a post annotation for struct S"]
+          [
+            "This is a post annotation for struct S"
+          ]
         ],
         [
-          [],
+          [
+          ],
           {
-            "DefConstant": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "s",
-                    "value": {
-                      "AstNode": {
-                        "data": {
-                          "ExprStruct": {
-                            "members": [
+            "DefConstant" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "s",
+                    "value" : {
+                      "AstNode" : {
+                        "data" : {
+                          "ExprStruct" : {
+                            "members" : [
                               {
-                                "AstNode": {
-                                  "data": {
-                                    "name": "x",
-                                    "value": {
-                                      "AstNode": {
-                                        "data": {
-                                          "ExprLiteralInt": {
-                                            "value": "1"
+                                "AstNode" : {
+                                  "data" : {
+                                    "name" : "x",
+                                    "value" : {
+                                      "AstNode" : {
+                                        "data" : {
+                                          "ExprLiteralInt" : {
+                                            "value" : "1"
                                           }
                                         },
-                                        "id": 34
+                                        "id" : 34
                                       }
                                     }
                                   },
-                                  "id": 35
+                                  "id" : 35
                                 }
                               },
                               {
-                                "AstNode": {
-                                  "data": {
-                                    "name": "y",
-                                    "value": {
-                                      "AstNode": {
-                                        "data": {
-                                          "ExprLiteralString": {
-                                            "value": "abc"
+                                "AstNode" : {
+                                  "data" : {
+                                    "name" : "y",
+                                    "value" : {
+                                      "AstNode" : {
+                                        "data" : {
+                                          "ExprLiteralString" : {
+                                            "value" : "abc"
                                           }
                                         },
-                                        "id": 36
+                                        "id" : 36
                                       }
                                     }
                                   },
-                                  "id": 37
+                                  "id" : 37
                                 }
                               }
                             ]
                           }
                         },
-                        "id": 38
+                        "id" : 38
                       }
                     },
-                    "isDictionaryDef": false
+                    "isDictionaryDef" : false
                   },
-                  "id": 39
+                  "id" : 39
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          [],
+          [
+          ],
           {
-            "DefStruct": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "S1",
-                    "members": [
+            "DefStruct" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "S1",
+                    "members" : [
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "AstNode": {
-                            "data": {
-                              "name": "x",
-                              "size": "None",
-                              "typeName": {
-                                "AstNode": {
-                                  "data": {
-                                    "TypeNameInt": {
-                                      "name": {
-                                        "U8": {}
+                          "AstNode" : {
+                            "data" : {
+                              "name" : "x",
+                              "size" : "None",
+                              "typeName" : {
+                                "AstNode" : {
+                                  "data" : {
+                                    "TypeNameInt" : {
+                                      "name" : {
+                                        "U8" : {
+                                          
+                                        }
                                       }
                                     }
                                   },
-                                  "id": 40
+                                  "id" : 40
                                 }
                               },
-                              "format": "None"
+                              "format" : "None"
                             },
-                            "id": 41
+                            "id" : 41
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "AstNode": {
-                            "data": {
-                              "name": "y",
-                              "size": "None",
-                              "typeName": {
-                                "AstNode": {
-                                  "data": {
-                                    "TypeNameString": {
-                                      "size": "None"
+                          "AstNode" : {
+                            "data" : {
+                              "name" : "y",
+                              "size" : "None",
+                              "typeName" : {
+                                "AstNode" : {
+                                  "data" : {
+                                    "TypeNameString" : {
+                                      "size" : "None"
                                     }
                                   },
-                                  "id": 46
+                                  "id" : 46
                                 }
                               },
-                              "format": "None"
+                              "format" : "None"
                             },
-                            "id": 47
+                            "id" : 47
                           }
                         },
-                        []
+                        [
+                        ]
                       ]
                     ],
-                    "default": {
-                      "Some": {
-                        "AstNode": {
-                          "data": {
-                            "ExprIdent": {
-                              "value": "s"
+                    "default" : {
+                      "Some" : {
+                        "AstNode" : {
+                          "data" : {
+                            "ExprIdent" : {
+                              "value" : "s"
                             }
                           },
-                          "id": 48
+                          "id" : 48
                         }
                       }
                     },
-                    "isDictionaryDef": false
+                    "isDictionaryDef" : false
                   },
-                  "id": 49
+                  "id" : 49
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          [],
+          [
+          ],
           {
-            "DefStruct": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "S2",
-                    "members": [
+            "DefStruct" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "S2",
+                    "members" : [
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "AstNode": {
-                            "data": {
-                              "name": "x",
-                              "size": "None",
-                              "typeName": {
-                                "AstNode": {
-                                  "data": {
-                                    "TypeNameInt": {
-                                      "name": {
-                                        "U32": {}
+                          "AstNode" : {
+                            "data" : {
+                              "name" : "x",
+                              "size" : "None",
+                              "typeName" : {
+                                "AstNode" : {
+                                  "data" : {
+                                    "TypeNameInt" : {
+                                      "name" : {
+                                        "U32" : {
+                                          
+                                        }
                                       }
                                     }
                                   },
-                                  "id": 50
+                                  "id" : 50
                                 }
                               },
-                              "format": "None"
+                              "format" : "None"
                             },
-                            "id": 51
+                            "id" : 51
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "AstNode": {
-                            "data": {
-                              "name": "y",
-                              "size": "None",
-                              "typeName": {
-                                "AstNode": {
-                                  "data": {
-                                    "TypeNameString": {
-                                      "size": "None"
+                          "AstNode" : {
+                            "data" : {
+                              "name" : "y",
+                              "size" : "None",
+                              "typeName" : {
+                                "AstNode" : {
+                                  "data" : {
+                                    "TypeNameString" : {
+                                      "size" : "None"
                                     }
                                   },
-                                  "id": 56
+                                  "id" : 56
                                 }
                               },
-                              "format": "None"
+                              "format" : "None"
                             },
-                            "id": 57
+                            "id" : 57
                           }
                         },
-                        []
+                        [
+                        ]
                       ]
                     ],
-                    "default": {
-                      "Some": {
-                        "AstNode": {
-                          "data": {
-                            "ExprIdent": {
-                              "value": "s"
+                    "default" : {
+                      "Some" : {
+                        "AstNode" : {
+                          "data" : {
+                            "ExprIdent" : {
+                              "value" : "s"
                             }
                           },
-                          "id": 58
+                          "id" : 58
                         }
                       }
                     },
-                    "isDictionaryDef": false
+                    "isDictionaryDef" : false
                   },
-                  "id": 59
+                  "id" : 59
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          [],
+          [
+          ],
           {
-            "DefAbsType": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "T"
+            "DefAbsType" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "T"
                   },
-                  "id": 60
+                  "id" : 60
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          [],
+          [
+          ],
           {
-            "DefArray": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "arr",
-                    "size": {
-                      "AstNode": {
-                        "data": {
-                          "ExprLiteralInt": {
-                            "value": "3"
+            "DefArray" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "arr",
+                    "size" : {
+                      "AstNode" : {
+                        "data" : {
+                          "ExprLiteralInt" : {
+                            "value" : "3"
                           }
                         },
-                        "id": 61
+                        "id" : 61
                       }
                     },
-                    "eltType": {
-                      "AstNode": {
-                        "data": {
-                          "TypeNameQualIdent": {
-                            "name": {
-                              "AstNode": {
-                                "data": {
-                                  "Unqualified": {
-                                    "name": "T"
+                    "eltType" : {
+                      "AstNode" : {
+                        "data" : {
+                          "TypeNameQualIdent" : {
+                            "name" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "Unqualified" : {
+                                    "name" : "T"
                                   }
                                 },
-                                "id": 63
+                                "id" : 63
                               }
                             }
                           }
                         },
-                        "id": 64
+                        "id" : 64
                       }
                     },
-                    "default": "None",
-                    "format": "None",
-                    "isDictionaryDef": false
+                    "default" : "None",
+                    "format" : "None",
+                    "isDictionaryDef" : false
                   },
-                  "id": 65
+                  "id" : 65
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          [],
+          [
+          ],
           {
-            "DefStruct": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "SignalInfo",
-                    "members": [
+            "DefStruct" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "SignalInfo",
+                    "members" : [
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "AstNode": {
-                            "data": {
-                              "name": "type",
-                              "size": "None",
-                              "typeName": {
-                                "AstNode": {
-                                  "data": {
-                                    "TypeNameQualIdent": {
-                                      "name": {
-                                        "AstNode": {
-                                          "data": {
-                                            "Unqualified": {
-                                              "name": "SignalType"
+                          "AstNode" : {
+                            "data" : {
+                              "name" : "type",
+                              "size" : "None",
+                              "typeName" : {
+                                "AstNode" : {
+                                  "data" : {
+                                    "TypeNameQualIdent" : {
+                                      "name" : {
+                                        "AstNode" : {
+                                          "data" : {
+                                            "Unqualified" : {
+                                              "name" : "SignalType"
                                             }
                                           },
-                                          "id": 67
+                                          "id" : 67
                                         }
                                       }
                                     }
                                   },
-                                  "id": 68
+                                  "id" : 68
                                 }
                               },
-                              "format": "None"
+                              "format" : "None"
                             },
-                            "id": 69
+                            "id" : 69
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "AstNode": {
-                            "data": {
-                              "name": "history",
-                              "size": "None",
-                              "typeName": {
-                                "AstNode": {
-                                  "data": {
-                                    "TypeNameQualIdent": {
-                                      "name": {
-                                        "AstNode": {
-                                          "data": {
-                                            "Unqualified": {
-                                              "name": "SignalSet"
+                          "AstNode" : {
+                            "data" : {
+                              "name" : "history",
+                              "size" : "None",
+                              "typeName" : {
+                                "AstNode" : {
+                                  "data" : {
+                                    "TypeNameQualIdent" : {
+                                      "name" : {
+                                        "AstNode" : {
+                                          "data" : {
+                                            "Unqualified" : {
+                                              "name" : "SignalSet"
                                             }
                                           },
-                                          "id": 71
+                                          "id" : 71
                                         }
                                       }
                                     }
                                   },
-                                  "id": 72
+                                  "id" : 72
                                 }
                               },
-                              "format": "None"
+                              "format" : "None"
                             },
-                            "id": 73
+                            "id" : 73
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "AstNode": {
-                            "data": {
-                              "name": "pairHistory",
-                              "size": "None",
-                              "typeName": {
-                                "AstNode": {
-                                  "data": {
-                                    "TypeNameQualIdent": {
-                                      "name": {
-                                        "AstNode": {
-                                          "data": {
-                                            "Unqualified": {
-                                              "name": "SignalPairSet"
+                          "AstNode" : {
+                            "data" : {
+                              "name" : "pairHistory",
+                              "size" : "None",
+                              "typeName" : {
+                                "AstNode" : {
+                                  "data" : {
+                                    "TypeNameQualIdent" : {
+                                      "name" : {
+                                        "AstNode" : {
+                                          "data" : {
+                                            "Unqualified" : {
+                                              "name" : "SignalPairSet"
                                             }
                                           },
-                                          "id": 83
+                                          "id" : 83
                                         }
                                       }
                                     }
                                   },
-                                  "id": 84
+                                  "id" : 84
                                 }
                               },
-                              "format": "None"
+                              "format" : "None"
                             },
-                            "id": 85
+                            "id" : 85
                           }
                         },
-                        []
+                        [
+                        ]
                       ]
                     ],
-                    "default": "None",
-                    "isDictionaryDef": true
+                    "default" : "None",
+                    "isDictionaryDef" : true
                   },
-                  "id": 86
+                  "id" : 86
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          [],
+          [
+          ],
           {
-            "DefStruct": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "SignalPair",
-                    "members": [
+            "DefStruct" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "SignalPair",
+                    "members" : [
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "AstNode": {
-                            "data": {
-                              "name": "time",
-                              "size": "None",
-                              "typeName": {
-                                "AstNode": {
-                                  "data": {
-                                    "TypeNameFloat": {
-                                      "name": {
-                                        "F32": {}
+                          "AstNode" : {
+                            "data" : {
+                              "name" : "time",
+                              "size" : "None",
+                              "typeName" : {
+                                "AstNode" : {
+                                  "data" : {
+                                    "TypeNameFloat" : {
+                                      "name" : {
+                                        "F32" : {
+                                          
+                                        }
                                       }
                                     }
                                   },
-                                  "id": 87
+                                  "id" : 87
                                 }
                               },
-                              "format": {
-                                "Some": {
-                                  "AstNode": {
-                                    "data": "{f}",
-                                    "id": 88
+                              "format" : {
+                                "Some" : {
+                                  "AstNode" : {
+                                    "data" : "{f}",
+                                    "id" : 88
                                   }
                                 }
                               }
                             },
-                            "id": 89
+                            "id" : 89
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "AstNode": {
-                            "data": {
-                              "name": "value",
-                              "size": "None",
-                              "typeName": {
-                                "AstNode": {
-                                  "data": {
-                                    "TypeNameFloat": {
-                                      "name": {
-                                        "F32": {}
+                          "AstNode" : {
+                            "data" : {
+                              "name" : "value",
+                              "size" : "None",
+                              "typeName" : {
+                                "AstNode" : {
+                                  "data" : {
+                                    "TypeNameFloat" : {
+                                      "name" : {
+                                        "F32" : {
+                                          
+                                        }
                                       }
                                     }
                                   },
-                                  "id": 96
+                                  "id" : 96
                                 }
                               },
-                              "format": {
-                                "Some": {
-                                  "AstNode": {
-                                    "data": "{f}",
-                                    "id": 97
+                              "format" : {
+                                "Some" : {
+                                  "AstNode" : {
+                                    "data" : "{f}",
+                                    "id" : 97
                                   }
                                 }
                               }
                             },
-                            "id": 98
+                            "id" : 98
                           }
                         },
-                        []
+                        [
+                        ]
                       ]
                     ],
-                    "default": "None",
-                    "isDictionaryDef": false
+                    "default" : "None",
+                    "isDictionaryDef" : false
                   },
-                  "id": 99
+                  "id" : 99
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          [],
+          [
+          ],
           {
-            "DefArray": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "SignalPairSet",
-                    "size": {
-                      "AstNode": {
-                        "data": {
-                          "ExprLiteralInt": {
-                            "value": "4"
+            "DefArray" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "SignalPairSet",
+                    "size" : {
+                      "AstNode" : {
+                        "data" : {
+                          "ExprLiteralInt" : {
+                            "value" : "4"
                           }
                         },
-                        "id": 100
+                        "id" : 100
                       }
                     },
-                    "eltType": {
-                      "AstNode": {
-                        "data": {
-                          "TypeNameQualIdent": {
-                            "name": {
-                              "AstNode": {
-                                "data": {
-                                  "Unqualified": {
-                                    "name": "SignalPair"
+                    "eltType" : {
+                      "AstNode" : {
+                        "data" : {
+                          "TypeNameQualIdent" : {
+                            "name" : {
+                              "AstNode" : {
+                                "data" : {
+                                  "Unqualified" : {
+                                    "name" : "SignalPair"
                                   }
                                 },
-                                "id": 102
+                                "id" : 102
                               }
                             }
                           }
                         },
-                        "id": 103
+                        "id" : 103
                       }
                     },
-                    "default": "None",
-                    "format": "None",
-                    "isDictionaryDef": false
+                    "default" : "None",
+                    "format" : "None",
+                    "isDictionaryDef" : false
                   },
-                  "id": 104
+                  "id" : 104
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          [],
+          [
+          ],
           {
-            "DefArray": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "SignalSet",
-                    "size": {
-                      "AstNode": {
-                        "data": {
-                          "ExprLiteralInt": {
-                            "value": "4"
+            "DefArray" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "SignalSet",
+                    "size" : {
+                      "AstNode" : {
+                        "data" : {
+                          "ExprLiteralInt" : {
+                            "value" : "4"
                           }
                         },
-                        "id": 105
+                        "id" : 105
                       }
                     },
-                    "eltType": {
-                      "AstNode": {
-                        "data": {
-                          "TypeNameFloat": {
-                            "name": {
-                              "F32": {}
+                    "eltType" : {
+                      "AstNode" : {
+                        "data" : {
+                          "TypeNameFloat" : {
+                            "name" : {
+                              "F32" : {
+                                
+                              }
                             }
                           }
                         },
-                        "id": 106
+                        "id" : 106
                       }
                     },
-                    "default": "None",
-                    "format": {
-                      "Some": {
-                        "AstNode": {
-                          "data": "{f}",
-                          "id": 107
+                    "default" : "None",
+                    "format" : {
+                      "Some" : {
+                        "AstNode" : {
+                          "data" : "{f}",
+                          "id" : 107
                         }
                       }
                     },
-                    "isDictionaryDef": true
+                    "isDictionaryDef" : true
                   },
-                  "id": 108
+                  "id" : 108
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          [],
+          [
+          ],
           {
-            "DefEnum": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "SignalType",
-                    "typeName": "None",
-                    "constants": [
+            "DefEnum" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "SignalType",
+                    "typeName" : "None",
+                    "constants" : [
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "AstNode": {
-                            "data": {
-                              "name": "TRIANGLE",
-                              "value": "None"
+                          "AstNode" : {
+                            "data" : {
+                              "name" : "TRIANGLE",
+                              "value" : "None"
                             },
-                            "id": 109
+                            "id" : 109
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "AstNode": {
-                            "data": {
-                              "name": "SQUARE",
-                              "value": "None"
+                          "AstNode" : {
+                            "data" : {
+                              "name" : "SQUARE",
+                              "value" : "None"
                             },
-                            "id": 110
+                            "id" : 110
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "AstNode": {
-                            "data": {
-                              "name": "SINE",
-                              "value": "None"
+                          "AstNode" : {
+                            "data" : {
+                              "name" : "SINE",
+                              "value" : "None"
                             },
-                            "id": 111
+                            "id" : 111
                           }
                         },
-                        []
+                        [
+                        ]
                       ],
                       [
-                        [],
+                        [
+                        ],
                         {
-                          "AstNode": {
-                            "data": {
-                              "name": "NOISE",
-                              "value": "None"
+                          "AstNode" : {
+                            "data" : {
+                              "name" : "NOISE",
+                              "value" : "None"
                             },
-                            "id": 114
+                            "id" : 114
                           }
                         },
-                        []
+                        [
+                        ]
                       ]
                     ],
-                    "default": "None",
-                    "isDictionaryDef": true
+                    "default" : "None",
+                    "isDictionaryDef" : true
                   },
-                  "id": 115
+                  "id" : 115
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          [],
+          [
+          ],
           {
-            "DefAliasType": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "Alias1",
-                    "typeName": {
-                      "AstNode": {
-                        "data": {
-                          "TypeNameInt": {
-                            "name": {
-                              "U32": {}
+            "DefAliasType" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "Alias1",
+                    "typeName" : {
+                      "AstNode" : {
+                        "data" : {
+                          "TypeNameInt" : {
+                            "name" : {
+                              "U32" : {
+                                
+                              }
                             }
                           }
                         },
-                        "id": 116
+                        "id" : 116
                       }
                     },
-                    "isDictionaryDef": true
+                    "isDictionaryDef" : true
                   },
-                  "id": 117
+                  "id" : 117
                 }
               }
             }
           },
-          []
+          [
+          ]
         ],
         [
-          [],
+          [
+          ],
           {
-            "DefAliasType": {
-              "node": {
-                "AstNode": {
-                  "data": {
-                    "name": "Alias2",
-                    "typeName": {
-                      "AstNode": {
-                        "data": {
-                          "TypeNameInt": {
-                            "name": {
-                              "U32": {}
+            "DefAliasType" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "name" : "Alias2",
+                    "typeName" : {
+                      "AstNode" : {
+                        "data" : {
+                          "TypeNameInt" : {
+                            "name" : {
+                              "U32" : {
+                                
+                              }
                             }
                           }
                         },
-                        "id": 118
+                        "id" : 118
                       }
                     },
-                    "isDictionaryDef": false
+                    "isDictionaryDef" : false
                   },
-                  "id": 119
+                  "id" : 119
                 }
               }
             }
           },
-          []
+          [
+          ]
         ]
       ]
     }

--- a/tests/types/types_locations.json
+++ b/tests/types/types_locations.json
@@ -1,605 +1,605 @@
 {
-  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
-  "locationMap": {
-    "0": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "1.35",
-      "includingLoc": "None"
-    },
-    "1": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "1.1",
-      "includingLoc": "None"
-    },
-    "2": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "2.12",
-      "includingLoc": "None"
-    },
-    "3": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "2.37",
-      "includingLoc": "None"
-    },
-    "4": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "2.25",
-      "includingLoc": "None"
-    },
-    "5": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "2.50",
-      "includingLoc": "None"
-    },
-    "6": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "2.55",
-      "includingLoc": "None"
-    },
-    "7": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "2.60",
-      "includingLoc": "None"
-    },
-    "8": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "2.48",
-      "includingLoc": "None"
-    },
-    "9": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "2.73",
-      "includingLoc": "None"
-    },
-    "10": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "2.1",
-      "includingLoc": "None"
-    },
-    "11": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "3.12",
-      "includingLoc": "None"
-    },
-    "12": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "3.15",
-      "includingLoc": "None"
-    },
-    "13": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "3.15",
-      "includingLoc": "None"
-    },
-    "14": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "3.15",
-      "includingLoc": "None"
-    },
-    "15": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "3.1",
-      "includingLoc": "None"
-    },
-    "16": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "8.6",
-      "includingLoc": "None"
-    },
-    "17": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "8.3",
-      "includingLoc": "None"
-    },
-    "18": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "8.6",
-      "includingLoc": "None"
-    },
-    "19": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "8.3",
-      "includingLoc": "None"
-    },
-    "20": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "10.6",
-      "includingLoc": "None"
-    },
-    "21": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "10.3",
-      "includingLoc": "None"
-    },
-    "22": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "10.6",
-      "includingLoc": "None"
-    },
-    "23": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "10.3",
-      "includingLoc": "None"
-    },
-    "24": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "6.1",
-      "includingLoc": "None"
-    },
-    "25": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "8.6",
-      "includingLoc": "None"
-    },
-    "26": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "8.3",
-      "includingLoc": "None"
-    },
-    "27": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "8.6",
-      "includingLoc": "None"
-    },
-    "28": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "8.3",
-      "includingLoc": "None"
-    },
-    "29": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "10.6",
-      "includingLoc": "None"
-    },
-    "30": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "10.3",
-      "includingLoc": "None"
-    },
-    "31": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "10.6",
-      "includingLoc": "None"
-    },
-    "32": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "10.3",
-      "includingLoc": "None"
-    },
-    "33": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "6.1",
-      "includingLoc": "None"
-    },
-    "34": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "13.20",
-      "includingLoc": "None"
-    },
-    "35": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "13.16",
-      "includingLoc": "None"
-    },
-    "36": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "13.27",
-      "includingLoc": "None"
-    },
-    "37": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "13.23",
-      "includingLoc": "None"
-    },
-    "38": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "13.14",
-      "includingLoc": "None"
-    },
-    "39": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "13.1",
-      "includingLoc": "None"
-    },
-    "40": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "14.16",
-      "includingLoc": "None"
-    },
-    "41": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "14.13",
-      "includingLoc": "None"
-    },
-    "42": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "14.23",
-      "includingLoc": "None"
-    },
-    "43": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "14.20",
-      "includingLoc": "None"
-    },
-    "44": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "14.23",
-      "includingLoc": "None"
-    },
-    "45": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "14.20",
-      "includingLoc": "None"
-    },
-    "46": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "14.23",
-      "includingLoc": "None"
-    },
-    "47": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "14.20",
-      "includingLoc": "None"
-    },
-    "48": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "14.40",
-      "includingLoc": "None"
-    },
-    "49": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "14.1",
-      "includingLoc": "None"
-    },
-    "50": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "15.16",
-      "includingLoc": "None"
-    },
-    "51": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "15.13",
-      "includingLoc": "None"
-    },
-    "52": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "15.24",
-      "includingLoc": "None"
-    },
-    "53": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "15.21",
-      "includingLoc": "None"
-    },
-    "54": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "15.24",
-      "includingLoc": "None"
-    },
-    "55": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "15.21",
-      "includingLoc": "None"
-    },
-    "56": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "15.24",
-      "includingLoc": "None"
-    },
-    "57": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "15.21",
-      "includingLoc": "None"
-    },
-    "58": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "15.41",
-      "includingLoc": "None"
-    },
-    "59": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "15.1",
-      "includingLoc": "None"
-    },
-    "60": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "17.1",
-      "includingLoc": "None"
-    },
-    "61": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "18.14",
-      "includingLoc": "None"
-    },
-    "62": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "18.17",
-      "includingLoc": "None"
-    },
-    "63": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "18.17",
-      "includingLoc": "None"
-    },
-    "64": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "18.17",
-      "includingLoc": "None"
-    },
-    "65": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "18.1",
-      "includingLoc": "None"
-    },
-    "66": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "22.10",
-      "includingLoc": "None"
-    },
-    "67": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "22.10",
-      "includingLoc": "None"
-    },
-    "68": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "22.10",
-      "includingLoc": "None"
-    },
-    "69": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "22.3",
-      "includingLoc": "None"
-    },
-    "70": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "23.12",
-      "includingLoc": "None"
-    },
-    "71": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "23.12",
-      "includingLoc": "None"
-    },
-    "72": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "23.12",
-      "includingLoc": "None"
-    },
-    "73": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "23.3",
-      "includingLoc": "None"
-    },
-    "74": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "24.16",
-      "includingLoc": "None"
-    },
-    "75": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "24.16",
-      "includingLoc": "None"
-    },
-    "76": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "24.16",
-      "includingLoc": "None"
-    },
-    "77": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "24.3",
-      "includingLoc": "None"
-    },
-    "78": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "24.16",
-      "includingLoc": "None"
-    },
-    "79": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "24.16",
-      "includingLoc": "None"
-    },
-    "80": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "24.16",
-      "includingLoc": "None"
-    },
-    "81": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "24.3",
-      "includingLoc": "None"
-    },
-    "82": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "24.16",
-      "includingLoc": "None"
-    },
-    "83": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "24.16",
-      "includingLoc": "None"
-    },
-    "84": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "24.16",
-      "includingLoc": "None"
-    },
-    "85": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "24.3",
-      "includingLoc": "None"
-    },
-    "86": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "21.1",
-      "includingLoc": "None"
-    },
-    "87": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "28.10",
-      "includingLoc": "None"
-    },
-    "88": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "28.21",
-      "includingLoc": "None"
-    },
-    "89": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "28.3",
-      "includingLoc": "None"
-    },
-    "90": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "29.10",
-      "includingLoc": "None"
-    },
-    "91": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "29.21",
-      "includingLoc": "None"
-    },
-    "92": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "29.3",
-      "includingLoc": "None"
-    },
-    "93": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "29.10",
-      "includingLoc": "None"
-    },
-    "94": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "29.21",
-      "includingLoc": "None"
-    },
-    "95": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "29.3",
-      "includingLoc": "None"
-    },
-    "96": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "29.10",
-      "includingLoc": "None"
-    },
-    "97": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "29.21",
-      "includingLoc": "None"
-    },
-    "98": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "29.3",
-      "includingLoc": "None"
-    },
-    "99": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "27.1",
-      "includingLoc": "None"
-    },
-    "100": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "32.24",
-      "includingLoc": "None"
-    },
-    "101": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "32.27",
-      "includingLoc": "None"
-    },
-    "102": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "32.27",
-      "includingLoc": "None"
-    },
-    "103": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "32.27",
-      "includingLoc": "None"
-    },
-    "104": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "32.1",
-      "includingLoc": "None"
-    },
-    "105": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "34.31",
-      "includingLoc": "None"
-    },
-    "106": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "34.34",
-      "includingLoc": "None"
-    },
-    "107": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "34.45",
-      "includingLoc": "None"
-    },
-    "108": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "34.1",
-      "includingLoc": "None"
-    },
-    "109": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "37.3",
-      "includingLoc": "None"
-    },
-    "110": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "38.3",
-      "includingLoc": "None"
-    },
-    "111": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "39.3",
-      "includingLoc": "None"
-    },
-    "112": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "40.3",
-      "includingLoc": "None"
-    },
-    "113": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "40.3",
-      "includingLoc": "None"
-    },
-    "114": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "40.3",
-      "includingLoc": "None"
-    },
-    "115": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "36.1",
-      "includingLoc": "None"
-    },
-    "116": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "43.26",
-      "includingLoc": "None"
-    },
-    "117": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "43.1",
-      "includingLoc": "None"
-    },
-    "118": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "44.15",
-      "includingLoc": "None"
-    },
-    "119": {
-      "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
-      "pos": "44.1",
-      "includingLoc": "None"
+  "fppVersion" : "v3.1.0a10-54-g11243e778",
+  "locationMap" : {
+    "0" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "1.35",
+      "includingLoc" : "None"
+    },
+    "1" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "1.1",
+      "includingLoc" : "None"
+    },
+    "2" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "2.12",
+      "includingLoc" : "None"
+    },
+    "3" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "2.37",
+      "includingLoc" : "None"
+    },
+    "4" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "2.25",
+      "includingLoc" : "None"
+    },
+    "5" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "2.50",
+      "includingLoc" : "None"
+    },
+    "6" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "2.55",
+      "includingLoc" : "None"
+    },
+    "7" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "2.60",
+      "includingLoc" : "None"
+    },
+    "8" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "2.48",
+      "includingLoc" : "None"
+    },
+    "9" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "2.73",
+      "includingLoc" : "None"
+    },
+    "10" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "2.1",
+      "includingLoc" : "None"
+    },
+    "11" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "3.12",
+      "includingLoc" : "None"
+    },
+    "12" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "3.15",
+      "includingLoc" : "None"
+    },
+    "13" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "3.15",
+      "includingLoc" : "None"
+    },
+    "14" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "3.15",
+      "includingLoc" : "None"
+    },
+    "15" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "3.1",
+      "includingLoc" : "None"
+    },
+    "16" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "8.6",
+      "includingLoc" : "None"
+    },
+    "17" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "8.3",
+      "includingLoc" : "None"
+    },
+    "18" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "8.6",
+      "includingLoc" : "None"
+    },
+    "19" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "8.3",
+      "includingLoc" : "None"
+    },
+    "20" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "10.6",
+      "includingLoc" : "None"
+    },
+    "21" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "10.3",
+      "includingLoc" : "None"
+    },
+    "22" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "10.6",
+      "includingLoc" : "None"
+    },
+    "23" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "10.3",
+      "includingLoc" : "None"
+    },
+    "24" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "6.1",
+      "includingLoc" : "None"
+    },
+    "25" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "8.6",
+      "includingLoc" : "None"
+    },
+    "26" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "8.3",
+      "includingLoc" : "None"
+    },
+    "27" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "8.6",
+      "includingLoc" : "None"
+    },
+    "28" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "8.3",
+      "includingLoc" : "None"
+    },
+    "29" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "10.6",
+      "includingLoc" : "None"
+    },
+    "30" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "10.3",
+      "includingLoc" : "None"
+    },
+    "31" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "10.6",
+      "includingLoc" : "None"
+    },
+    "32" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "10.3",
+      "includingLoc" : "None"
+    },
+    "33" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "6.1",
+      "includingLoc" : "None"
+    },
+    "34" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "13.20",
+      "includingLoc" : "None"
+    },
+    "35" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "13.16",
+      "includingLoc" : "None"
+    },
+    "36" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "13.27",
+      "includingLoc" : "None"
+    },
+    "37" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "13.23",
+      "includingLoc" : "None"
+    },
+    "38" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "13.14",
+      "includingLoc" : "None"
+    },
+    "39" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "13.1",
+      "includingLoc" : "None"
+    },
+    "40" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "14.16",
+      "includingLoc" : "None"
+    },
+    "41" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "14.13",
+      "includingLoc" : "None"
+    },
+    "42" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "14.23",
+      "includingLoc" : "None"
+    },
+    "43" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "14.20",
+      "includingLoc" : "None"
+    },
+    "44" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "14.23",
+      "includingLoc" : "None"
+    },
+    "45" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "14.20",
+      "includingLoc" : "None"
+    },
+    "46" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "14.23",
+      "includingLoc" : "None"
+    },
+    "47" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "14.20",
+      "includingLoc" : "None"
+    },
+    "48" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "14.40",
+      "includingLoc" : "None"
+    },
+    "49" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "14.1",
+      "includingLoc" : "None"
+    },
+    "50" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "15.16",
+      "includingLoc" : "None"
+    },
+    "51" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "15.13",
+      "includingLoc" : "None"
+    },
+    "52" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "15.24",
+      "includingLoc" : "None"
+    },
+    "53" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "15.21",
+      "includingLoc" : "None"
+    },
+    "54" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "15.24",
+      "includingLoc" : "None"
+    },
+    "55" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "15.21",
+      "includingLoc" : "None"
+    },
+    "56" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "15.24",
+      "includingLoc" : "None"
+    },
+    "57" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "15.21",
+      "includingLoc" : "None"
+    },
+    "58" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "15.41",
+      "includingLoc" : "None"
+    },
+    "59" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "15.1",
+      "includingLoc" : "None"
+    },
+    "60" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "17.1",
+      "includingLoc" : "None"
+    },
+    "61" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "18.14",
+      "includingLoc" : "None"
+    },
+    "62" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "18.17",
+      "includingLoc" : "None"
+    },
+    "63" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "18.17",
+      "includingLoc" : "None"
+    },
+    "64" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "18.17",
+      "includingLoc" : "None"
+    },
+    "65" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "18.1",
+      "includingLoc" : "None"
+    },
+    "66" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "22.10",
+      "includingLoc" : "None"
+    },
+    "67" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "22.10",
+      "includingLoc" : "None"
+    },
+    "68" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "22.10",
+      "includingLoc" : "None"
+    },
+    "69" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "22.3",
+      "includingLoc" : "None"
+    },
+    "70" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "23.12",
+      "includingLoc" : "None"
+    },
+    "71" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "23.12",
+      "includingLoc" : "None"
+    },
+    "72" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "23.12",
+      "includingLoc" : "None"
+    },
+    "73" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "23.3",
+      "includingLoc" : "None"
+    },
+    "74" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "24.16",
+      "includingLoc" : "None"
+    },
+    "75" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "24.16",
+      "includingLoc" : "None"
+    },
+    "76" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "24.16",
+      "includingLoc" : "None"
+    },
+    "77" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "24.3",
+      "includingLoc" : "None"
+    },
+    "78" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "24.16",
+      "includingLoc" : "None"
+    },
+    "79" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "24.16",
+      "includingLoc" : "None"
+    },
+    "80" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "24.16",
+      "includingLoc" : "None"
+    },
+    "81" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "24.3",
+      "includingLoc" : "None"
+    },
+    "82" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "24.16",
+      "includingLoc" : "None"
+    },
+    "83" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "24.16",
+      "includingLoc" : "None"
+    },
+    "84" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "24.16",
+      "includingLoc" : "None"
+    },
+    "85" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "24.3",
+      "includingLoc" : "None"
+    },
+    "86" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "21.1",
+      "includingLoc" : "None"
+    },
+    "87" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "28.10",
+      "includingLoc" : "None"
+    },
+    "88" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "28.21",
+      "includingLoc" : "None"
+    },
+    "89" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "28.3",
+      "includingLoc" : "None"
+    },
+    "90" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "29.10",
+      "includingLoc" : "None"
+    },
+    "91" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "29.21",
+      "includingLoc" : "None"
+    },
+    "92" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "29.3",
+      "includingLoc" : "None"
+    },
+    "93" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "29.10",
+      "includingLoc" : "None"
+    },
+    "94" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "29.21",
+      "includingLoc" : "None"
+    },
+    "95" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "29.3",
+      "includingLoc" : "None"
+    },
+    "96" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "29.10",
+      "includingLoc" : "None"
+    },
+    "97" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "29.21",
+      "includingLoc" : "None"
+    },
+    "98" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "29.3",
+      "includingLoc" : "None"
+    },
+    "99" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "27.1",
+      "includingLoc" : "None"
+    },
+    "100" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "32.24",
+      "includingLoc" : "None"
+    },
+    "101" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "32.27",
+      "includingLoc" : "None"
+    },
+    "102" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "32.27",
+      "includingLoc" : "None"
+    },
+    "103" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "32.27",
+      "includingLoc" : "None"
+    },
+    "104" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "32.1",
+      "includingLoc" : "None"
+    },
+    "105" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "34.31",
+      "includingLoc" : "None"
+    },
+    "106" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "34.34",
+      "includingLoc" : "None"
+    },
+    "107" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "34.45",
+      "includingLoc" : "None"
+    },
+    "108" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "34.1",
+      "includingLoc" : "None"
+    },
+    "109" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "37.3",
+      "includingLoc" : "None"
+    },
+    "110" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "38.3",
+      "includingLoc" : "None"
+    },
+    "111" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "39.3",
+      "includingLoc" : "None"
+    },
+    "112" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "40.3",
+      "includingLoc" : "None"
+    },
+    "113" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "40.3",
+      "includingLoc" : "None"
+    },
+    "114" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "40.3",
+      "includingLoc" : "None"
+    },
+    "115" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "36.1",
+      "includingLoc" : "None"
+    },
+    "116" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "43.26",
+      "includingLoc" : "None"
+    },
+    "117" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "43.1",
+      "includingLoc" : "None"
+    },
+    "118" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "44.15",
+      "includingLoc" : "None"
+    },
+    "119" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",
+      "pos" : "44.1",
+      "includingLoc" : "None"
     }
   }
 }

--- a/tests/types/types_locations.json
+++ b/tests/types/types_locations.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion": "[ fpp version ]",
+  "fppVersion": "v3.1.0a10-46-g5b2da7ca1",
   "locationMap": {
     "0": {
       "file": "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",


### PR DESCRIPTION
- Updated to work with FPP v3.1.0.
- Added minimum FPP version check and throw an error if the input JSON files are not compatible.
- Update error messages to include node location information (if present).