### PR TITLE
Format JSON refs

### DIFF
--- a/tests/generate_ref_files.py
+++ b/tests/generate_ref_files.py
@@ -90,7 +90,7 @@ def create_json_ref_files(
 ):
     fpp_to_json_cmd: List[str] = [str(fpp_to_json), "-f", fpp_ref_model]
     if input_file:
-        fpp_to_json_cmd = [str(fpp_to_json), fpp_ref_model, input_file]
+        fpp_to_json_cmd = [str(fpp_to_json), "-f", fpp_ref_model, input_file]
     # Run fpp-to-json on reference model and save output to test case directory
     result = subprocess.run(fpp_to_json_cmd)
     if result.returncode != 0:

--- a/tests/generate_ref_files.py
+++ b/tests/generate_ref_files.py
@@ -88,7 +88,7 @@ def create_json_ref_files(
     test_name: str,
     input_file: Optional[str] = None,
 ):
-    fpp_to_json_cmd: List[str] = [str(fpp_to_json), fpp_ref_model]
+    fpp_to_json_cmd: List[str] = [str(fpp_to_json), "-f", fpp_ref_model]
     if input_file:
         fpp_to_json_cmd = [str(fpp_to_json), fpp_ref_model, input_file]
     # Run fpp-to-json on reference model and save output to test case directory


### PR DESCRIPTION
This PR is a tandem with https://github.com/nasa/fpp/pull/1004. That PR changes the default `fpp-to-json` behavior to dump minimized JSON by default (no whitespace). This PR includes the new option that will generate ref files with whitespace.