### PR TITLE
Update code and tests for v3.3.0

### DIFF
--- a/fprime_python_model/fpp_ast/fpp_ast.py
+++ b/fprime_python_model/fpp_ast/fpp_ast.py
@@ -535,6 +535,7 @@ class DefTopology(FrozenAstData):
     :type members: List[TopologyMember]
     """
 
+    isDeployment: bool
     name: Ident
     members: List["TopologyMember"]
     implements: List[AstNode[QualIdent]]

--- a/fprime_python_model/translators/ast_translator.py
+++ b/fprime_python_model/translators/ast_translator.py
@@ -1157,6 +1157,7 @@ class AstTranslator:
                     member = fpp_ast.ModuleMemberDefTopology(
                         AstNode.create_with_id(
                             fpp_ast.DefTopology(
+                                data["isDeployment"],
                                 data["name"],
                                 self.translate_topology_members(data["members"]),
                                 [

--- a/fprime_python_model/utils/fpp_writer.py
+++ b/fprime_python_model/utils/fpp_writer.py
@@ -512,6 +512,10 @@ class FppWriter(AstVisitor, LineUtils):
         _, node, _ = a_node
         data = node.data
 
+        if data.isDeployment:
+            topology = "deployment topology"
+        else:
+            topology = "topology"
         implements_clause = (
             [n.data for n in data.implements] if data.implements else None
         )
@@ -519,7 +523,7 @@ class FppWriter(AstVisitor, LineUtils):
         header = Lines(
             [
                 self.line(
-                    f"topology {self.ident(data.name)} "
+                    f"{topology} {self.ident(data.name)} "
                     + ("implements" if implements_clause else "{")
                 )
             ]

--- a/tests/active_component/active_component_analysis.json
+++ b/tests/active_component/active_component_analysis.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion" : "v3.2.0",
+  "fppVersion" : "v3.3.0a16-110-g291b338cc",
   "analysis" : {
     "componentInstanceMap" : {
       "165" : {

--- a/tests/active_component/active_component_ast.json
+++ b/tests/active_component/active_component_ast.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion" : "v3.2.0",
+  "fppVersion" : "v3.3.0a16-110-g291b338cc",
   "ast" : [
     {
       "members" : [

--- a/tests/active_component/active_component_locations.json
+++ b/tests/active_component/active_component_locations.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion" : "v3.2.0",
+  "fppVersion" : "v3.3.0a16-110-g291b338cc",
   "locationMap" : {
     "0" : {
       "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/activeComponents.fpp",

--- a/tests/command_patterned_connections/command_patterned_connections_analysis.json
+++ b/tests/command_patterned_connections/command_patterned_connections_analysis.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion" : "v3.2.0",
+  "fppVersion" : "v3.3.0a16-110-g291b338cc",
   "analysis" : {
     "componentInstanceMap" : {
       "36" : {
@@ -1526,6 +1526,145 @@
             {
               "interfaceInstance" : {
                 "InterfaceComponentInstance" : {
+                  "astNodeId" : 40
+                }
+              },
+              "portInstance" : {
+                "Special" : {
+                  "aNode" : {
+                    "astNodeId" : 31
+                  },
+                  "specifier" : {
+                    "inputKind" : "None",
+                    "kind" : {
+                      "CommandResp" : {
+                        
+                      }
+                    },
+                    "name" : "cmdResponseOut",
+                    "priority" : "None",
+                    "queueFull" : "None"
+                  },
+                  "symbol" : {
+                    "Port" : {
+                      "nodeId" : 4,
+                      "unqualifiedName" : "CmdResponse"
+                    }
+                  },
+                  "priority" : "None",
+                  "queueFull" : "None",
+                  "importNodeIds" : [
+                  ]
+                }
+              }
+            },
+            [
+              {
+                "from" : {
+                  "loc" : {
+                    "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+                    "pos" : "22.5",
+                    "includingLoc" : "None"
+                  },
+                  "port" : {
+                    "interfaceInstance" : {
+                      "InterfaceComponentInstance" : {
+                        "astNodeId" : 40
+                      }
+                    },
+                    "portInstance" : {
+                      "Special" : {
+                        "aNode" : {
+                          "astNodeId" : 31
+                        },
+                        "specifier" : {
+                          "inputKind" : "None",
+                          "kind" : {
+                            "CommandResp" : {
+                              
+                            }
+                          },
+                          "name" : "cmdResponseOut",
+                          "priority" : "None",
+                          "queueFull" : "None"
+                        },
+                        "symbol" : {
+                          "Port" : {
+                            "nodeId" : 4,
+                            "unqualifiedName" : "CmdResponse"
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None",
+                        "importNodeIds" : [
+                        ]
+                      }
+                    }
+                  },
+                  "portNumber" : "None",
+                  "topologyPort" : "None"
+                },
+                "to" : {
+                  "loc" : {
+                    "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+                    "pos" : "22.5",
+                    "includingLoc" : "None"
+                  },
+                  "port" : {
+                    "interfaceInstance" : {
+                      "InterfaceComponentInstance" : {
+                        "astNodeId" : 36
+                      }
+                    },
+                    "portInstance" : {
+                      "General" : {
+                        "aNode" : {
+                          "astNodeId" : 25
+                        },
+                        "specifier" : {
+                          "kind" : {
+                            "SyncInput" : {
+                              
+                            }
+                          },
+                          "name" : "cmdResponseIn",
+                          "size" : "None",
+                          "port" : {
+                            "Some" : {
+                              "astNodeId" : 24
+                            }
+                          },
+                          "priority" : "None",
+                          "queueFull" : "None"
+                        },
+                        "kind" : "SyncInput",
+                        "size" : 1,
+                        "ty" : {
+                          "DefPort" : {
+                            "symbol" : {
+                              "Port" : {
+                                "nodeId" : 4,
+                                "unqualifiedName" : "CmdResponse"
+                              }
+                            }
+                          }
+                        },
+                        "importNodeIds" : [
+                        ]
+                      }
+                    }
+                  },
+                  "portNumber" : "None",
+                  "topologyPort" : "None"
+                },
+                "isUnmatched" : false
+              }
+            ]
+          ],
+          [
+            {
+              "interfaceInstance" : {
+                "InterfaceComponentInstance" : {
                   "astNodeId" : 36
                 }
               },
@@ -1669,7 +1808,9 @@
                 "isUnmatched" : false
               }
             ]
-          ],
+          ]
+        ],
+        "inputConnectionMap" : [
           [
             {
               "interfaceInstance" : {
@@ -1680,23 +1821,23 @@
               "portInstance" : {
                 "Special" : {
                   "aNode" : {
-                    "astNodeId" : 31
+                    "astNodeId" : 28
                   },
                   "specifier" : {
                     "inputKind" : "None",
                     "kind" : {
-                      "CommandResp" : {
+                      "CommandRecv" : {
                         
                       }
                     },
-                    "name" : "cmdResponseOut",
+                    "name" : "cmdIn",
                     "priority" : "None",
                     "queueFull" : "None"
                   },
                   "symbol" : {
                     "Port" : {
-                      "nodeId" : 4,
-                      "unqualifiedName" : "CmdResponse"
+                      "nodeId" : 0,
+                      "unqualifiedName" : "Cmd"
                     }
                   },
                   "priority" : "None",
@@ -1717,33 +1858,42 @@
                   "port" : {
                     "interfaceInstance" : {
                       "InterfaceComponentInstance" : {
-                        "astNodeId" : 40
+                        "astNodeId" : 36
                       }
                     },
                     "portInstance" : {
-                      "Special" : {
+                      "General" : {
                         "aNode" : {
-                          "astNodeId" : 31
+                          "astNodeId" : 13
                         },
                         "specifier" : {
-                          "inputKind" : "None",
                           "kind" : {
-                            "CommandResp" : {
+                            "Output" : {
                               
                             }
                           },
-                          "name" : "cmdResponseOut",
+                          "name" : "cmdOut",
+                          "size" : "None",
+                          "port" : {
+                            "Some" : {
+                              "astNodeId" : 12
+                            }
+                          },
                           "priority" : "None",
                           "queueFull" : "None"
                         },
-                        "symbol" : {
-                          "Port" : {
-                            "nodeId" : 4,
-                            "unqualifiedName" : "CmdResponse"
+                        "kind" : "Output",
+                        "size" : 1,
+                        "ty" : {
+                          "DefPort" : {
+                            "symbol" : {
+                              "Port" : {
+                                "nodeId" : 0,
+                                "unqualifiedName" : "Cmd"
+                              }
+                            }
                           }
                         },
-                        "priority" : "None",
-                        "queueFull" : "None",
                         "importNodeIds" : [
                         ]
                       }
@@ -1761,42 +1911,33 @@
                   "port" : {
                     "interfaceInstance" : {
                       "InterfaceComponentInstance" : {
-                        "astNodeId" : 36
+                        "astNodeId" : 40
                       }
                     },
                     "portInstance" : {
-                      "General" : {
+                      "Special" : {
                         "aNode" : {
-                          "astNodeId" : 25
+                          "astNodeId" : 28
                         },
                         "specifier" : {
+                          "inputKind" : "None",
                           "kind" : {
-                            "SyncInput" : {
+                            "CommandRecv" : {
                               
                             }
                           },
-                          "name" : "cmdResponseIn",
-                          "size" : "None",
-                          "port" : {
-                            "Some" : {
-                              "astNodeId" : 24
-                            }
-                          },
+                          "name" : "cmdIn",
                           "priority" : "None",
                           "queueFull" : "None"
                         },
-                        "kind" : "SyncInput",
-                        "size" : 1,
-                        "ty" : {
-                          "DefPort" : {
-                            "symbol" : {
-                              "Port" : {
-                                "nodeId" : 4,
-                                "unqualifiedName" : "CmdResponse"
-                              }
-                            }
+                        "symbol" : {
+                          "Port" : {
+                            "nodeId" : 0,
+                            "unqualifiedName" : "Cmd"
                           }
                         },
+                        "priority" : "None",
+                        "queueFull" : "None",
                         "importNodeIds" : [
                         ]
                       }
@@ -1808,9 +1949,7 @@
                 "isUnmatched" : false
               }
             ]
-          ]
-        ],
-        "inputConnectionMap" : [
+          ],
           [
             {
               "interfaceInstance" : {
@@ -1947,145 +2086,6 @@
                             }
                           }
                         },
-                        "importNodeIds" : [
-                        ]
-                      }
-                    }
-                  },
-                  "portNumber" : "None",
-                  "topologyPort" : "None"
-                },
-                "isUnmatched" : false
-              }
-            ]
-          ],
-          [
-            {
-              "interfaceInstance" : {
-                "InterfaceComponentInstance" : {
-                  "astNodeId" : 40
-                }
-              },
-              "portInstance" : {
-                "Special" : {
-                  "aNode" : {
-                    "astNodeId" : 28
-                  },
-                  "specifier" : {
-                    "inputKind" : "None",
-                    "kind" : {
-                      "CommandRecv" : {
-                        
-                      }
-                    },
-                    "name" : "cmdIn",
-                    "priority" : "None",
-                    "queueFull" : "None"
-                  },
-                  "symbol" : {
-                    "Port" : {
-                      "nodeId" : 0,
-                      "unqualifiedName" : "Cmd"
-                    }
-                  },
-                  "priority" : "None",
-                  "queueFull" : "None",
-                  "importNodeIds" : [
-                  ]
-                }
-              }
-            },
-            [
-              {
-                "from" : {
-                  "loc" : {
-                    "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
-                    "pos" : "22.5",
-                    "includingLoc" : "None"
-                  },
-                  "port" : {
-                    "interfaceInstance" : {
-                      "InterfaceComponentInstance" : {
-                        "astNodeId" : 36
-                      }
-                    },
-                    "portInstance" : {
-                      "General" : {
-                        "aNode" : {
-                          "astNodeId" : 13
-                        },
-                        "specifier" : {
-                          "kind" : {
-                            "Output" : {
-                              
-                            }
-                          },
-                          "name" : "cmdOut",
-                          "size" : "None",
-                          "port" : {
-                            "Some" : {
-                              "astNodeId" : 12
-                            }
-                          },
-                          "priority" : "None",
-                          "queueFull" : "None"
-                        },
-                        "kind" : "Output",
-                        "size" : 1,
-                        "ty" : {
-                          "DefPort" : {
-                            "symbol" : {
-                              "Port" : {
-                                "nodeId" : 0,
-                                "unqualifiedName" : "Cmd"
-                              }
-                            }
-                          }
-                        },
-                        "importNodeIds" : [
-                        ]
-                      }
-                    }
-                  },
-                  "portNumber" : "None",
-                  "topologyPort" : "None"
-                },
-                "to" : {
-                  "loc" : {
-                    "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
-                    "pos" : "22.5",
-                    "includingLoc" : "None"
-                  },
-                  "port" : {
-                    "interfaceInstance" : {
-                      "InterfaceComponentInstance" : {
-                        "astNodeId" : 40
-                      }
-                    },
-                    "portInstance" : {
-                      "Special" : {
-                        "aNode" : {
-                          "astNodeId" : 28
-                        },
-                        "specifier" : {
-                          "inputKind" : "None",
-                          "kind" : {
-                            "CommandRecv" : {
-                              
-                            }
-                          },
-                          "name" : "cmdIn",
-                          "priority" : "None",
-                          "queueFull" : "None"
-                        },
-                        "symbol" : {
-                          "Port" : {
-                            "nodeId" : 0,
-                            "unqualifiedName" : "Cmd"
-                          }
-                        },
-                        "priority" : "None",
-                        "queueFull" : "None",
                         "importNodeIds" : [
                         ]
                       }
@@ -2248,109 +2248,6 @@
           ]
         ],
         "fromPortNumberMap" : [
-          [
-            {
-              "from" : {
-                "loc" : {
-                  "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
-                  "pos" : "22.5",
-                  "includingLoc" : "None"
-                },
-                "port" : {
-                  "interfaceInstance" : {
-                    "InterfaceComponentInstance" : {
-                      "astNodeId" : 36
-                    }
-                  },
-                  "portInstance" : {
-                    "General" : {
-                      "aNode" : {
-                        "astNodeId" : 13
-                      },
-                      "specifier" : {
-                        "kind" : {
-                          "Output" : {
-                            
-                          }
-                        },
-                        "name" : "cmdOut",
-                        "size" : "None",
-                        "port" : {
-                          "Some" : {
-                            "astNodeId" : 12
-                          }
-                        },
-                        "priority" : "None",
-                        "queueFull" : "None"
-                      },
-                      "kind" : "Output",
-                      "size" : 1,
-                      "ty" : {
-                        "DefPort" : {
-                          "symbol" : {
-                            "Port" : {
-                              "nodeId" : 0,
-                              "unqualifiedName" : "Cmd"
-                            }
-                          }
-                        }
-                      },
-                      "importNodeIds" : [
-                      ]
-                    }
-                  }
-                },
-                "portNumber" : "None",
-                "topologyPort" : "None"
-              },
-              "to" : {
-                "loc" : {
-                  "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
-                  "pos" : "22.5",
-                  "includingLoc" : "None"
-                },
-                "port" : {
-                  "interfaceInstance" : {
-                    "InterfaceComponentInstance" : {
-                      "astNodeId" : 40
-                    }
-                  },
-                  "portInstance" : {
-                    "Special" : {
-                      "aNode" : {
-                        "astNodeId" : 28
-                      },
-                      "specifier" : {
-                        "inputKind" : "None",
-                        "kind" : {
-                          "CommandRecv" : {
-                            
-                          }
-                        },
-                        "name" : "cmdIn",
-                        "priority" : "None",
-                        "queueFull" : "None"
-                      },
-                      "symbol" : {
-                        "Port" : {
-                          "nodeId" : 0,
-                          "unqualifiedName" : "Cmd"
-                        }
-                      },
-                      "priority" : "None",
-                      "queueFull" : "None",
-                      "importNodeIds" : [
-                      ]
-                    }
-                  }
-                },
-                "portNumber" : "None",
-                "topologyPort" : "None"
-              },
-              "isUnmatched" : false
-            },
-            0
-          ],
           [
             {
               "from" : {
@@ -2545,6 +2442,109 @@
                           }
                         }
                       },
+                      "importNodeIds" : [
+                      ]
+                    }
+                  }
+                },
+                "portNumber" : "None",
+                "topologyPort" : "None"
+              },
+              "isUnmatched" : false
+            },
+            0
+          ],
+          [
+            {
+              "from" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+                  "pos" : "22.5",
+                  "includingLoc" : "None"
+                },
+                "port" : {
+                  "interfaceInstance" : {
+                    "InterfaceComponentInstance" : {
+                      "astNodeId" : 36
+                    }
+                  },
+                  "portInstance" : {
+                    "General" : {
+                      "aNode" : {
+                        "astNodeId" : 13
+                      },
+                      "specifier" : {
+                        "kind" : {
+                          "Output" : {
+                            
+                          }
+                        },
+                        "name" : "cmdOut",
+                        "size" : "None",
+                        "port" : {
+                          "Some" : {
+                            "astNodeId" : 12
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None"
+                      },
+                      "kind" : "Output",
+                      "size" : 1,
+                      "ty" : {
+                        "DefPort" : {
+                          "symbol" : {
+                            "Port" : {
+                              "nodeId" : 0,
+                              "unqualifiedName" : "Cmd"
+                            }
+                          }
+                        }
+                      },
+                      "importNodeIds" : [
+                      ]
+                    }
+                  }
+                },
+                "portNumber" : "None",
+                "topologyPort" : "None"
+              },
+              "to" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",
+                  "pos" : "22.5",
+                  "includingLoc" : "None"
+                },
+                "port" : {
+                  "interfaceInstance" : {
+                    "InterfaceComponentInstance" : {
+                      "astNodeId" : 40
+                    }
+                  },
+                  "portInstance" : {
+                    "Special" : {
+                      "aNode" : {
+                        "astNodeId" : 28
+                      },
+                      "specifier" : {
+                        "inputKind" : "None",
+                        "kind" : {
+                          "CommandRecv" : {
+                            
+                          }
+                        },
+                        "name" : "cmdIn",
+                        "priority" : "None",
+                        "queueFull" : "None"
+                      },
+                      "symbol" : {
+                        "Port" : {
+                          "nodeId" : 0,
+                          "unqualifiedName" : "Cmd"
+                        }
+                      },
+                      "priority" : "None",
+                      "queueFull" : "None",
                       "importNodeIds" : [
                       ]
                     }
@@ -3002,31 +3002,7 @@
       
     },
     "dictionaryMap" : {
-      "106" : {
-        "usedSymbolSet" : [
-        ],
-        "commandEntryMap" : {
-          
-        },
-        "tlmChannelEntryMap" : {
-          
-        },
-        "eventEntryMap" : {
-          
-        },
-        "paramEntryMap" : {
-          
-        },
-        "recordEntryMap" : {
-          
-        },
-        "containerEntryMap" : {
-          
-        },
-        "tlmPacketSetMap" : {
-          
-        }
-      }
+      
     }
   }
 }

--- a/tests/command_patterned_connections/command_patterned_connections_ast.json
+++ b/tests/command_patterned_connections/command_patterned_connections_ast.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion" : "v3.2.0",
+  "fppVersion" : "v3.3.0a16-110-g291b338cc",
   "ast" : [
     {
       "members" : [
@@ -495,6 +495,7 @@
                             "node" : {
                               "AstNode" : {
                                 "data" : {
+                                  "isDeployment" : false,
                                   "name" : "T",
                                   "members" : [
                                     [

--- a/tests/command_patterned_connections/command_patterned_connections_locations.json
+++ b/tests/command_patterned_connections/command_patterned_connections_locations.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion" : "v3.2.0",
+  "fppVersion" : "v3.3.0a16-110-g291b338cc",
   "locationMap" : {
     "0" : {
       "file" : "[ local path prefix ]/compiler/tools/fpp-check/test/connection_pattern/command_ok.fpp",

--- a/tests/commands/commands_analysis.json
+++ b/tests/commands/commands_analysis.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion" : "v3.2.0",
+  "fppVersion" : "v3.3.0a16-110-g291b338cc",
   "analysis" : {
     "componentInstanceMap" : {
       

--- a/tests/commands/commands_ast.json
+++ b/tests/commands/commands_ast.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion" : "v3.2.0",
+  "fppVersion" : "v3.3.0a16-110-g291b338cc",
   "ast" : [
     {
       "members" : [

--- a/tests/commands/commands_locations.json
+++ b/tests/commands/commands_locations.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion" : "v3.2.0",
+  "fppVersion" : "v3.3.0a16-110-g291b338cc",
   "locationMap" : {
     "0" : {
       "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/commands.fpp",

--- a/tests/constants/constants_analysis.json
+++ b/tests/constants/constants_analysis.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion" : "v3.2.0",
+  "fppVersion" : "v3.3.0a16-110-g291b338cc",
   "analysis" : {
     "componentInstanceMap" : {
       

--- a/tests/constants/constants_ast.json
+++ b/tests/constants/constants_ast.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion" : "v3.2.0",
+  "fppVersion" : "v3.3.0a16-110-g291b338cc",
   "ast" : [
     {
       "members" : [

--- a/tests/constants/constants_locations.json
+++ b/tests/constants/constants_locations.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion" : "v3.2.0",
+  "fppVersion" : "v3.3.0a16-110-g291b338cc",
   "locationMap" : {
     "0" : {
       "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/constants.fpp",

--- a/tests/data_products/data_products_analysis.json
+++ b/tests/data_products/data_products_analysis.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion" : "v3.2.0",
+  "fppVersion" : "v3.3.0a16-110-g291b338cc",
   "analysis" : {
     "componentInstanceMap" : {
       

--- a/tests/data_products/data_products_ast.json
+++ b/tests/data_products/data_products_ast.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion" : "v3.2.0",
+  "fppVersion" : "v3.3.0a16-110-g291b338cc",
   "ast" : [
     {
       "members" : [

--- a/tests/data_products/data_products_locations.json
+++ b/tests/data_products/data_products_locations.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion" : "v3.2.0",
+  "fppVersion" : "v3.3.0a16-110-g291b338cc",
   "locationMap" : {
     "0" : {
       "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/dataProducts.fpp",

--- a/tests/events/events_analysis.json
+++ b/tests/events/events_analysis.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion" : "v3.2.0",
+  "fppVersion" : "v3.3.0a16-110-g291b338cc",
   "analysis" : {
     "componentInstanceMap" : {
       

--- a/tests/events/events_ast.json
+++ b/tests/events/events_ast.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion" : "v3.2.0",
+  "fppVersion" : "v3.3.0a16-110-g291b338cc",
   "ast" : [
     {
       "members" : [

--- a/tests/events/events_locations.json
+++ b/tests/events/events_locations.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion" : "v3.2.0",
+  "fppVersion" : "v3.3.0a16-110-g291b338cc",
   "locationMap" : {
     "0" : {
       "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/events.fpp",

--- a/tests/generate_ref_files.py
+++ b/tests/generate_ref_files.py
@@ -40,7 +40,7 @@ additional_tests: Dict[str, Tuple[str, Optional[str]]] = {
         "compiler/tools/fpp-to-json/test/fprime/defs.fpp",
     ),
     "location_specifier": (
-        "compiler/tools/fpp-depend/test/dictionary_no_top.fpp",
+        "compiler/tools/fpp-depend/test/dictionary_no_deployment_top.fpp",
         None,
     ),
     "command_patterned_connections": (

--- a/tests/imported_topology/imported_topology.fpp
+++ b/tests/imported_topology/imported_topology.fpp
@@ -61,7 +61,7 @@ topology Simple2 {
 }
 
 @ A third Simple Topology
-topology Simple3 {
+deployment topology Simple3 {
 
   instance Simple2
 

--- a/tests/imported_topology/imported_topology_analysis.json
+++ b/tests/imported_topology/imported_topology_analysis.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion" : "v3.2.0",
+  "fppVersion" : "v3.3.0a16-110-g291b338cc",
   "analysis" : {
     "componentInstanceMap" : {
       "17" : {
@@ -1082,163 +1082,6 @@
             {
               "interfaceInstance" : {
                 "InterfaceComponentInstance" : {
-                  "astNodeId" : 21
-                }
-              },
-              "portInstance" : {
-                "General" : {
-                  "aNode" : {
-                    "astNodeId" : 3
-                  },
-                  "specifier" : {
-                    "kind" : {
-                      "SyncInput" : {
-                        
-                      }
-                    },
-                    "name" : "pIn",
-                    "size" : "None",
-                    "port" : {
-                      "Some" : {
-                        "astNodeId" : 2
-                      }
-                    },
-                    "priority" : "None",
-                    "queueFull" : "None"
-                  },
-                  "kind" : "SyncInput",
-                  "size" : 1,
-                  "ty" : {
-                    "DefPort" : {
-                      "symbol" : {
-                        "Port" : {
-                          "nodeId" : 0,
-                          "unqualifiedName" : "P"
-                        }
-                      }
-                    }
-                  },
-                  "importNodeIds" : [
-                  ]
-                }
-              }
-            },
-            [
-              {
-                "from" : {
-                  "loc" : {
-                    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                    "pos" : "23.5",
-                    "includingLoc" : "None"
-                  },
-                  "port" : {
-                    "interfaceInstance" : {
-                      "InterfaceComponentInstance" : {
-                        "astNodeId" : 17
-                      }
-                    },
-                    "portInstance" : {
-                      "General" : {
-                        "aNode" : {
-                          "astNodeId" : 12
-                        },
-                        "specifier" : {
-                          "kind" : {
-                            "Output" : {
-                              
-                            }
-                          },
-                          "name" : "pOut",
-                          "size" : "None",
-                          "port" : {
-                            "Some" : {
-                              "astNodeId" : 11
-                            }
-                          },
-                          "priority" : "None",
-                          "queueFull" : "None"
-                        },
-                        "kind" : "Output",
-                        "size" : 1,
-                        "ty" : {
-                          "DefPort" : {
-                            "symbol" : {
-                              "Port" : {
-                                "nodeId" : 0,
-                                "unqualifiedName" : "P"
-                              }
-                            }
-                          }
-                        },
-                        "importNodeIds" : [
-                        ]
-                      }
-                    }
-                  },
-                  "portNumber" : "None",
-                  "topologyPort" : "None"
-                },
-                "to" : {
-                  "loc" : {
-                    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                    "pos" : "23.16",
-                    "includingLoc" : "None"
-                  },
-                  "port" : {
-                    "interfaceInstance" : {
-                      "InterfaceComponentInstance" : {
-                        "astNodeId" : 21
-                      }
-                    },
-                    "portInstance" : {
-                      "General" : {
-                        "aNode" : {
-                          "astNodeId" : 3
-                        },
-                        "specifier" : {
-                          "kind" : {
-                            "SyncInput" : {
-                              
-                            }
-                          },
-                          "name" : "pIn",
-                          "size" : "None",
-                          "port" : {
-                            "Some" : {
-                              "astNodeId" : 2
-                            }
-                          },
-                          "priority" : "None",
-                          "queueFull" : "None"
-                        },
-                        "kind" : "SyncInput",
-                        "size" : 1,
-                        "ty" : {
-                          "DefPort" : {
-                            "symbol" : {
-                              "Port" : {
-                                "nodeId" : 0,
-                                "unqualifiedName" : "P"
-                              }
-                            }
-                          }
-                        },
-                        "importNodeIds" : [
-                        ]
-                      }
-                    }
-                  },
-                  "portNumber" : "None",
-                  "topologyPort" : "None"
-                },
-                "isUnmatched" : false
-              }
-            ]
-          ],
-          [
-            {
-              "interfaceInstance" : {
-                "InterfaceComponentInstance" : {
                   "astNodeId" : 17
                 }
               },
@@ -1345,6 +1188,163 @@
                     "interfaceInstance" : {
                       "InterfaceComponentInstance" : {
                         "astNodeId" : 17
+                      }
+                    },
+                    "portInstance" : {
+                      "General" : {
+                        "aNode" : {
+                          "astNodeId" : 3
+                        },
+                        "specifier" : {
+                          "kind" : {
+                            "SyncInput" : {
+                              
+                            }
+                          },
+                          "name" : "pIn",
+                          "size" : "None",
+                          "port" : {
+                            "Some" : {
+                              "astNodeId" : 2
+                            }
+                          },
+                          "priority" : "None",
+                          "queueFull" : "None"
+                        },
+                        "kind" : "SyncInput",
+                        "size" : 1,
+                        "ty" : {
+                          "DefPort" : {
+                            "symbol" : {
+                              "Port" : {
+                                "nodeId" : 0,
+                                "unqualifiedName" : "P"
+                              }
+                            }
+                          }
+                        },
+                        "importNodeIds" : [
+                        ]
+                      }
+                    }
+                  },
+                  "portNumber" : "None",
+                  "topologyPort" : "None"
+                },
+                "isUnmatched" : false
+              }
+            ]
+          ],
+          [
+            {
+              "interfaceInstance" : {
+                "InterfaceComponentInstance" : {
+                  "astNodeId" : 21
+                }
+              },
+              "portInstance" : {
+                "General" : {
+                  "aNode" : {
+                    "astNodeId" : 3
+                  },
+                  "specifier" : {
+                    "kind" : {
+                      "SyncInput" : {
+                        
+                      }
+                    },
+                    "name" : "pIn",
+                    "size" : "None",
+                    "port" : {
+                      "Some" : {
+                        "astNodeId" : 2
+                      }
+                    },
+                    "priority" : "None",
+                    "queueFull" : "None"
+                  },
+                  "kind" : "SyncInput",
+                  "size" : 1,
+                  "ty" : {
+                    "DefPort" : {
+                      "symbol" : {
+                        "Port" : {
+                          "nodeId" : 0,
+                          "unqualifiedName" : "P"
+                        }
+                      }
+                    }
+                  },
+                  "importNodeIds" : [
+                  ]
+                }
+              }
+            },
+            [
+              {
+                "from" : {
+                  "loc" : {
+                    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                    "pos" : "23.5",
+                    "includingLoc" : "None"
+                  },
+                  "port" : {
+                    "interfaceInstance" : {
+                      "InterfaceComponentInstance" : {
+                        "astNodeId" : 17
+                      }
+                    },
+                    "portInstance" : {
+                      "General" : {
+                        "aNode" : {
+                          "astNodeId" : 12
+                        },
+                        "specifier" : {
+                          "kind" : {
+                            "Output" : {
+                              
+                            }
+                          },
+                          "name" : "pOut",
+                          "size" : "None",
+                          "port" : {
+                            "Some" : {
+                              "astNodeId" : 11
+                            }
+                          },
+                          "priority" : "None",
+                          "queueFull" : "None"
+                        },
+                        "kind" : "Output",
+                        "size" : 1,
+                        "ty" : {
+                          "DefPort" : {
+                            "symbol" : {
+                              "Port" : {
+                                "nodeId" : 0,
+                                "unqualifiedName" : "P"
+                              }
+                            }
+                          }
+                        },
+                        "importNodeIds" : [
+                        ]
+                      }
+                    }
+                  },
+                  "portNumber" : "None",
+                  "topologyPort" : "None"
+                },
+                "to" : {
+                  "loc" : {
+                    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                    "pos" : "23.16",
+                    "includingLoc" : "None"
+                  },
+                  "port" : {
+                    "interfaceInstance" : {
+                      "InterfaceComponentInstance" : {
+                        "astNodeId" : 21
                       }
                     },
                     "portInstance" : {
@@ -1625,118 +1625,6 @@
               "from" : {
                 "loc" : {
                   "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                  "pos" : "28.5",
-                  "includingLoc" : "None"
-                },
-                "port" : {
-                  "interfaceInstance" : {
-                    "InterfaceComponentInstance" : {
-                      "astNodeId" : 21
-                    }
-                  },
-                  "portInstance" : {
-                    "General" : {
-                      "aNode" : {
-                        "astNodeId" : 12
-                      },
-                      "specifier" : {
-                        "kind" : {
-                          "Output" : {
-                            
-                          }
-                        },
-                        "name" : "pOut",
-                        "size" : "None",
-                        "port" : {
-                          "Some" : {
-                            "astNodeId" : 11
-                          }
-                        },
-                        "priority" : "None",
-                        "queueFull" : "None"
-                      },
-                      "kind" : "Output",
-                      "size" : 1,
-                      "ty" : {
-                        "DefPort" : {
-                          "symbol" : {
-                            "Port" : {
-                              "nodeId" : 0,
-                              "unqualifiedName" : "P"
-                            }
-                          }
-                        }
-                      },
-                      "importNodeIds" : [
-                      ]
-                    }
-                  }
-                },
-                "portNumber" : "None",
-                "topologyPort" : "None"
-              },
-              "to" : {
-                "loc" : {
-                  "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                  "pos" : "28.16",
-                  "includingLoc" : "None"
-                },
-                "port" : {
-                  "interfaceInstance" : {
-                    "InterfaceComponentInstance" : {
-                      "astNodeId" : 17
-                    }
-                  },
-                  "portInstance" : {
-                    "General" : {
-                      "aNode" : {
-                        "astNodeId" : 3
-                      },
-                      "specifier" : {
-                        "kind" : {
-                          "SyncInput" : {
-                            
-                          }
-                        },
-                        "name" : "pIn",
-                        "size" : "None",
-                        "port" : {
-                          "Some" : {
-                            "astNodeId" : 2
-                          }
-                        },
-                        "priority" : "None",
-                        "queueFull" : "None"
-                      },
-                      "kind" : "SyncInput",
-                      "size" : 1,
-                      "ty" : {
-                        "DefPort" : {
-                          "symbol" : {
-                            "Port" : {
-                              "nodeId" : 0,
-                              "unqualifiedName" : "P"
-                            }
-                          }
-                        }
-                      },
-                      "importNodeIds" : [
-                      ]
-                    }
-                  }
-                },
-                "portNumber" : "None",
-                "topologyPort" : "None"
-              },
-              "isUnmatched" : false
-            },
-            0
-          ],
-          [
-            {
-              "from" : {
-                "loc" : {
-                  "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
                   "pos" : "23.5",
                   "includingLoc" : "None"
                 },
@@ -1797,6 +1685,118 @@
                   "interfaceInstance" : {
                     "InterfaceComponentInstance" : {
                       "astNodeId" : 21
+                    }
+                  },
+                  "portInstance" : {
+                    "General" : {
+                      "aNode" : {
+                        "astNodeId" : 3
+                      },
+                      "specifier" : {
+                        "kind" : {
+                          "SyncInput" : {
+                            
+                          }
+                        },
+                        "name" : "pIn",
+                        "size" : "None",
+                        "port" : {
+                          "Some" : {
+                            "astNodeId" : 2
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None"
+                      },
+                      "kind" : "SyncInput",
+                      "size" : 1,
+                      "ty" : {
+                        "DefPort" : {
+                          "symbol" : {
+                            "Port" : {
+                              "nodeId" : 0,
+                              "unqualifiedName" : "P"
+                            }
+                          }
+                        }
+                      },
+                      "importNodeIds" : [
+                      ]
+                    }
+                  }
+                },
+                "portNumber" : "None",
+                "topologyPort" : "None"
+              },
+              "isUnmatched" : false
+            },
+            0
+          ],
+          [
+            {
+              "from" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                  "pos" : "28.5",
+                  "includingLoc" : "None"
+                },
+                "port" : {
+                  "interfaceInstance" : {
+                    "InterfaceComponentInstance" : {
+                      "astNodeId" : 21
+                    }
+                  },
+                  "portInstance" : {
+                    "General" : {
+                      "aNode" : {
+                        "astNodeId" : 12
+                      },
+                      "specifier" : {
+                        "kind" : {
+                          "Output" : {
+                            
+                          }
+                        },
+                        "name" : "pOut",
+                        "size" : "None",
+                        "port" : {
+                          "Some" : {
+                            "astNodeId" : 11
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None"
+                      },
+                      "kind" : "Output",
+                      "size" : 1,
+                      "ty" : {
+                        "DefPort" : {
+                          "symbol" : {
+                            "Port" : {
+                              "nodeId" : 0,
+                              "unqualifiedName" : "P"
+                            }
+                          }
+                        }
+                      },
+                      "importNodeIds" : [
+                      ]
+                    }
+                  }
+                },
+                "portNumber" : "None",
+                "topologyPort" : "None"
+              },
+              "to" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                  "pos" : "28.16",
+                  "includingLoc" : "None"
+                },
+                "port" : {
+                  "interfaceInstance" : {
+                    "InterfaceComponentInstance" : {
+                      "astNodeId" : 17
                     }
                   },
                   "portInstance" : {
@@ -2637,320 +2637,6 @@
             {
               "interfaceInstance" : {
                 "InterfaceComponentInstance" : {
-                  "astNodeId" : 25
-                }
-              },
-              "portInstance" : {
-                "General" : {
-                  "aNode" : {
-                    "astNodeId" : 12
-                  },
-                  "specifier" : {
-                    "kind" : {
-                      "Output" : {
-                        
-                      }
-                    },
-                    "name" : "pOut",
-                    "size" : "None",
-                    "port" : {
-                      "Some" : {
-                        "astNodeId" : 11
-                      }
-                    },
-                    "priority" : "None",
-                    "queueFull" : "None"
-                  },
-                  "kind" : "Output",
-                  "size" : 1,
-                  "ty" : {
-                    "DefPort" : {
-                      "symbol" : {
-                        "Port" : {
-                          "nodeId" : 0,
-                          "unqualifiedName" : "P"
-                        }
-                      }
-                    }
-                  },
-                  "importNodeIds" : [
-                  ]
-                }
-              }
-            },
-            [
-              {
-                "from" : {
-                  "loc" : {
-                    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                    "pos" : "43.5",
-                    "includingLoc" : "None"
-                  },
-                  "port" : {
-                    "interfaceInstance" : {
-                      "InterfaceComponentInstance" : {
-                        "astNodeId" : 25
-                      }
-                    },
-                    "portInstance" : {
-                      "General" : {
-                        "aNode" : {
-                          "astNodeId" : 12
-                        },
-                        "specifier" : {
-                          "kind" : {
-                            "Output" : {
-                              
-                            }
-                          },
-                          "name" : "pOut",
-                          "size" : "None",
-                          "port" : {
-                            "Some" : {
-                              "astNodeId" : 11
-                            }
-                          },
-                          "priority" : "None",
-                          "queueFull" : "None"
-                        },
-                        "kind" : "Output",
-                        "size" : 1,
-                        "ty" : {
-                          "DefPort" : {
-                            "symbol" : {
-                              "Port" : {
-                                "nodeId" : 0,
-                                "unqualifiedName" : "P"
-                              }
-                            }
-                          }
-                        },
-                        "importNodeIds" : [
-                        ]
-                      }
-                    }
-                  },
-                  "portNumber" : "None",
-                  "topologyPort" : "None"
-                },
-                "to" : {
-                  "loc" : {
-                    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                    "pos" : "43.16",
-                    "includingLoc" : "None"
-                  },
-                  "port" : {
-                    "interfaceInstance" : {
-                      "InterfaceComponentInstance" : {
-                        "astNodeId" : 29
-                      }
-                    },
-                    "portInstance" : {
-                      "General" : {
-                        "aNode" : {
-                          "astNodeId" : 3
-                        },
-                        "specifier" : {
-                          "kind" : {
-                            "SyncInput" : {
-                              
-                            }
-                          },
-                          "name" : "pIn",
-                          "size" : "None",
-                          "port" : {
-                            "Some" : {
-                              "astNodeId" : 2
-                            }
-                          },
-                          "priority" : "None",
-                          "queueFull" : "None"
-                        },
-                        "kind" : "SyncInput",
-                        "size" : 1,
-                        "ty" : {
-                          "DefPort" : {
-                            "symbol" : {
-                              "Port" : {
-                                "nodeId" : 0,
-                                "unqualifiedName" : "P"
-                              }
-                            }
-                          }
-                        },
-                        "importNodeIds" : [
-                        ]
-                      }
-                    }
-                  },
-                  "portNumber" : "None",
-                  "topologyPort" : "None"
-                },
-                "isUnmatched" : false
-              }
-            ]
-          ],
-          [
-            {
-              "interfaceInstance" : {
-                "InterfaceComponentInstance" : {
-                  "astNodeId" : 29
-                }
-              },
-              "portInstance" : {
-                "General" : {
-                  "aNode" : {
-                    "astNodeId" : 12
-                  },
-                  "specifier" : {
-                    "kind" : {
-                      "Output" : {
-                        
-                      }
-                    },
-                    "name" : "pOut",
-                    "size" : "None",
-                    "port" : {
-                      "Some" : {
-                        "astNodeId" : 11
-                      }
-                    },
-                    "priority" : "None",
-                    "queueFull" : "None"
-                  },
-                  "kind" : "Output",
-                  "size" : 1,
-                  "ty" : {
-                    "DefPort" : {
-                      "symbol" : {
-                        "Port" : {
-                          "nodeId" : 0,
-                          "unqualifiedName" : "P"
-                        }
-                      }
-                    }
-                  },
-                  "importNodeIds" : [
-                  ]
-                }
-              }
-            },
-            [
-              {
-                "from" : {
-                  "loc" : {
-                    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                    "pos" : "48.5",
-                    "includingLoc" : "None"
-                  },
-                  "port" : {
-                    "interfaceInstance" : {
-                      "InterfaceComponentInstance" : {
-                        "astNodeId" : 29
-                      }
-                    },
-                    "portInstance" : {
-                      "General" : {
-                        "aNode" : {
-                          "astNodeId" : 12
-                        },
-                        "specifier" : {
-                          "kind" : {
-                            "Output" : {
-                              
-                            }
-                          },
-                          "name" : "pOut",
-                          "size" : "None",
-                          "port" : {
-                            "Some" : {
-                              "astNodeId" : 11
-                            }
-                          },
-                          "priority" : "None",
-                          "queueFull" : "None"
-                        },
-                        "kind" : "Output",
-                        "size" : 1,
-                        "ty" : {
-                          "DefPort" : {
-                            "symbol" : {
-                              "Port" : {
-                                "nodeId" : 0,
-                                "unqualifiedName" : "P"
-                              }
-                            }
-                          }
-                        },
-                        "importNodeIds" : [
-                        ]
-                      }
-                    }
-                  },
-                  "portNumber" : "None",
-                  "topologyPort" : "None"
-                },
-                "to" : {
-                  "loc" : {
-                    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                    "pos" : "48.16",
-                    "includingLoc" : "None"
-                  },
-                  "port" : {
-                    "interfaceInstance" : {
-                      "InterfaceComponentInstance" : {
-                        "astNodeId" : 25
-                      }
-                    },
-                    "portInstance" : {
-                      "General" : {
-                        "aNode" : {
-                          "astNodeId" : 3
-                        },
-                        "specifier" : {
-                          "kind" : {
-                            "SyncInput" : {
-                              
-                            }
-                          },
-                          "name" : "pIn",
-                          "size" : "None",
-                          "port" : {
-                            "Some" : {
-                              "astNodeId" : 2
-                            }
-                          },
-                          "priority" : "None",
-                          "queueFull" : "None"
-                        },
-                        "kind" : "SyncInput",
-                        "size" : 1,
-                        "ty" : {
-                          "DefPort" : {
-                            "symbol" : {
-                              "Port" : {
-                                "nodeId" : 0,
-                                "unqualifiedName" : "P"
-                              }
-                            }
-                          }
-                        },
-                        "importNodeIds" : [
-                        ]
-                      }
-                    }
-                  },
-                  "portNumber" : "None",
-                  "topologyPort" : "None"
-                },
-                "isUnmatched" : false
-              }
-            ]
-          ],
-          [
-            {
-              "interfaceInstance" : {
-                "InterfaceComponentInstance" : {
                   "astNodeId" : 17
                 }
               },
@@ -3214,6 +2900,320 @@
                     "interfaceInstance" : {
                       "InterfaceComponentInstance" : {
                         "astNodeId" : 17
+                      }
+                    },
+                    "portInstance" : {
+                      "General" : {
+                        "aNode" : {
+                          "astNodeId" : 3
+                        },
+                        "specifier" : {
+                          "kind" : {
+                            "SyncInput" : {
+                              
+                            }
+                          },
+                          "name" : "pIn",
+                          "size" : "None",
+                          "port" : {
+                            "Some" : {
+                              "astNodeId" : 2
+                            }
+                          },
+                          "priority" : "None",
+                          "queueFull" : "None"
+                        },
+                        "kind" : "SyncInput",
+                        "size" : 1,
+                        "ty" : {
+                          "DefPort" : {
+                            "symbol" : {
+                              "Port" : {
+                                "nodeId" : 0,
+                                "unqualifiedName" : "P"
+                              }
+                            }
+                          }
+                        },
+                        "importNodeIds" : [
+                        ]
+                      }
+                    }
+                  },
+                  "portNumber" : "None",
+                  "topologyPort" : "None"
+                },
+                "isUnmatched" : false
+              }
+            ]
+          ],
+          [
+            {
+              "interfaceInstance" : {
+                "InterfaceComponentInstance" : {
+                  "astNodeId" : 25
+                }
+              },
+              "portInstance" : {
+                "General" : {
+                  "aNode" : {
+                    "astNodeId" : 12
+                  },
+                  "specifier" : {
+                    "kind" : {
+                      "Output" : {
+                        
+                      }
+                    },
+                    "name" : "pOut",
+                    "size" : "None",
+                    "port" : {
+                      "Some" : {
+                        "astNodeId" : 11
+                      }
+                    },
+                    "priority" : "None",
+                    "queueFull" : "None"
+                  },
+                  "kind" : "Output",
+                  "size" : 1,
+                  "ty" : {
+                    "DefPort" : {
+                      "symbol" : {
+                        "Port" : {
+                          "nodeId" : 0,
+                          "unqualifiedName" : "P"
+                        }
+                      }
+                    }
+                  },
+                  "importNodeIds" : [
+                  ]
+                }
+              }
+            },
+            [
+              {
+                "from" : {
+                  "loc" : {
+                    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                    "pos" : "43.5",
+                    "includingLoc" : "None"
+                  },
+                  "port" : {
+                    "interfaceInstance" : {
+                      "InterfaceComponentInstance" : {
+                        "astNodeId" : 25
+                      }
+                    },
+                    "portInstance" : {
+                      "General" : {
+                        "aNode" : {
+                          "astNodeId" : 12
+                        },
+                        "specifier" : {
+                          "kind" : {
+                            "Output" : {
+                              
+                            }
+                          },
+                          "name" : "pOut",
+                          "size" : "None",
+                          "port" : {
+                            "Some" : {
+                              "astNodeId" : 11
+                            }
+                          },
+                          "priority" : "None",
+                          "queueFull" : "None"
+                        },
+                        "kind" : "Output",
+                        "size" : 1,
+                        "ty" : {
+                          "DefPort" : {
+                            "symbol" : {
+                              "Port" : {
+                                "nodeId" : 0,
+                                "unqualifiedName" : "P"
+                              }
+                            }
+                          }
+                        },
+                        "importNodeIds" : [
+                        ]
+                      }
+                    }
+                  },
+                  "portNumber" : "None",
+                  "topologyPort" : "None"
+                },
+                "to" : {
+                  "loc" : {
+                    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                    "pos" : "43.16",
+                    "includingLoc" : "None"
+                  },
+                  "port" : {
+                    "interfaceInstance" : {
+                      "InterfaceComponentInstance" : {
+                        "astNodeId" : 29
+                      }
+                    },
+                    "portInstance" : {
+                      "General" : {
+                        "aNode" : {
+                          "astNodeId" : 3
+                        },
+                        "specifier" : {
+                          "kind" : {
+                            "SyncInput" : {
+                              
+                            }
+                          },
+                          "name" : "pIn",
+                          "size" : "None",
+                          "port" : {
+                            "Some" : {
+                              "astNodeId" : 2
+                            }
+                          },
+                          "priority" : "None",
+                          "queueFull" : "None"
+                        },
+                        "kind" : "SyncInput",
+                        "size" : 1,
+                        "ty" : {
+                          "DefPort" : {
+                            "symbol" : {
+                              "Port" : {
+                                "nodeId" : 0,
+                                "unqualifiedName" : "P"
+                              }
+                            }
+                          }
+                        },
+                        "importNodeIds" : [
+                        ]
+                      }
+                    }
+                  },
+                  "portNumber" : "None",
+                  "topologyPort" : "None"
+                },
+                "isUnmatched" : false
+              }
+            ]
+          ],
+          [
+            {
+              "interfaceInstance" : {
+                "InterfaceComponentInstance" : {
+                  "astNodeId" : 29
+                }
+              },
+              "portInstance" : {
+                "General" : {
+                  "aNode" : {
+                    "astNodeId" : 12
+                  },
+                  "specifier" : {
+                    "kind" : {
+                      "Output" : {
+                        
+                      }
+                    },
+                    "name" : "pOut",
+                    "size" : "None",
+                    "port" : {
+                      "Some" : {
+                        "astNodeId" : 11
+                      }
+                    },
+                    "priority" : "None",
+                    "queueFull" : "None"
+                  },
+                  "kind" : "Output",
+                  "size" : 1,
+                  "ty" : {
+                    "DefPort" : {
+                      "symbol" : {
+                        "Port" : {
+                          "nodeId" : 0,
+                          "unqualifiedName" : "P"
+                        }
+                      }
+                    }
+                  },
+                  "importNodeIds" : [
+                  ]
+                }
+              }
+            },
+            [
+              {
+                "from" : {
+                  "loc" : {
+                    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                    "pos" : "48.5",
+                    "includingLoc" : "None"
+                  },
+                  "port" : {
+                    "interfaceInstance" : {
+                      "InterfaceComponentInstance" : {
+                        "astNodeId" : 29
+                      }
+                    },
+                    "portInstance" : {
+                      "General" : {
+                        "aNode" : {
+                          "astNodeId" : 12
+                        },
+                        "specifier" : {
+                          "kind" : {
+                            "Output" : {
+                              
+                            }
+                          },
+                          "name" : "pOut",
+                          "size" : "None",
+                          "port" : {
+                            "Some" : {
+                              "astNodeId" : 11
+                            }
+                          },
+                          "priority" : "None",
+                          "queueFull" : "None"
+                        },
+                        "kind" : "Output",
+                        "size" : 1,
+                        "ty" : {
+                          "DefPort" : {
+                            "symbol" : {
+                              "Port" : {
+                                "nodeId" : 0,
+                                "unqualifiedName" : "P"
+                              }
+                            }
+                          }
+                        },
+                        "importNodeIds" : [
+                        ]
+                      }
+                    }
+                  },
+                  "portNumber" : "None",
+                  "topologyPort" : "None"
+                },
+                "to" : {
+                  "loc" : {
+                    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                    "pos" : "48.16",
+                    "includingLoc" : "None"
+                  },
+                  "port" : {
+                    "interfaceInstance" : {
+                      "InterfaceComponentInstance" : {
+                        "astNodeId" : 25
                       }
                     },
                     "portInstance" : {
@@ -3267,7 +3267,7 @@
             {
               "interfaceInstance" : {
                 "InterfaceComponentInstance" : {
-                  "astNodeId" : 29
+                  "astNodeId" : 17
                 }
               },
               "portInstance" : {
@@ -3313,13 +3313,13 @@
                 "from" : {
                   "loc" : {
                     "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                    "pos" : "43.5",
+                    "pos" : "28.5",
                     "includingLoc" : "None"
                   },
                   "port" : {
                     "interfaceInstance" : {
                       "InterfaceComponentInstance" : {
-                        "astNodeId" : 25
+                        "astNodeId" : 21
                       }
                     },
                     "portInstance" : {
@@ -3366,170 +3366,13 @@
                 "to" : {
                   "loc" : {
                     "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                    "pos" : "43.16",
+                    "pos" : "28.16",
                     "includingLoc" : "None"
                   },
                   "port" : {
                     "interfaceInstance" : {
                       "InterfaceComponentInstance" : {
-                        "astNodeId" : 29
-                      }
-                    },
-                    "portInstance" : {
-                      "General" : {
-                        "aNode" : {
-                          "astNodeId" : 3
-                        },
-                        "specifier" : {
-                          "kind" : {
-                            "SyncInput" : {
-                              
-                            }
-                          },
-                          "name" : "pIn",
-                          "size" : "None",
-                          "port" : {
-                            "Some" : {
-                              "astNodeId" : 2
-                            }
-                          },
-                          "priority" : "None",
-                          "queueFull" : "None"
-                        },
-                        "kind" : "SyncInput",
-                        "size" : 1,
-                        "ty" : {
-                          "DefPort" : {
-                            "symbol" : {
-                              "Port" : {
-                                "nodeId" : 0,
-                                "unqualifiedName" : "P"
-                              }
-                            }
-                          }
-                        },
-                        "importNodeIds" : [
-                        ]
-                      }
-                    }
-                  },
-                  "portNumber" : "None",
-                  "topologyPort" : "None"
-                },
-                "isUnmatched" : false
-              }
-            ]
-          ],
-          [
-            {
-              "interfaceInstance" : {
-                "InterfaceComponentInstance" : {
-                  "astNodeId" : 25
-                }
-              },
-              "portInstance" : {
-                "General" : {
-                  "aNode" : {
-                    "astNodeId" : 3
-                  },
-                  "specifier" : {
-                    "kind" : {
-                      "SyncInput" : {
-                        
-                      }
-                    },
-                    "name" : "pIn",
-                    "size" : "None",
-                    "port" : {
-                      "Some" : {
-                        "astNodeId" : 2
-                      }
-                    },
-                    "priority" : "None",
-                    "queueFull" : "None"
-                  },
-                  "kind" : "SyncInput",
-                  "size" : 1,
-                  "ty" : {
-                    "DefPort" : {
-                      "symbol" : {
-                        "Port" : {
-                          "nodeId" : 0,
-                          "unqualifiedName" : "P"
-                        }
-                      }
-                    }
-                  },
-                  "importNodeIds" : [
-                  ]
-                }
-              }
-            },
-            [
-              {
-                "from" : {
-                  "loc" : {
-                    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                    "pos" : "48.5",
-                    "includingLoc" : "None"
-                  },
-                  "port" : {
-                    "interfaceInstance" : {
-                      "InterfaceComponentInstance" : {
-                        "astNodeId" : 29
-                      }
-                    },
-                    "portInstance" : {
-                      "General" : {
-                        "aNode" : {
-                          "astNodeId" : 12
-                        },
-                        "specifier" : {
-                          "kind" : {
-                            "Output" : {
-                              
-                            }
-                          },
-                          "name" : "pOut",
-                          "size" : "None",
-                          "port" : {
-                            "Some" : {
-                              "astNodeId" : 11
-                            }
-                          },
-                          "priority" : "None",
-                          "queueFull" : "None"
-                        },
-                        "kind" : "Output",
-                        "size" : 1,
-                        "ty" : {
-                          "DefPort" : {
-                            "symbol" : {
-                              "Port" : {
-                                "nodeId" : 0,
-                                "unqualifiedName" : "P"
-                              }
-                            }
-                          }
-                        },
-                        "importNodeIds" : [
-                        ]
-                      }
-                    }
-                  },
-                  "portNumber" : "None",
-                  "topologyPort" : "None"
-                },
-                "to" : {
-                  "loc" : {
-                    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                    "pos" : "48.16",
-                    "includingLoc" : "None"
-                  },
-                  "port" : {
-                    "interfaceInstance" : {
-                      "InterfaceComponentInstance" : {
-                        "astNodeId" : 25
+                        "astNodeId" : 17
                       }
                     },
                     "portInstance" : {
@@ -3738,7 +3581,7 @@
             {
               "interfaceInstance" : {
                 "InterfaceComponentInstance" : {
-                  "astNodeId" : 17
+                  "astNodeId" : 25
                 }
               },
               "portInstance" : {
@@ -3784,13 +3627,13 @@
                 "from" : {
                   "loc" : {
                     "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                    "pos" : "28.5",
+                    "pos" : "48.5",
                     "includingLoc" : "None"
                   },
                   "port" : {
                     "interfaceInstance" : {
                       "InterfaceComponentInstance" : {
-                        "astNodeId" : 21
+                        "astNodeId" : 29
                       }
                     },
                     "portInstance" : {
@@ -3837,13 +3680,170 @@
                 "to" : {
                   "loc" : {
                     "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                    "pos" : "28.16",
+                    "pos" : "48.16",
                     "includingLoc" : "None"
                   },
                   "port" : {
                     "interfaceInstance" : {
                       "InterfaceComponentInstance" : {
-                        "astNodeId" : 17
+                        "astNodeId" : 25
+                      }
+                    },
+                    "portInstance" : {
+                      "General" : {
+                        "aNode" : {
+                          "astNodeId" : 3
+                        },
+                        "specifier" : {
+                          "kind" : {
+                            "SyncInput" : {
+                              
+                            }
+                          },
+                          "name" : "pIn",
+                          "size" : "None",
+                          "port" : {
+                            "Some" : {
+                              "astNodeId" : 2
+                            }
+                          },
+                          "priority" : "None",
+                          "queueFull" : "None"
+                        },
+                        "kind" : "SyncInput",
+                        "size" : 1,
+                        "ty" : {
+                          "DefPort" : {
+                            "symbol" : {
+                              "Port" : {
+                                "nodeId" : 0,
+                                "unqualifiedName" : "P"
+                              }
+                            }
+                          }
+                        },
+                        "importNodeIds" : [
+                        ]
+                      }
+                    }
+                  },
+                  "portNumber" : "None",
+                  "topologyPort" : "None"
+                },
+                "isUnmatched" : false
+              }
+            ]
+          ],
+          [
+            {
+              "interfaceInstance" : {
+                "InterfaceComponentInstance" : {
+                  "astNodeId" : 29
+                }
+              },
+              "portInstance" : {
+                "General" : {
+                  "aNode" : {
+                    "astNodeId" : 3
+                  },
+                  "specifier" : {
+                    "kind" : {
+                      "SyncInput" : {
+                        
+                      }
+                    },
+                    "name" : "pIn",
+                    "size" : "None",
+                    "port" : {
+                      "Some" : {
+                        "astNodeId" : 2
+                      }
+                    },
+                    "priority" : "None",
+                    "queueFull" : "None"
+                  },
+                  "kind" : "SyncInput",
+                  "size" : 1,
+                  "ty" : {
+                    "DefPort" : {
+                      "symbol" : {
+                        "Port" : {
+                          "nodeId" : 0,
+                          "unqualifiedName" : "P"
+                        }
+                      }
+                    }
+                  },
+                  "importNodeIds" : [
+                  ]
+                }
+              }
+            },
+            [
+              {
+                "from" : {
+                  "loc" : {
+                    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                    "pos" : "43.5",
+                    "includingLoc" : "None"
+                  },
+                  "port" : {
+                    "interfaceInstance" : {
+                      "InterfaceComponentInstance" : {
+                        "astNodeId" : 25
+                      }
+                    },
+                    "portInstance" : {
+                      "General" : {
+                        "aNode" : {
+                          "astNodeId" : 12
+                        },
+                        "specifier" : {
+                          "kind" : {
+                            "Output" : {
+                              
+                            }
+                          },
+                          "name" : "pOut",
+                          "size" : "None",
+                          "port" : {
+                            "Some" : {
+                              "astNodeId" : 11
+                            }
+                          },
+                          "priority" : "None",
+                          "queueFull" : "None"
+                        },
+                        "kind" : "Output",
+                        "size" : 1,
+                        "ty" : {
+                          "DefPort" : {
+                            "symbol" : {
+                              "Port" : {
+                                "nodeId" : 0,
+                                "unqualifiedName" : "P"
+                              }
+                            }
+                          }
+                        },
+                        "importNodeIds" : [
+                        ]
+                      }
+                    }
+                  },
+                  "portNumber" : "None",
+                  "topologyPort" : "None"
+                },
+                "to" : {
+                  "loc" : {
+                    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                    "pos" : "43.16",
+                    "includingLoc" : "None"
+                  },
+                  "port" : {
+                    "interfaceInstance" : {
+                      "InterfaceComponentInstance" : {
+                        "astNodeId" : 29
                       }
                     },
                     "portInstance" : {
@@ -3893,6 +3893,118 @@
           ]
         ],
         "fromPortNumberMap" : [
+          [
+            {
+              "from" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                  "pos" : "23.5",
+                  "includingLoc" : "None"
+                },
+                "port" : {
+                  "interfaceInstance" : {
+                    "InterfaceComponentInstance" : {
+                      "astNodeId" : 17
+                    }
+                  },
+                  "portInstance" : {
+                    "General" : {
+                      "aNode" : {
+                        "astNodeId" : 12
+                      },
+                      "specifier" : {
+                        "kind" : {
+                          "Output" : {
+                            
+                          }
+                        },
+                        "name" : "pOut",
+                        "size" : "None",
+                        "port" : {
+                          "Some" : {
+                            "astNodeId" : 11
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None"
+                      },
+                      "kind" : "Output",
+                      "size" : 1,
+                      "ty" : {
+                        "DefPort" : {
+                          "symbol" : {
+                            "Port" : {
+                              "nodeId" : 0,
+                              "unqualifiedName" : "P"
+                            }
+                          }
+                        }
+                      },
+                      "importNodeIds" : [
+                      ]
+                    }
+                  }
+                },
+                "portNumber" : "None",
+                "topologyPort" : "None"
+              },
+              "to" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                  "pos" : "23.16",
+                  "includingLoc" : "None"
+                },
+                "port" : {
+                  "interfaceInstance" : {
+                    "InterfaceComponentInstance" : {
+                      "astNodeId" : 21
+                    }
+                  },
+                  "portInstance" : {
+                    "General" : {
+                      "aNode" : {
+                        "astNodeId" : 3
+                      },
+                      "specifier" : {
+                        "kind" : {
+                          "SyncInput" : {
+                            
+                          }
+                        },
+                        "name" : "pIn",
+                        "size" : "None",
+                        "port" : {
+                          "Some" : {
+                            "astNodeId" : 2
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None"
+                      },
+                      "kind" : "SyncInput",
+                      "size" : 1,
+                      "ty" : {
+                        "DefPort" : {
+                          "symbol" : {
+                            "Port" : {
+                              "nodeId" : 0,
+                              "unqualifiedName" : "P"
+                            }
+                          }
+                        }
+                      },
+                      "importNodeIds" : [
+                      ]
+                    }
+                  }
+                },
+                "portNumber" : "None",
+                "topologyPort" : "None"
+              },
+              "isUnmatched" : false
+            },
+            0
+          ],
           [
             {
               "from" : {
@@ -4070,118 +4182,6 @@
                   "interfaceInstance" : {
                     "InterfaceComponentInstance" : {
                       "astNodeId" : 29
-                    }
-                  },
-                  "portInstance" : {
-                    "General" : {
-                      "aNode" : {
-                        "astNodeId" : 3
-                      },
-                      "specifier" : {
-                        "kind" : {
-                          "SyncInput" : {
-                            
-                          }
-                        },
-                        "name" : "pIn",
-                        "size" : "None",
-                        "port" : {
-                          "Some" : {
-                            "astNodeId" : 2
-                          }
-                        },
-                        "priority" : "None",
-                        "queueFull" : "None"
-                      },
-                      "kind" : "SyncInput",
-                      "size" : 1,
-                      "ty" : {
-                        "DefPort" : {
-                          "symbol" : {
-                            "Port" : {
-                              "nodeId" : 0,
-                              "unqualifiedName" : "P"
-                            }
-                          }
-                        }
-                      },
-                      "importNodeIds" : [
-                      ]
-                    }
-                  }
-                },
-                "portNumber" : "None",
-                "topologyPort" : "None"
-              },
-              "isUnmatched" : false
-            },
-            0
-          ],
-          [
-            {
-              "from" : {
-                "loc" : {
-                  "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                  "pos" : "23.5",
-                  "includingLoc" : "None"
-                },
-                "port" : {
-                  "interfaceInstance" : {
-                    "InterfaceComponentInstance" : {
-                      "astNodeId" : 17
-                    }
-                  },
-                  "portInstance" : {
-                    "General" : {
-                      "aNode" : {
-                        "astNodeId" : 12
-                      },
-                      "specifier" : {
-                        "kind" : {
-                          "Output" : {
-                            
-                          }
-                        },
-                        "name" : "pOut",
-                        "size" : "None",
-                        "port" : {
-                          "Some" : {
-                            "astNodeId" : 11
-                          }
-                        },
-                        "priority" : "None",
-                        "queueFull" : "None"
-                      },
-                      "kind" : "Output",
-                      "size" : 1,
-                      "ty" : {
-                        "DefPort" : {
-                          "symbol" : {
-                            "Port" : {
-                              "nodeId" : 0,
-                              "unqualifiedName" : "P"
-                            }
-                          }
-                        }
-                      },
-                      "importNodeIds" : [
-                      ]
-                    }
-                  }
-                },
-                "portNumber" : "None",
-                "topologyPort" : "None"
-              },
-              "to" : {
-                "loc" : {
-                  "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                  "pos" : "23.16",
-                  "includingLoc" : "None"
-                },
-                "port" : {
-                  "interfaceInstance" : {
-                    "InterfaceComponentInstance" : {
-                      "astNodeId" : 21
                     }
                   },
                   "portInstance" : {
@@ -4460,118 +4460,6 @@
               "from" : {
                 "loc" : {
                   "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                  "pos" : "48.5",
-                  "includingLoc" : "None"
-                },
-                "port" : {
-                  "interfaceInstance" : {
-                    "InterfaceComponentInstance" : {
-                      "astNodeId" : 29
-                    }
-                  },
-                  "portInstance" : {
-                    "General" : {
-                      "aNode" : {
-                        "astNodeId" : 12
-                      },
-                      "specifier" : {
-                        "kind" : {
-                          "Output" : {
-                            
-                          }
-                        },
-                        "name" : "pOut",
-                        "size" : "None",
-                        "port" : {
-                          "Some" : {
-                            "astNodeId" : 11
-                          }
-                        },
-                        "priority" : "None",
-                        "queueFull" : "None"
-                      },
-                      "kind" : "Output",
-                      "size" : 1,
-                      "ty" : {
-                        "DefPort" : {
-                          "symbol" : {
-                            "Port" : {
-                              "nodeId" : 0,
-                              "unqualifiedName" : "P"
-                            }
-                          }
-                        }
-                      },
-                      "importNodeIds" : [
-                      ]
-                    }
-                  }
-                },
-                "portNumber" : "None",
-                "topologyPort" : "None"
-              },
-              "to" : {
-                "loc" : {
-                  "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                  "pos" : "48.16",
-                  "includingLoc" : "None"
-                },
-                "port" : {
-                  "interfaceInstance" : {
-                    "InterfaceComponentInstance" : {
-                      "astNodeId" : 25
-                    }
-                  },
-                  "portInstance" : {
-                    "General" : {
-                      "aNode" : {
-                        "astNodeId" : 3
-                      },
-                      "specifier" : {
-                        "kind" : {
-                          "SyncInput" : {
-                            
-                          }
-                        },
-                        "name" : "pIn",
-                        "size" : "None",
-                        "port" : {
-                          "Some" : {
-                            "astNodeId" : 2
-                          }
-                        },
-                        "priority" : "None",
-                        "queueFull" : "None"
-                      },
-                      "kind" : "SyncInput",
-                      "size" : 1,
-                      "ty" : {
-                        "DefPort" : {
-                          "symbol" : {
-                            "Port" : {
-                              "nodeId" : 0,
-                              "unqualifiedName" : "P"
-                            }
-                          }
-                        }
-                      },
-                      "importNodeIds" : [
-                      ]
-                    }
-                  }
-                },
-                "portNumber" : "None",
-                "topologyPort" : "None"
-              },
-              "isUnmatched" : false
-            },
-            0
-          ],
-          [
-            {
-              "from" : {
-                "loc" : {
-                  "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
                   "pos" : "28.5",
                   "includingLoc" : "None"
                 },
@@ -4744,6 +4632,118 @@
                   "interfaceInstance" : {
                     "InterfaceComponentInstance" : {
                       "astNodeId" : 29
+                    }
+                  },
+                  "portInstance" : {
+                    "General" : {
+                      "aNode" : {
+                        "astNodeId" : 3
+                      },
+                      "specifier" : {
+                        "kind" : {
+                          "SyncInput" : {
+                            
+                          }
+                        },
+                        "name" : "pIn",
+                        "size" : "None",
+                        "port" : {
+                          "Some" : {
+                            "astNodeId" : 2
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None"
+                      },
+                      "kind" : "SyncInput",
+                      "size" : 1,
+                      "ty" : {
+                        "DefPort" : {
+                          "symbol" : {
+                            "Port" : {
+                              "nodeId" : 0,
+                              "unqualifiedName" : "P"
+                            }
+                          }
+                        }
+                      },
+                      "importNodeIds" : [
+                      ]
+                    }
+                  }
+                },
+                "portNumber" : "None",
+                "topologyPort" : "None"
+              },
+              "isUnmatched" : false
+            },
+            0
+          ],
+          [
+            {
+              "from" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                  "pos" : "48.5",
+                  "includingLoc" : "None"
+                },
+                "port" : {
+                  "interfaceInstance" : {
+                    "InterfaceComponentInstance" : {
+                      "astNodeId" : 29
+                    }
+                  },
+                  "portInstance" : {
+                    "General" : {
+                      "aNode" : {
+                        "astNodeId" : 12
+                      },
+                      "specifier" : {
+                        "kind" : {
+                          "Output" : {
+                            
+                          }
+                        },
+                        "name" : "pOut",
+                        "size" : "None",
+                        "port" : {
+                          "Some" : {
+                            "astNodeId" : 11
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None"
+                      },
+                      "kind" : "Output",
+                      "size" : 1,
+                      "ty" : {
+                        "DefPort" : {
+                          "symbol" : {
+                            "Port" : {
+                              "nodeId" : 0,
+                              "unqualifiedName" : "P"
+                            }
+                          }
+                        }
+                      },
+                      "importNodeIds" : [
+                      ]
+                    }
+                  }
+                },
+                "portNumber" : "None",
+                "topologyPort" : "None"
+              },
+              "to" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                  "pos" : "48.16",
+                  "includingLoc" : "None"
+                },
+                "port" : {
+                  "interfaceInstance" : {
+                    "InterfaceComponentInstance" : {
+                      "astNodeId" : 25
                     }
                   },
                   "portInstance" : {
@@ -6001,163 +6001,6 @@
             {
               "interfaceInstance" : {
                 "InterfaceComponentInstance" : {
-                  "astNodeId" : 21
-                }
-              },
-              "portInstance" : {
-                "General" : {
-                  "aNode" : {
-                    "astNodeId" : 3
-                  },
-                  "specifier" : {
-                    "kind" : {
-                      "SyncInput" : {
-                        
-                      }
-                    },
-                    "name" : "pIn",
-                    "size" : "None",
-                    "port" : {
-                      "Some" : {
-                        "astNodeId" : 2
-                      }
-                    },
-                    "priority" : "None",
-                    "queueFull" : "None"
-                  },
-                  "kind" : "SyncInput",
-                  "size" : 1,
-                  "ty" : {
-                    "DefPort" : {
-                      "symbol" : {
-                        "Port" : {
-                          "nodeId" : 0,
-                          "unqualifiedName" : "P"
-                        }
-                      }
-                    }
-                  },
-                  "importNodeIds" : [
-                  ]
-                }
-              }
-            },
-            [
-              {
-                "from" : {
-                  "loc" : {
-                    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                    "pos" : "23.5",
-                    "includingLoc" : "None"
-                  },
-                  "port" : {
-                    "interfaceInstance" : {
-                      "InterfaceComponentInstance" : {
-                        "astNodeId" : 17
-                      }
-                    },
-                    "portInstance" : {
-                      "General" : {
-                        "aNode" : {
-                          "astNodeId" : 12
-                        },
-                        "specifier" : {
-                          "kind" : {
-                            "Output" : {
-                              
-                            }
-                          },
-                          "name" : "pOut",
-                          "size" : "None",
-                          "port" : {
-                            "Some" : {
-                              "astNodeId" : 11
-                            }
-                          },
-                          "priority" : "None",
-                          "queueFull" : "None"
-                        },
-                        "kind" : "Output",
-                        "size" : 1,
-                        "ty" : {
-                          "DefPort" : {
-                            "symbol" : {
-                              "Port" : {
-                                "nodeId" : 0,
-                                "unqualifiedName" : "P"
-                              }
-                            }
-                          }
-                        },
-                        "importNodeIds" : [
-                        ]
-                      }
-                    }
-                  },
-                  "portNumber" : "None",
-                  "topologyPort" : "None"
-                },
-                "to" : {
-                  "loc" : {
-                    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                    "pos" : "23.16",
-                    "includingLoc" : "None"
-                  },
-                  "port" : {
-                    "interfaceInstance" : {
-                      "InterfaceComponentInstance" : {
-                        "astNodeId" : 21
-                      }
-                    },
-                    "portInstance" : {
-                      "General" : {
-                        "aNode" : {
-                          "astNodeId" : 3
-                        },
-                        "specifier" : {
-                          "kind" : {
-                            "SyncInput" : {
-                              
-                            }
-                          },
-                          "name" : "pIn",
-                          "size" : "None",
-                          "port" : {
-                            "Some" : {
-                              "astNodeId" : 2
-                            }
-                          },
-                          "priority" : "None",
-                          "queueFull" : "None"
-                        },
-                        "kind" : "SyncInput",
-                        "size" : 1,
-                        "ty" : {
-                          "DefPort" : {
-                            "symbol" : {
-                              "Port" : {
-                                "nodeId" : 0,
-                                "unqualifiedName" : "P"
-                              }
-                            }
-                          }
-                        },
-                        "importNodeIds" : [
-                        ]
-                      }
-                    }
-                  },
-                  "portNumber" : "None",
-                  "topologyPort" : "None"
-                },
-                "isUnmatched" : false
-              }
-            ]
-          ],
-          [
-            {
-              "interfaceInstance" : {
-                "InterfaceComponentInstance" : {
                   "astNodeId" : 17
                 }
               },
@@ -6315,7 +6158,7 @@
             {
               "interfaceInstance" : {
                 "InterfaceComponentInstance" : {
-                  "astNodeId" : 29
+                  "astNodeId" : 21
                 }
               },
               "portInstance" : {
@@ -6361,13 +6204,13 @@
                 "from" : {
                   "loc" : {
                     "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                    "pos" : "43.5",
+                    "pos" : "23.5",
                     "includingLoc" : "None"
                   },
                   "port" : {
                     "interfaceInstance" : {
                       "InterfaceComponentInstance" : {
-                        "astNodeId" : 25
+                        "astNodeId" : 17
                       }
                     },
                     "portInstance" : {
@@ -6414,13 +6257,13 @@
                 "to" : {
                   "loc" : {
                     "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                    "pos" : "43.16",
+                    "pos" : "23.16",
                     "includingLoc" : "None"
                   },
                   "port" : {
                     "interfaceInstance" : {
                       "InterfaceComponentInstance" : {
-                        "astNodeId" : 29
+                        "astNodeId" : 21
                       }
                     },
                     "portInstance" : {
@@ -6624,9 +6467,278 @@
                 "isUnmatched" : false
               }
             ]
+          ],
+          [
+            {
+              "interfaceInstance" : {
+                "InterfaceComponentInstance" : {
+                  "astNodeId" : 29
+                }
+              },
+              "portInstance" : {
+                "General" : {
+                  "aNode" : {
+                    "astNodeId" : 3
+                  },
+                  "specifier" : {
+                    "kind" : {
+                      "SyncInput" : {
+                        
+                      }
+                    },
+                    "name" : "pIn",
+                    "size" : "None",
+                    "port" : {
+                      "Some" : {
+                        "astNodeId" : 2
+                      }
+                    },
+                    "priority" : "None",
+                    "queueFull" : "None"
+                  },
+                  "kind" : "SyncInput",
+                  "size" : 1,
+                  "ty" : {
+                    "DefPort" : {
+                      "symbol" : {
+                        "Port" : {
+                          "nodeId" : 0,
+                          "unqualifiedName" : "P"
+                        }
+                      }
+                    }
+                  },
+                  "importNodeIds" : [
+                  ]
+                }
+              }
+            },
+            [
+              {
+                "from" : {
+                  "loc" : {
+                    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                    "pos" : "43.5",
+                    "includingLoc" : "None"
+                  },
+                  "port" : {
+                    "interfaceInstance" : {
+                      "InterfaceComponentInstance" : {
+                        "astNodeId" : 25
+                      }
+                    },
+                    "portInstance" : {
+                      "General" : {
+                        "aNode" : {
+                          "astNodeId" : 12
+                        },
+                        "specifier" : {
+                          "kind" : {
+                            "Output" : {
+                              
+                            }
+                          },
+                          "name" : "pOut",
+                          "size" : "None",
+                          "port" : {
+                            "Some" : {
+                              "astNodeId" : 11
+                            }
+                          },
+                          "priority" : "None",
+                          "queueFull" : "None"
+                        },
+                        "kind" : "Output",
+                        "size" : 1,
+                        "ty" : {
+                          "DefPort" : {
+                            "symbol" : {
+                              "Port" : {
+                                "nodeId" : 0,
+                                "unqualifiedName" : "P"
+                              }
+                            }
+                          }
+                        },
+                        "importNodeIds" : [
+                        ]
+                      }
+                    }
+                  },
+                  "portNumber" : "None",
+                  "topologyPort" : "None"
+                },
+                "to" : {
+                  "loc" : {
+                    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                    "pos" : "43.16",
+                    "includingLoc" : "None"
+                  },
+                  "port" : {
+                    "interfaceInstance" : {
+                      "InterfaceComponentInstance" : {
+                        "astNodeId" : 29
+                      }
+                    },
+                    "portInstance" : {
+                      "General" : {
+                        "aNode" : {
+                          "astNodeId" : 3
+                        },
+                        "specifier" : {
+                          "kind" : {
+                            "SyncInput" : {
+                              
+                            }
+                          },
+                          "name" : "pIn",
+                          "size" : "None",
+                          "port" : {
+                            "Some" : {
+                              "astNodeId" : 2
+                            }
+                          },
+                          "priority" : "None",
+                          "queueFull" : "None"
+                        },
+                        "kind" : "SyncInput",
+                        "size" : 1,
+                        "ty" : {
+                          "DefPort" : {
+                            "symbol" : {
+                              "Port" : {
+                                "nodeId" : 0,
+                                "unqualifiedName" : "P"
+                              }
+                            }
+                          }
+                        },
+                        "importNodeIds" : [
+                        ]
+                      }
+                    }
+                  },
+                  "portNumber" : "None",
+                  "topologyPort" : "None"
+                },
+                "isUnmatched" : false
+              }
+            ]
           ]
         ],
         "fromPortNumberMap" : [
+          [
+            {
+              "from" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                  "pos" : "23.5",
+                  "includingLoc" : "None"
+                },
+                "port" : {
+                  "interfaceInstance" : {
+                    "InterfaceComponentInstance" : {
+                      "astNodeId" : 17
+                    }
+                  },
+                  "portInstance" : {
+                    "General" : {
+                      "aNode" : {
+                        "astNodeId" : 12
+                      },
+                      "specifier" : {
+                        "kind" : {
+                          "Output" : {
+                            
+                          }
+                        },
+                        "name" : "pOut",
+                        "size" : "None",
+                        "port" : {
+                          "Some" : {
+                            "astNodeId" : 11
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None"
+                      },
+                      "kind" : "Output",
+                      "size" : 1,
+                      "ty" : {
+                        "DefPort" : {
+                          "symbol" : {
+                            "Port" : {
+                              "nodeId" : 0,
+                              "unqualifiedName" : "P"
+                            }
+                          }
+                        }
+                      },
+                      "importNodeIds" : [
+                      ]
+                    }
+                  }
+                },
+                "portNumber" : "None",
+                "topologyPort" : "None"
+              },
+              "to" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                  "pos" : "23.16",
+                  "includingLoc" : "None"
+                },
+                "port" : {
+                  "interfaceInstance" : {
+                    "InterfaceComponentInstance" : {
+                      "astNodeId" : 21
+                    }
+                  },
+                  "portInstance" : {
+                    "General" : {
+                      "aNode" : {
+                        "astNodeId" : 3
+                      },
+                      "specifier" : {
+                        "kind" : {
+                          "SyncInput" : {
+                            
+                          }
+                        },
+                        "name" : "pIn",
+                        "size" : "None",
+                        "port" : {
+                          "Some" : {
+                            "astNodeId" : 2
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None"
+                      },
+                      "kind" : "SyncInput",
+                      "size" : 1,
+                      "ty" : {
+                        "DefPort" : {
+                          "symbol" : {
+                            "Port" : {
+                              "nodeId" : 0,
+                              "unqualifiedName" : "P"
+                            }
+                          }
+                        }
+                      },
+                      "importNodeIds" : [
+                      ]
+                    }
+                  }
+                },
+                "portNumber" : "None",
+                "topologyPort" : "None"
+              },
+              "isUnmatched" : false
+            },
+            0
+          ],
           [
             {
               "from" : {
@@ -6804,118 +6916,6 @@
                   "interfaceInstance" : {
                     "InterfaceComponentInstance" : {
                       "astNodeId" : 29
-                    }
-                  },
-                  "portInstance" : {
-                    "General" : {
-                      "aNode" : {
-                        "astNodeId" : 3
-                      },
-                      "specifier" : {
-                        "kind" : {
-                          "SyncInput" : {
-                            
-                          }
-                        },
-                        "name" : "pIn",
-                        "size" : "None",
-                        "port" : {
-                          "Some" : {
-                            "astNodeId" : 2
-                          }
-                        },
-                        "priority" : "None",
-                        "queueFull" : "None"
-                      },
-                      "kind" : "SyncInput",
-                      "size" : 1,
-                      "ty" : {
-                        "DefPort" : {
-                          "symbol" : {
-                            "Port" : {
-                              "nodeId" : 0,
-                              "unqualifiedName" : "P"
-                            }
-                          }
-                        }
-                      },
-                      "importNodeIds" : [
-                      ]
-                    }
-                  }
-                },
-                "portNumber" : "None",
-                "topologyPort" : "None"
-              },
-              "isUnmatched" : false
-            },
-            0
-          ],
-          [
-            {
-              "from" : {
-                "loc" : {
-                  "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                  "pos" : "23.5",
-                  "includingLoc" : "None"
-                },
-                "port" : {
-                  "interfaceInstance" : {
-                    "InterfaceComponentInstance" : {
-                      "astNodeId" : 17
-                    }
-                  },
-                  "portInstance" : {
-                    "General" : {
-                      "aNode" : {
-                        "astNodeId" : 12
-                      },
-                      "specifier" : {
-                        "kind" : {
-                          "Output" : {
-                            
-                          }
-                        },
-                        "name" : "pOut",
-                        "size" : "None",
-                        "port" : {
-                          "Some" : {
-                            "astNodeId" : 11
-                          }
-                        },
-                        "priority" : "None",
-                        "queueFull" : "None"
-                      },
-                      "kind" : "Output",
-                      "size" : 1,
-                      "ty" : {
-                        "DefPort" : {
-                          "symbol" : {
-                            "Port" : {
-                              "nodeId" : 0,
-                              "unqualifiedName" : "P"
-                            }
-                          }
-                        }
-                      },
-                      "importNodeIds" : [
-                      ]
-                    }
-                  }
-                },
-                "portNumber" : "None",
-                "topologyPort" : "None"
-              },
-              "to" : {
-                "loc" : {
-                  "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                  "pos" : "23.16",
-                  "includingLoc" : "None"
-                },
-                "port" : {
-                  "interfaceInstance" : {
-                    "InterfaceComponentInstance" : {
-                      "astNodeId" : 21
                     }
                   },
                   "portInstance" : {
@@ -7194,118 +7194,6 @@
               "from" : {
                 "loc" : {
                   "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                  "pos" : "48.5",
-                  "includingLoc" : "None"
-                },
-                "port" : {
-                  "interfaceInstance" : {
-                    "InterfaceComponentInstance" : {
-                      "astNodeId" : 29
-                    }
-                  },
-                  "portInstance" : {
-                    "General" : {
-                      "aNode" : {
-                        "astNodeId" : 12
-                      },
-                      "specifier" : {
-                        "kind" : {
-                          "Output" : {
-                            
-                          }
-                        },
-                        "name" : "pOut",
-                        "size" : "None",
-                        "port" : {
-                          "Some" : {
-                            "astNodeId" : 11
-                          }
-                        },
-                        "priority" : "None",
-                        "queueFull" : "None"
-                      },
-                      "kind" : "Output",
-                      "size" : 1,
-                      "ty" : {
-                        "DefPort" : {
-                          "symbol" : {
-                            "Port" : {
-                              "nodeId" : 0,
-                              "unqualifiedName" : "P"
-                            }
-                          }
-                        }
-                      },
-                      "importNodeIds" : [
-                      ]
-                    }
-                  }
-                },
-                "portNumber" : "None",
-                "topologyPort" : "None"
-              },
-              "to" : {
-                "loc" : {
-                  "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
-                  "pos" : "48.16",
-                  "includingLoc" : "None"
-                },
-                "port" : {
-                  "interfaceInstance" : {
-                    "InterfaceComponentInstance" : {
-                      "astNodeId" : 25
-                    }
-                  },
-                  "portInstance" : {
-                    "General" : {
-                      "aNode" : {
-                        "astNodeId" : 3
-                      },
-                      "specifier" : {
-                        "kind" : {
-                          "SyncInput" : {
-                            
-                          }
-                        },
-                        "name" : "pIn",
-                        "size" : "None",
-                        "port" : {
-                          "Some" : {
-                            "astNodeId" : 2
-                          }
-                        },
-                        "priority" : "None",
-                        "queueFull" : "None"
-                      },
-                      "kind" : "SyncInput",
-                      "size" : 1,
-                      "ty" : {
-                        "DefPort" : {
-                          "symbol" : {
-                            "Port" : {
-                              "nodeId" : 0,
-                              "unqualifiedName" : "P"
-                            }
-                          }
-                        }
-                      },
-                      "importNodeIds" : [
-                      ]
-                    }
-                  }
-                },
-                "portNumber" : "None",
-                "topologyPort" : "None"
-              },
-              "isUnmatched" : false
-            },
-            0
-          ],
-          [
-            {
-              "from" : {
-                "loc" : {
-                  "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
                   "pos" : "28.5",
                   "includingLoc" : "None"
                 },
@@ -7478,6 +7366,118 @@
                   "interfaceInstance" : {
                     "InterfaceComponentInstance" : {
                       "astNodeId" : 29
+                    }
+                  },
+                  "portInstance" : {
+                    "General" : {
+                      "aNode" : {
+                        "astNodeId" : 3
+                      },
+                      "specifier" : {
+                        "kind" : {
+                          "SyncInput" : {
+                            
+                          }
+                        },
+                        "name" : "pIn",
+                        "size" : "None",
+                        "port" : {
+                          "Some" : {
+                            "astNodeId" : 2
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None"
+                      },
+                      "kind" : "SyncInput",
+                      "size" : 1,
+                      "ty" : {
+                        "DefPort" : {
+                          "symbol" : {
+                            "Port" : {
+                              "nodeId" : 0,
+                              "unqualifiedName" : "P"
+                            }
+                          }
+                        }
+                      },
+                      "importNodeIds" : [
+                      ]
+                    }
+                  }
+                },
+                "portNumber" : "None",
+                "topologyPort" : "None"
+              },
+              "isUnmatched" : false
+            },
+            0
+          ],
+          [
+            {
+              "from" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                  "pos" : "48.5",
+                  "includingLoc" : "None"
+                },
+                "port" : {
+                  "interfaceInstance" : {
+                    "InterfaceComponentInstance" : {
+                      "astNodeId" : 29
+                    }
+                  },
+                  "portInstance" : {
+                    "General" : {
+                      "aNode" : {
+                        "astNodeId" : 12
+                      },
+                      "specifier" : {
+                        "kind" : {
+                          "Output" : {
+                            
+                          }
+                        },
+                        "name" : "pOut",
+                        "size" : "None",
+                        "port" : {
+                          "Some" : {
+                            "astNodeId" : 11
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None"
+                      },
+                      "kind" : "Output",
+                      "size" : 1,
+                      "ty" : {
+                        "DefPort" : {
+                          "symbol" : {
+                            "Port" : {
+                              "nodeId" : 0,
+                              "unqualifiedName" : "P"
+                            }
+                          }
+                        }
+                      },
+                      "importNodeIds" : [
+                      ]
+                    }
+                  }
+                },
+                "portNumber" : "None",
+                "topologyPort" : "None"
+              },
+              "to" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",
+                  "pos" : "48.16",
+                  "includingLoc" : "None"
+                },
+                "port" : {
+                  "interfaceInstance" : {
+                    "InterfaceComponentInstance" : {
+                      "astNodeId" : 25
                     }
                   },
                   "portInstance" : {
@@ -7713,56 +7713,6 @@
       
     },
     "dictionaryMap" : {
-      "72" : {
-        "usedSymbolSet" : [
-        ],
-        "commandEntryMap" : {
-          
-        },
-        "tlmChannelEntryMap" : {
-          
-        },
-        "eventEntryMap" : {
-          
-        },
-        "paramEntryMap" : {
-          
-        },
-        "recordEntryMap" : {
-          
-        },
-        "containerEntryMap" : {
-          
-        },
-        "tlmPacketSetMap" : {
-          
-        }
-      },
-      "118" : {
-        "usedSymbolSet" : [
-        ],
-        "commandEntryMap" : {
-          
-        },
-        "tlmChannelEntryMap" : {
-          
-        },
-        "eventEntryMap" : {
-          
-        },
-        "paramEntryMap" : {
-          
-        },
-        "recordEntryMap" : {
-          
-        },
-        "containerEntryMap" : {
-          
-        },
-        "tlmPacketSetMap" : {
-          
-        }
-      },
       "128" : {
         "usedSymbolSet" : [
         ],

--- a/tests/imported_topology/imported_topology_ast.json
+++ b/tests/imported_topology/imported_topology_ast.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion" : "v3.2.0",
+  "fppVersion" : "v3.3.0a16-110-g291b338cc",
   "ast" : [
     {
       "members" : [
@@ -322,6 +322,7 @@
               "node" : {
                 "AstNode" : {
                   "data" : {
+                    "isDeployment" : false,
                     "name" : "Simple1",
                     "members" : [
                       [
@@ -549,6 +550,7 @@
               "node" : {
                 "AstNode" : {
                   "data" : {
+                    "isDeployment" : false,
                     "name" : "Simple2",
                     "members" : [
                       [
@@ -803,6 +805,7 @@
               "node" : {
                 "AstNode" : {
                   "data" : {
+                    "isDeployment" : true,
                     "name" : "Simple3",
                     "members" : [
                       [

--- a/tests/imported_topology/imported_topology_locations.json
+++ b/tests/imported_topology/imported_topology_locations.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion" : "v3.2.0",
+  "fppVersion" : "v3.3.0a16-110-g291b338cc",
   "locationMap" : {
     "0" : {
       "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/importedTopologies.fpp",

--- a/tests/interfaces/interfaces_analysis.json
+++ b/tests/interfaces/interfaces_analysis.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion" : "v3.2.0",
+  "fppVersion" : "v3.3.0a16-110-g291b338cc",
   "analysis" : {
     "componentInstanceMap" : {
       

--- a/tests/interfaces/interfaces_ast.json
+++ b/tests/interfaces/interfaces_ast.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion" : "v3.2.0",
+  "fppVersion" : "v3.3.0a16-110-g291b338cc",
   "ast" : [
     {
       "members" : [

--- a/tests/interfaces/interfaces_locations.json
+++ b/tests/interfaces/interfaces_locations.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion" : "v3.2.0",
+  "fppVersion" : "v3.3.0a16-110-g291b338cc",
   "locationMap" : {
     "0" : {
       "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/interfaces.fpp",

--- a/tests/internal_ports/internal_ports_analysis.json
+++ b/tests/internal_ports/internal_ports_analysis.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion" : "v3.2.0",
+  "fppVersion" : "v3.3.0a16-110-g291b338cc",
   "analysis" : {
     "componentInstanceMap" : {
       

--- a/tests/internal_ports/internal_ports_ast.json
+++ b/tests/internal_ports/internal_ports_ast.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion" : "v3.2.0",
+  "fppVersion" : "v3.3.0a16-110-g291b338cc",
   "ast" : [
     {
       "members" : [

--- a/tests/internal_ports/internal_ports_locations.json
+++ b/tests/internal_ports/internal_ports_locations.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion" : "v3.2.0",
+  "fppVersion" : "v3.3.0a16-110-g291b338cc",
   "locationMap" : {
     "0" : {
       "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/internalPorts.fpp",

--- a/tests/location_specifier/location_specifier.fpp
+++ b/tests/location_specifier/location_specifier.fpp
@@ -1,3 +1,8 @@
 locate dictionary constant c at "dictionary_c.fpp"
 
 locate dictionary type T1 at "dictionary_T1.fpp"
+
+topology T {
+
+
+}

--- a/tests/location_specifier/location_specifier_analysis.json
+++ b/tests/location_specifier/location_specifier_analysis.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion" : "v3.2.0",
+  "fppVersion" : "v3.3.0a16-110-g291b338cc",
   "analysis" : {
     "componentInstanceMap" : {
       
@@ -18,7 +18,7 @@
     "includedFileSet" : [
     ],
     "inputFileSet" : [
-      "[ local path prefix ]/compiler/tools/fpp-depend/test/dictionary_no_top.fpp"
+      "[ local path prefix ]/compiler/tools/fpp-depend/test/dictionary_no_deployment_top.fpp"
     ],
     "locationSpecifierMap" : [
       [
@@ -63,7 +63,59 @@
       
     },
     "topologyMap" : {
-      
+      "8" : {
+        "aNode" : {
+          "astNodeId" : 8
+        },
+        "qualifiedName" : {
+          "qualifier" : [
+          ],
+          "base" : "T"
+        },
+        "directTopologies" : {
+          
+        },
+        "directComponentInstances" : {
+          
+        },
+        "transitiveImportSet" : [
+        ],
+        "instanceMap" : [
+        ],
+        "ports" : [
+        ],
+        "portMap" : {
+          
+        },
+        "portInterface" : {
+          "instanceType" : "topology",
+          "portMap" : {
+            
+          },
+          "specialPortMap" : {
+            
+          }
+        },
+        "patternMap" : {
+          
+        },
+        "connectionMap" : {
+          
+        },
+        "localConnectionMap" : {
+          
+        },
+        "outputConnectionMap" : [
+        ],
+        "inputConnectionMap" : [
+        ],
+        "fromPortNumberMap" : [
+        ],
+        "toPortNumberMap" : [
+        ],
+        "unconnectedPortSet" : [
+        ]
+      }
     },
     "typeMap" : {
       

--- a/tests/location_specifier/location_specifier_ast.json
+++ b/tests/location_specifier/location_specifier_ast.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion" : "v3.2.0",
+  "fppVersion" : "v3.3.0a16-110-g291b338cc",
   "ast" : [
     {
       "members" : [
@@ -74,6 +74,29 @@
                     "isDictionaryDef" : true
                   },
                   "id" : 7
+                }
+              }
+            }
+          },
+          [
+          ]
+        ],
+        [
+          [
+          ],
+          {
+            "DefTopology" : {
+              "node" : {
+                "AstNode" : {
+                  "data" : {
+                    "isDeployment" : false,
+                    "name" : "T",
+                    "members" : [
+                    ],
+                    "implements" : [
+                    ]
+                  },
+                  "id" : 8
                 }
               }
             }

--- a/tests/location_specifier/location_specifier_locations.json
+++ b/tests/location_specifier/location_specifier_locations.json
@@ -1,44 +1,49 @@
 {
-  "fppVersion" : "v3.2.0",
+  "fppVersion" : "v3.3.0a16-110-g291b338cc",
   "locationMap" : {
     "0" : {
-      "file" : "[ local path prefix ]/compiler/tools/fpp-depend/test/dictionary_no_top.fpp",
+      "file" : "[ local path prefix ]/compiler/tools/fpp-depend/test/dictionary_no_deployment_top.fpp",
       "pos" : "4.28",
       "includingLoc" : "None"
     },
     "1" : {
-      "file" : "[ local path prefix ]/compiler/tools/fpp-depend/test/dictionary_no_top.fpp",
+      "file" : "[ local path prefix ]/compiler/tools/fpp-depend/test/dictionary_no_deployment_top.fpp",
       "pos" : "4.28",
       "includingLoc" : "None"
     },
     "2" : {
-      "file" : "[ local path prefix ]/compiler/tools/fpp-depend/test/dictionary_no_top.fpp",
+      "file" : "[ local path prefix ]/compiler/tools/fpp-depend/test/dictionary_no_deployment_top.fpp",
       "pos" : "4.33",
       "includingLoc" : "None"
     },
     "3" : {
-      "file" : "[ local path prefix ]/compiler/tools/fpp-depend/test/dictionary_no_top.fpp",
+      "file" : "[ local path prefix ]/compiler/tools/fpp-depend/test/dictionary_no_deployment_top.fpp",
       "pos" : "4.1",
       "includingLoc" : "None"
     },
     "4" : {
-      "file" : "[ local path prefix ]/compiler/tools/fpp-depend/test/dictionary_no_top.fpp",
+      "file" : "[ local path prefix ]/compiler/tools/fpp-depend/test/dictionary_no_deployment_top.fpp",
       "pos" : "5.24",
       "includingLoc" : "None"
     },
     "5" : {
-      "file" : "[ local path prefix ]/compiler/tools/fpp-depend/test/dictionary_no_top.fpp",
+      "file" : "[ local path prefix ]/compiler/tools/fpp-depend/test/dictionary_no_deployment_top.fpp",
       "pos" : "5.24",
       "includingLoc" : "None"
     },
     "6" : {
-      "file" : "[ local path prefix ]/compiler/tools/fpp-depend/test/dictionary_no_top.fpp",
+      "file" : "[ local path prefix ]/compiler/tools/fpp-depend/test/dictionary_no_deployment_top.fpp",
       "pos" : "5.30",
       "includingLoc" : "None"
     },
     "7" : {
-      "file" : "[ local path prefix ]/compiler/tools/fpp-depend/test/dictionary_no_top.fpp",
+      "file" : "[ local path prefix ]/compiler/tools/fpp-depend/test/dictionary_no_deployment_top.fpp",
       "pos" : "5.1",
+      "includingLoc" : "None"
+    },
+    "8" : {
+      "file" : "[ local path prefix ]/compiler/tools/fpp-depend/test/dictionary_no_deployment_top.fpp",
+      "pos" : "8.1",
       "includingLoc" : "None"
     }
   }

--- a/tests/matched_ports/matched_ports_analysis.json
+++ b/tests/matched_ports/matched_ports_analysis.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion" : "v3.2.0",
+  "fppVersion" : "v3.3.0a16-110-g291b338cc",
   "analysis" : {
     "componentInstanceMap" : {
       

--- a/tests/matched_ports/matched_ports_ast.json
+++ b/tests/matched_ports/matched_ports_ast.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion" : "v3.2.0",
+  "fppVersion" : "v3.3.0a16-110-g291b338cc",
   "ast" : [
     {
       "members" : [

--- a/tests/matched_ports/matched_ports_locations.json
+++ b/tests/matched_ports/matched_ports_locations.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion" : "v3.2.0",
+  "fppVersion" : "v3.3.0a16-110-g291b338cc",
   "locationMap" : {
     "0" : {
       "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/matchedPorts.fpp",

--- a/tests/parameters/parameters_analysis.json
+++ b/tests/parameters/parameters_analysis.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion" : "v3.2.0",
+  "fppVersion" : "v3.3.0a16-110-g291b338cc",
   "analysis" : {
     "componentInstanceMap" : {
       

--- a/tests/parameters/parameters_ast.json
+++ b/tests/parameters/parameters_ast.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion" : "v3.2.0",
+  "fppVersion" : "v3.3.0a16-110-g291b338cc",
   "ast" : [
     {
       "members" : [

--- a/tests/parameters/parameters_locations.json
+++ b/tests/parameters/parameters_locations.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion" : "v3.2.0",
+  "fppVersion" : "v3.3.0a16-110-g291b338cc",
   "locationMap" : {
     "0" : {
       "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/parameters.fpp",

--- a/tests/passive_component/passive_component_analysis.json
+++ b/tests/passive_component/passive_component_analysis.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion" : "v3.2.0",
+  "fppVersion" : "v3.3.0a16-110-g291b338cc",
   "analysis" : {
     "componentInstanceMap" : {
       "60" : {

--- a/tests/passive_component/passive_component_ast.json
+++ b/tests/passive_component/passive_component_ast.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion" : "v3.2.0",
+  "fppVersion" : "v3.3.0a16-110-g291b338cc",
   "ast" : [
     {
       "members" : [

--- a/tests/passive_component/passive_component_locations.json
+++ b/tests/passive_component/passive_component_locations.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion" : "v3.2.0",
+  "fppVersion" : "v3.3.0a16-110-g291b338cc",
   "locationMap" : {
     "0" : {
       "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/passiveComponent.fpp",

--- a/tests/patterned_connections/patterned_connections_analysis.json
+++ b/tests/patterned_connections/patterned_connections_analysis.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion" : "v3.2.0",
+  "fppVersion" : "v3.3.0a16-110-g291b338cc",
   "analysis" : {
     "componentInstanceMap" : {
       "114" : {
@@ -1657,13 +1657,13 @@
           {
             "interfaceInstance" : {
               "InterfaceComponentInstance" : {
-                "astNodeId" : 134
+                "astNodeId" : 114
               }
             },
             "portInstance" : {
               "General" : {
                 "aNode" : {
-                  "astNodeId" : 96
+                  "astNodeId" : 11
                 },
                 "specifier" : {
                   "kind" : {
@@ -1671,11 +1671,11 @@
                       
                     }
                   },
-                  "name" : "tlm",
+                  "name" : "timeGetPort",
                   "size" : "None",
                   "port" : {
                     "Some" : {
-                      "astNodeId" : 95
+                      "astNodeId" : 10
                     }
                   },
                   "priority" : "None",
@@ -1687,140 +1687,8 @@
                   "DefPort" : {
                     "symbol" : {
                       "Port" : {
-                        "nodeId" : 294,
-                        "unqualifiedName" : "Tlm"
-                      }
-                    }
-                  }
-                },
-                "importNodeIds" : [
-                ]
-              }
-            }
-          },
-          {
-            "interfaceInstance" : {
-              "InterfaceComponentInstance" : {
-                "astNodeId" : 118
-              }
-            },
-            "portInstance" : {
-              "General" : {
-                "aNode" : {
-                  "astNodeId" : 24
-                },
-                "specifier" : {
-                  "kind" : {
-                    "SyncInput" : {
-                      
-                    }
-                  },
-                  "name" : "cmdResponseOut",
-                  "size" : "None",
-                  "port" : {
-                    "Some" : {
-                      "astNodeId" : 23
-                    }
-                  },
-                  "priority" : "None",
-                  "queueFull" : "None"
-                },
-                "kind" : "SyncInput",
-                "size" : 1,
-                "ty" : {
-                  "DefPort" : {
-                    "symbol" : {
-                      "Port" : {
-                        "nodeId" : 288,
-                        "unqualifiedName" : "CmdResponse"
-                      }
-                    }
-                  }
-                },
-                "importNodeIds" : [
-                ]
-              }
-            }
-          },
-          {
-            "interfaceInstance" : {
-              "InterfaceComponentInstance" : {
-                "astNodeId" : 126
-              }
-            },
-            "portInstance" : {
-              "General" : {
-                "aNode" : {
-                  "astNodeId" : 66
-                },
-                "specifier" : {
-                  "kind" : {
-                    "SyncInput" : {
-                      
-                    }
-                  },
-                  "name" : "PingReturn",
-                  "size" : "None",
-                  "port" : {
-                    "Some" : {
-                      "astNodeId" : 65
-                    }
-                  },
-                  "priority" : "None",
-                  "queueFull" : "None"
-                },
-                "kind" : "SyncInput",
-                "size" : 1,
-                "ty" : {
-                  "DefPort" : {
-                    "symbol" : {
-                      "Port" : {
-                        "nodeId" : 301,
-                        "unqualifiedName" : "Ping"
-                      }
-                    }
-                  }
-                },
-                "importNodeIds" : [
-                ]
-              }
-            }
-          },
-          {
-            "interfaceInstance" : {
-              "InterfaceComponentInstance" : {
-                "astNodeId" : 118
-              }
-            },
-            "portInstance" : {
-              "General" : {
-                "aNode" : {
-                  "astNodeId" : 36
-                },
-                "specifier" : {
-                  "kind" : {
-                    "Output" : {
-                      
-                    }
-                  },
-                  "name" : "cmdSend",
-                  "size" : "None",
-                  "port" : {
-                    "Some" : {
-                      "astNodeId" : 35
-                    }
-                  },
-                  "priority" : "None",
-                  "queueFull" : "None"
-                },
-                "kind" : "Output",
-                "size" : 1,
-                "ty" : {
-                  "DefPort" : {
-                    "symbol" : {
-                      "Port" : {
-                        "nodeId" : 286,
-                        "unqualifiedName" : "Cmd"
+                        "nodeId" : 293,
+                        "unqualifiedName" : "Time"
                       }
                     }
                   }
@@ -1877,94 +1745,6 @@
           {
             "interfaceInstance" : {
               "InterfaceComponentInstance" : {
-                "astNodeId" : 130
-              }
-            },
-            "portInstance" : {
-              "General" : {
-                "aNode" : {
-                  "astNodeId" : 83
-                },
-                "specifier" : {
-                  "kind" : {
-                    "SyncInput" : {
-                      
-                    }
-                  },
-                  "name" : "paramSet",
-                  "size" : "None",
-                  "port" : {
-                    "Some" : {
-                      "astNodeId" : 82
-                    }
-                  },
-                  "priority" : "None",
-                  "queueFull" : "None"
-                },
-                "kind" : "SyncInput",
-                "size" : 1,
-                "ty" : {
-                  "DefPort" : {
-                    "symbol" : {
-                      "Port" : {
-                        "nodeId" : 292,
-                        "unqualifiedName" : "PrmSet"
-                      }
-                    }
-                  }
-                },
-                "importNodeIds" : [
-                ]
-              }
-            }
-          },
-          {
-            "interfaceInstance" : {
-              "InterfaceComponentInstance" : {
-                "astNodeId" : 126
-              }
-            },
-            "portInstance" : {
-              "General" : {
-                "aNode" : {
-                  "astNodeId" : 54
-                },
-                "specifier" : {
-                  "kind" : {
-                    "Output" : {
-                      
-                    }
-                  },
-                  "name" : "PingSend",
-                  "size" : "None",
-                  "port" : {
-                    "Some" : {
-                      "astNodeId" : 53
-                    }
-                  },
-                  "priority" : "None",
-                  "queueFull" : "None"
-                },
-                "kind" : "Output",
-                "size" : 1,
-                "ty" : {
-                  "DefPort" : {
-                    "symbol" : {
-                      "Port" : {
-                        "nodeId" : 301,
-                        "unqualifiedName" : "Ping"
-                      }
-                    }
-                  }
-                },
-                "importNodeIds" : [
-                ]
-              }
-            }
-          },
-          {
-            "interfaceInstance" : {
-              "InterfaceComponentInstance" : {
                 "astNodeId" : 118
               }
             },
@@ -2009,13 +1789,13 @@
           {
             "interfaceInstance" : {
               "InterfaceComponentInstance" : {
-                "astNodeId" : 138
+                "astNodeId" : 118
               }
             },
             "portInstance" : {
               "General" : {
                 "aNode" : {
-                  "astNodeId" : 109
+                  "astNodeId" : 24
                 },
                 "specifier" : {
                   "kind" : {
@@ -2023,11 +1803,11 @@
                       
                     }
                   },
-                  "name" : "textEventLog",
+                  "name" : "cmdResponseOut",
                   "size" : "None",
                   "port" : {
                     "Some" : {
-                      "astNodeId" : 108
+                      "astNodeId" : 23
                     }
                   },
                   "priority" : "None",
@@ -2039,8 +1819,8 @@
                   "DefPort" : {
                     "symbol" : {
                       "Port" : {
-                        "nodeId" : 290,
-                        "unqualifiedName" : "LogText"
+                        "nodeId" : 288,
+                        "unqualifiedName" : "CmdResponse"
                       }
                     }
                   }
@@ -2053,38 +1833,38 @@
           {
             "interfaceInstance" : {
               "InterfaceComponentInstance" : {
-                "astNodeId" : 114
+                "astNodeId" : 118
               }
             },
             "portInstance" : {
               "General" : {
                 "aNode" : {
-                  "astNodeId" : 11
+                  "astNodeId" : 36
                 },
                 "specifier" : {
                   "kind" : {
-                    "SyncInput" : {
+                    "Output" : {
                       
                     }
                   },
-                  "name" : "timeGetPort",
+                  "name" : "cmdSend",
                   "size" : "None",
                   "port" : {
                     "Some" : {
-                      "astNodeId" : 10
+                      "astNodeId" : 35
                     }
                   },
                   "priority" : "None",
                   "queueFull" : "None"
                 },
-                "kind" : "SyncInput",
+                "kind" : "Output",
                 "size" : 1,
                 "ty" : {
                   "DefPort" : {
                     "symbol" : {
                       "Port" : {
-                        "nodeId" : 293,
-                        "unqualifiedName" : "Time"
+                        "nodeId" : 286,
+                        "unqualifiedName" : "Cmd"
                       }
                     }
                   }
@@ -2141,6 +1921,94 @@
           {
             "interfaceInstance" : {
               "InterfaceComponentInstance" : {
+                "astNodeId" : 126
+              }
+            },
+            "portInstance" : {
+              "General" : {
+                "aNode" : {
+                  "astNodeId" : 66
+                },
+                "specifier" : {
+                  "kind" : {
+                    "SyncInput" : {
+                      
+                    }
+                  },
+                  "name" : "PingReturn",
+                  "size" : "None",
+                  "port" : {
+                    "Some" : {
+                      "astNodeId" : 65
+                    }
+                  },
+                  "priority" : "None",
+                  "queueFull" : "None"
+                },
+                "kind" : "SyncInput",
+                "size" : 1,
+                "ty" : {
+                  "DefPort" : {
+                    "symbol" : {
+                      "Port" : {
+                        "nodeId" : 301,
+                        "unqualifiedName" : "Ping"
+                      }
+                    }
+                  }
+                },
+                "importNodeIds" : [
+                ]
+              }
+            }
+          },
+          {
+            "interfaceInstance" : {
+              "InterfaceComponentInstance" : {
+                "astNodeId" : 126
+              }
+            },
+            "portInstance" : {
+              "General" : {
+                "aNode" : {
+                  "astNodeId" : 54
+                },
+                "specifier" : {
+                  "kind" : {
+                    "Output" : {
+                      
+                    }
+                  },
+                  "name" : "PingSend",
+                  "size" : "None",
+                  "port" : {
+                    "Some" : {
+                      "astNodeId" : 53
+                    }
+                  },
+                  "priority" : "None",
+                  "queueFull" : "None"
+                },
+                "kind" : "Output",
+                "size" : 1,
+                "ty" : {
+                  "DefPort" : {
+                    "symbol" : {
+                      "Port" : {
+                        "nodeId" : 301,
+                        "unqualifiedName" : "Ping"
+                      }
+                    }
+                  }
+                },
+                "importNodeIds" : [
+                ]
+              }
+            }
+          },
+          {
+            "interfaceInstance" : {
+              "InterfaceComponentInstance" : {
                 "astNodeId" : 130
               }
             },
@@ -2173,6 +2041,138 @@
                       "Port" : {
                         "nodeId" : 291,
                         "unqualifiedName" : "PrmGet"
+                      }
+                    }
+                  }
+                },
+                "importNodeIds" : [
+                ]
+              }
+            }
+          },
+          {
+            "interfaceInstance" : {
+              "InterfaceComponentInstance" : {
+                "astNodeId" : 130
+              }
+            },
+            "portInstance" : {
+              "General" : {
+                "aNode" : {
+                  "astNodeId" : 83
+                },
+                "specifier" : {
+                  "kind" : {
+                    "SyncInput" : {
+                      
+                    }
+                  },
+                  "name" : "paramSet",
+                  "size" : "None",
+                  "port" : {
+                    "Some" : {
+                      "astNodeId" : 82
+                    }
+                  },
+                  "priority" : "None",
+                  "queueFull" : "None"
+                },
+                "kind" : "SyncInput",
+                "size" : 1,
+                "ty" : {
+                  "DefPort" : {
+                    "symbol" : {
+                      "Port" : {
+                        "nodeId" : 292,
+                        "unqualifiedName" : "PrmSet"
+                      }
+                    }
+                  }
+                },
+                "importNodeIds" : [
+                ]
+              }
+            }
+          },
+          {
+            "interfaceInstance" : {
+              "InterfaceComponentInstance" : {
+                "astNodeId" : 134
+              }
+            },
+            "portInstance" : {
+              "General" : {
+                "aNode" : {
+                  "astNodeId" : 96
+                },
+                "specifier" : {
+                  "kind" : {
+                    "SyncInput" : {
+                      
+                    }
+                  },
+                  "name" : "tlm",
+                  "size" : "None",
+                  "port" : {
+                    "Some" : {
+                      "astNodeId" : 95
+                    }
+                  },
+                  "priority" : "None",
+                  "queueFull" : "None"
+                },
+                "kind" : "SyncInput",
+                "size" : 1,
+                "ty" : {
+                  "DefPort" : {
+                    "symbol" : {
+                      "Port" : {
+                        "nodeId" : 294,
+                        "unqualifiedName" : "Tlm"
+                      }
+                    }
+                  }
+                },
+                "importNodeIds" : [
+                ]
+              }
+            }
+          },
+          {
+            "interfaceInstance" : {
+              "InterfaceComponentInstance" : {
+                "astNodeId" : 138
+              }
+            },
+            "portInstance" : {
+              "General" : {
+                "aNode" : {
+                  "astNodeId" : 109
+                },
+                "specifier" : {
+                  "kind" : {
+                    "SyncInput" : {
+                      
+                    }
+                  },
+                  "name" : "textEventLog",
+                  "size" : "None",
+                  "port" : {
+                    "Some" : {
+                      "astNodeId" : 108
+                    }
+                  },
+                  "priority" : "None",
+                  "queueFull" : "None"
+                },
+                "kind" : "SyncInput",
+                "size" : 1,
+                "ty" : {
+                  "DefPort" : {
+                    "symbol" : {
+                      "Port" : {
+                        "nodeId" : 290,
+                        "unqualifiedName" : "LogText"
                       }
                     }
                   }
@@ -2554,31 +2554,7 @@
       
     },
     "dictionaryMap" : {
-      "285" : {
-        "usedSymbolSet" : [
-        ],
-        "commandEntryMap" : {
-          
-        },
-        "tlmChannelEntryMap" : {
-          
-        },
-        "eventEntryMap" : {
-          
-        },
-        "paramEntryMap" : {
-          
-        },
-        "recordEntryMap" : {
-          
-        },
-        "containerEntryMap" : {
-          
-        },
-        "tlmPacketSetMap" : {
-          
-        }
-      }
+      
     }
   }
 }

--- a/tests/patterned_connections/patterned_connections_ast.json
+++ b/tests/patterned_connections/patterned_connections_ast.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion" : "v3.2.0",
+  "fppVersion" : "v3.3.0a16-110-g291b338cc",
   "ast" : [
     {
       "members" : [
@@ -1168,6 +1168,7 @@
               "node" : {
                 "AstNode" : {
                   "data" : {
+                    "isDeployment" : false,
                     "name" : "T",
                     "members" : [
                       [

--- a/tests/patterned_connections/patterned_connections_locations.json
+++ b/tests/patterned_connections/patterned_connections_locations.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion" : "v3.2.0",
+  "fppVersion" : "v3.3.0a16-110-g291b338cc",
   "locationMap" : {
     "0" : {
       "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/patternedConnections.fpp",

--- a/tests/ports/ports_analysis.json
+++ b/tests/ports/ports_analysis.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion" : "v3.2.0",
+  "fppVersion" : "v3.3.0a16-110-g291b338cc",
   "analysis" : {
     "componentInstanceMap" : {
       "92" : {
@@ -1052,31 +1052,7 @@
       
     },
     "dictionaryMap" : {
-      "122" : {
-        "usedSymbolSet" : [
-        ],
-        "commandEntryMap" : {
-          
-        },
-        "tlmChannelEntryMap" : {
-          
-        },
-        "eventEntryMap" : {
-          
-        },
-        "paramEntryMap" : {
-          
-        },
-        "recordEntryMap" : {
-          
-        },
-        "containerEntryMap" : {
-          
-        },
-        "tlmPacketSetMap" : {
-          
-        }
-      }
+      
     }
   }
 }

--- a/tests/ports/ports_ast.json
+++ b/tests/ports/ports_ast.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion" : "v3.2.0",
+  "fppVersion" : "v3.3.0a16-110-g291b338cc",
   "ast" : [
     {
       "members" : [
@@ -864,6 +864,7 @@
                             "node" : {
                               "AstNode" : {
                                 "data" : {
+                                  "isDeployment" : false,
                                   "name" : "T",
                                   "members" : [
                                     [

--- a/tests/ports/ports_locations.json
+++ b/tests/ports/ports_locations.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion" : "v3.2.0",
+  "fppVersion" : "v3.3.0a16-110-g291b338cc",
   "locationMap" : {
     "0" : {
       "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/ports.fpp",

--- a/tests/queued_component/queued_component_analysis.json
+++ b/tests/queued_component/queued_component_analysis.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion" : "v3.2.0",
+  "fppVersion" : "v3.3.0a16-110-g291b338cc",
   "analysis" : {
     "componentInstanceMap" : {
       "79" : {

--- a/tests/queued_component/queued_component_ast.json
+++ b/tests/queued_component/queued_component_ast.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion" : "v3.2.0",
+  "fppVersion" : "v3.3.0a16-110-g291b338cc",
   "ast" : [
     {
       "members" : [

--- a/tests/queued_component/queued_component_locations.json
+++ b/tests/queued_component/queued_component_locations.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion" : "v3.2.0",
+  "fppVersion" : "v3.3.0a16-110-g291b338cc",
   "locationMap" : {
     "0" : {
       "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/queuedComponents.fpp",

--- a/tests/special_ports/special_ports_analysis.json
+++ b/tests/special_ports/special_ports_analysis.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion" : "v3.2.0",
+  "fppVersion" : "v3.3.0a16-110-g291b338cc",
   "analysis" : {
     "componentInstanceMap" : {
       

--- a/tests/special_ports/special_ports_ast.json
+++ b/tests/special_ports/special_ports_ast.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion" : "v3.2.0",
+  "fppVersion" : "v3.3.0a16-110-g291b338cc",
   "ast" : [
     {
       "members" : [

--- a/tests/special_ports/special_ports_locations.json
+++ b/tests/special_ports/special_ports_locations.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion" : "v3.2.0",
+  "fppVersion" : "v3.3.0a16-110-g291b338cc",
   "locationMap" : {
     "0" : {
       "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/specialPorts.fpp",

--- a/tests/state_machine/state_machine_analysis.json
+++ b/tests/state_machine/state_machine_analysis.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion" : "v3.2.0",
+  "fppVersion" : "v3.3.0a16-110-g291b338cc",
   "analysis" : {
     "componentInstanceMap" : {
       

--- a/tests/state_machine/state_machine_ast.json
+++ b/tests/state_machine/state_machine_ast.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion" : "v3.2.0",
+  "fppVersion" : "v3.3.0a16-110-g291b338cc",
   "ast" : [
     {
       "members" : [

--- a/tests/state_machine/state_machine_locations.json
+++ b/tests/state_machine/state_machine_locations.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion" : "v3.2.0",
+  "fppVersion" : "v3.3.0a16-110-g291b338cc",
   "locationMap" : {
     "0" : {
       "file" : "[ local path prefix ]/compiler/tools/fpp-syntax/test/state-machine.fpp",

--- a/tests/telemetry/telemetry_analysis.json
+++ b/tests/telemetry/telemetry_analysis.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion" : "v3.2.0",
+  "fppVersion" : "v3.3.0a16-110-g291b338cc",
   "analysis" : {
     "componentInstanceMap" : {
       "67" : {
@@ -794,23 +794,23 @@
             "portInstance" : {
               "Special" : {
                 "aNode" : {
-                  "astNodeId" : 0
+                  "astNodeId" : 1
                 },
                 "specifier" : {
                   "inputKind" : "None",
                   "kind" : {
-                    "Telemetry" : {
+                    "TimeGet" : {
                       
                     }
                   },
-                  "name" : "tlmOut",
+                  "name" : "timeGetOut",
                   "priority" : "None",
                   "queueFull" : "None"
                 },
                 "symbol" : {
                   "Port" : {
-                    "nodeId" : 59,
-                    "unqualifiedName" : "Tlm"
+                    "nodeId" : 62,
+                    "unqualifiedName" : "Time"
                   }
                 },
                 "priority" : "None",
@@ -829,23 +829,23 @@
             "portInstance" : {
               "Special" : {
                 "aNode" : {
-                  "astNodeId" : 1
+                  "astNodeId" : 0
                 },
                 "specifier" : {
                   "inputKind" : "None",
                   "kind" : {
-                    "TimeGet" : {
+                    "Telemetry" : {
                       
                     }
                   },
-                  "name" : "timeGetOut",
+                  "name" : "tlmOut",
                   "priority" : "None",
                   "queueFull" : "None"
                 },
                 "symbol" : {
                   "Port" : {
-                    "nodeId" : 62,
-                    "unqualifiedName" : "Time"
+                    "nodeId" : 59,
+                    "unqualifiedName" : "Tlm"
                   }
                 },
                 "priority" : "None",
@@ -1146,335 +1146,7 @@
       
     },
     "dictionaryMap" : {
-      "97" : {
-        "usedSymbolSet" : [
-        ],
-        "commandEntryMap" : {
-          
-        },
-        "tlmChannelEntryMap" : {
-          "18944" : {
-            "instance" : {
-              "aNode" : {
-                "astNodeId" : 67
-              },
-              "qualifiedName" : {
-                "qualifier" : [
-                ],
-                "base" : "i"
-              },
-              "component" : {
-                "astNodeId" : 58
-              },
-              "baseId" : 18944,
-              "maxId" : 18961,
-              "file" : "None",
-              "queueSize" : "None",
-              "stackSize" : "None",
-              "priority" : "None",
-              "cpu" : "None",
-              "initSpecifierMap" : {
-                
-              }
-            },
-            "tlmChannel" : {
-              "aNode" : {
-                "astNodeId" : 11
-              },
-              "channelType" : {
-                "Int" : {
-                  "PrimitiveInt" : {
-                    "kind" : {
-                      "U32" : {
-                        
-                      }
-                    }
-                  }
-                }
-              },
-              "update" : {
-                "Always" : {
-                  
-                }
-              },
-              "format" : {
-                "Some" : {
-                  "prefix" : "",
-                  "fields" : [
-                    [
-                      {
-                        "Default" : {
-                          
-                        }
-                      },
-                      "s"
-                    ]
-                  ]
-                }
-              },
-              "lowLimits" : {
-                "orange" : [
-                  7,
-                  {
-                    "Integer" : {
-                      "value" : 1
-                    }
-                  }
-                ],
-                "red" : [
-                  5,
-                  {
-                    "Integer" : {
-                      "value" : 0
-                    }
-                  }
-                ],
-                "yellow" : [
-                  9,
-                  {
-                    "Integer" : {
-                      "value" : 2
-                    }
-                  }
-                ]
-              },
-              "highLimits" : {
-                
-              }
-            }
-          },
-          "18960" : {
-            "instance" : {
-              "aNode" : {
-                "astNodeId" : 67
-              },
-              "qualifiedName" : {
-                "qualifier" : [
-                ],
-                "base" : "i"
-              },
-              "component" : {
-                "astNodeId" : 58
-              },
-              "baseId" : 18944,
-              "maxId" : 18961,
-              "file" : "None",
-              "queueSize" : "None",
-              "stackSize" : "None",
-              "priority" : "None",
-              "cpu" : "None",
-              "initSpecifierMap" : {
-                
-              }
-            },
-            "tlmChannel" : {
-              "aNode" : {
-                "astNodeId" : 30
-              },
-              "channelType" : {
-                "Primitive" : {
-                  "Float" : {
-                    "kind" : {
-                      "F64" : {
-                        
-                      }
-                    }
-                  }
-                }
-              },
-              "update" : {
-                "OnChange" : {
-                  
-                }
-              },
-              "format" : {
-                "Some" : {
-                  "prefix" : "",
-                  "fields" : [
-                    [
-                      {
-                        "Rational" : {
-                          "precision" : {
-                            "Some" : 3
-                          },
-                          "t" : {
-                            "Fixed" : {
-                              
-                            }
-                          }
-                        }
-                      },
-                      ""
-                    ]
-                  ]
-                }
-              },
-              "lowLimits" : {
-                "orange" : [
-                  18,
-                  {
-                    "Integer" : {
-                      "value" : -2
-                    }
-                  }
-                ],
-                "red" : [
-                  15,
-                  {
-                    "Integer" : {
-                      "value" : -3
-                    }
-                  }
-                ],
-                "yellow" : [
-                  21,
-                  {
-                    "Integer" : {
-                      "value" : -1
-                    }
-                  }
-                ]
-              },
-              "highLimits" : {
-                "orange" : [
-                  26,
-                  {
-                    "Integer" : {
-                      "value" : 2
-                    }
-                  }
-                ],
-                "red" : [
-                  24,
-                  {
-                    "Integer" : {
-                      "value" : 3
-                    }
-                  }
-                ],
-                "yellow" : [
-                  28,
-                  {
-                    "Integer" : {
-                      "value" : 1
-                    }
-                  }
-                ]
-              }
-            }
-          },
-          "18961" : {
-            "instance" : {
-              "aNode" : {
-                "astNodeId" : 67
-              },
-              "qualifiedName" : {
-                "qualifier" : [
-                ],
-                "base" : "i"
-              },
-              "component" : {
-                "astNodeId" : 58
-              },
-              "baseId" : 18944,
-              "maxId" : 18961,
-              "file" : "None",
-              "queueSize" : "None",
-              "stackSize" : "None",
-              "priority" : "None",
-              "cpu" : "None",
-              "initSpecifierMap" : {
-                
-              }
-            },
-            "tlmChannel" : {
-              "aNode" : {
-                "astNodeId" : 57
-              },
-              "channelType" : {
-                "Primitive" : {
-                  "Float" : {
-                    "kind" : {
-                      "F64" : {
-                        
-                      }
-                    }
-                  }
-                }
-              },
-              "update" : {
-                "Always" : {
-                  
-                }
-              },
-              "format" : {
-                "Some" : {
-                  "prefix" : "",
-                  "fields" : [
-                    [
-                      {
-                        "Rational" : {
-                          "precision" : "None",
-                          "t" : {
-                            "Exponent" : {
-                              
-                            }
-                          }
-                        }
-                      },
-                      ""
-                    ]
-                  ]
-                }
-              },
-              "lowLimits" : {
-                
-              },
-              "highLimits" : {
-                "orange" : [
-                  53,
-                  {
-                    "Integer" : {
-                      "value" : 2
-                    }
-                  }
-                ],
-                "red" : [
-                  51,
-                  {
-                    "Integer" : {
-                      "value" : 3
-                    }
-                  }
-                ],
-                "yellow" : [
-                  55,
-                  {
-                    "Integer" : {
-                      "value" : 1
-                    }
-                  }
-                ]
-              }
-            }
-          }
-        },
-        "eventEntryMap" : {
-          
-        },
-        "paramEntryMap" : {
-          
-        },
-        "recordEntryMap" : {
-          
-        },
-        "containerEntryMap" : {
-          
-        },
-        "tlmPacketSetMap" : {
-          
-        }
-      }
+      
     }
   }
 }

--- a/tests/telemetry/telemetry_ast.json
+++ b/tests/telemetry/telemetry_ast.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion" : "v3.2.0",
+  "fppVersion" : "v3.3.0a16-110-g291b338cc",
   "ast" : [
     {
       "members" : [
@@ -694,6 +694,7 @@
                             "node" : {
                               "AstNode" : {
                                 "data" : {
+                                  "isDeployment" : false,
                                   "name" : "T",
                                   "members" : [
                                     [

--- a/tests/telemetry/telemetry_locations.json
+++ b/tests/telemetry/telemetry_locations.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion" : "v3.2.0",
+  "fppVersion" : "v3.3.0a16-110-g291b338cc",
   "locationMap" : {
     "0" : {
       "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetry.fpp",

--- a/tests/telemetry_packets/telemetry_packets.fpp
+++ b/tests/telemetry_packets/telemetry_packets.fpp
@@ -27,7 +27,7 @@ instance c1: C base id 0x100
 instance c2: C base id 0x200
 
 @ A topology with telemetry packets
-topology TelemetryPackets {
+deployment topology TelemetryPackets {
 
   instance c1
 

--- a/tests/telemetry_packets/telemetry_packets_analysis.json
+++ b/tests/telemetry_packets/telemetry_packets_analysis.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion" : "v3.2.0",
+  "fppVersion" : "v3.3.0a16-110-g291b338cc",
   "analysis" : {
     "componentInstanceMap" : {
       "24" : {
@@ -483,6 +483,50 @@
             "portInstance" : {
               "General" : {
                 "aNode" : {
+                  "astNodeId" : 8
+                },
+                "specifier" : {
+                  "kind" : {
+                    "SyncInput" : {
+                      
+                    }
+                  },
+                  "name" : "pIn",
+                  "size" : "None",
+                  "port" : {
+                    "Some" : {
+                      "astNodeId" : 7
+                    }
+                  },
+                  "priority" : "None",
+                  "queueFull" : "None"
+                },
+                "kind" : "SyncInput",
+                "size" : 1,
+                "ty" : {
+                  "DefPort" : {
+                    "symbol" : {
+                      "Port" : {
+                        "nodeId" : 5,
+                        "unqualifiedName" : "P"
+                      }
+                    }
+                  }
+                },
+                "importNodeIds" : [
+                ]
+              }
+            }
+          },
+          {
+            "interfaceInstance" : {
+              "InterfaceComponentInstance" : {
+                "astNodeId" : 24
+              }
+            },
+            "portInstance" : {
+              "General" : {
+                "aNode" : {
                   "astNodeId" : 11
                 },
                 "specifier" : {
@@ -521,7 +565,42 @@
           {
             "interfaceInstance" : {
               "InterfaceComponentInstance" : {
-                "astNodeId" : 28
+                "astNodeId" : 24
+              }
+            },
+            "portInstance" : {
+              "Special" : {
+                "aNode" : {
+                  "astNodeId" : 13
+                },
+                "specifier" : {
+                  "inputKind" : "None",
+                  "kind" : {
+                    "TimeGet" : {
+                      
+                    }
+                  },
+                  "name" : "timeGetOut",
+                  "priority" : "None",
+                  "queueFull" : "None"
+                },
+                "symbol" : {
+                  "Port" : {
+                    "nodeId" : 3,
+                    "unqualifiedName" : "Time"
+                  }
+                },
+                "priority" : "None",
+                "queueFull" : "None",
+                "importNodeIds" : [
+                ]
+              }
+            }
+          },
+          {
+            "interfaceInstance" : {
+              "InterfaceComponentInstance" : {
+                "astNodeId" : 24
               }
             },
             "portInstance" : {
@@ -556,7 +635,7 @@
           {
             "interfaceInstance" : {
               "InterfaceComponentInstance" : {
-                "astNodeId" : 24
+                "astNodeId" : 28
               }
             },
             "portInstance" : {
@@ -680,85 +759,6 @@
             "interfaceInstance" : {
               "InterfaceComponentInstance" : {
                 "astNodeId" : 28
-              }
-            },
-            "portInstance" : {
-              "General" : {
-                "aNode" : {
-                  "astNodeId" : 8
-                },
-                "specifier" : {
-                  "kind" : {
-                    "SyncInput" : {
-                      
-                    }
-                  },
-                  "name" : "pIn",
-                  "size" : "None",
-                  "port" : {
-                    "Some" : {
-                      "astNodeId" : 7
-                    }
-                  },
-                  "priority" : "None",
-                  "queueFull" : "None"
-                },
-                "kind" : "SyncInput",
-                "size" : 1,
-                "ty" : {
-                  "DefPort" : {
-                    "symbol" : {
-                      "Port" : {
-                        "nodeId" : 5,
-                        "unqualifiedName" : "P"
-                      }
-                    }
-                  }
-                },
-                "importNodeIds" : [
-                ]
-              }
-            }
-          },
-          {
-            "interfaceInstance" : {
-              "InterfaceComponentInstance" : {
-                "astNodeId" : 24
-              }
-            },
-            "portInstance" : {
-              "Special" : {
-                "aNode" : {
-                  "astNodeId" : 13
-                },
-                "specifier" : {
-                  "inputKind" : "None",
-                  "kind" : {
-                    "TimeGet" : {
-                      
-                    }
-                  },
-                  "name" : "timeGetOut",
-                  "priority" : "None",
-                  "queueFull" : "None"
-                },
-                "symbol" : {
-                  "Port" : {
-                    "nodeId" : 3,
-                    "unqualifiedName" : "Time"
-                  }
-                },
-                "priority" : "None",
-                "queueFull" : "None",
-                "importNodeIds" : [
-                ]
-              }
-            }
-          },
-          {
-            "interfaceInstance" : {
-              "InterfaceComponentInstance" : {
-                "astNodeId" : 24
               }
             },
             "portInstance" : {

--- a/tests/telemetry_packets/telemetry_packets_ast.json
+++ b/tests/telemetry_packets/telemetry_packets_ast.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion" : "v3.2.0",
+  "fppVersion" : "v3.3.0a16-110-g291b338cc",
   "ast" : [
     {
       "members" : [
@@ -387,6 +387,7 @@
               "node" : {
                 "AstNode" : {
                   "data" : {
+                    "isDeployment" : true,
                     "name" : "TelemetryPackets",
                     "members" : [
                       [

--- a/tests/telemetry_packets/telemetry_packets_locations.json
+++ b/tests/telemetry_packets/telemetry_packets_locations.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion" : "v3.2.0",
+  "fppVersion" : "v3.3.0a16-110-g291b338cc",
   "locationMap" : {
     "0" : {
       "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/telemetryPackets.fpp",

--- a/tests/topology/topology_analysis.json
+++ b/tests/topology/topology_analysis.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion" : "v3.2.0",
+  "fppVersion" : "v3.3.0a16-110-g291b338cc",
   "analysis" : {
     "componentInstanceMap" : {
       "18" : {
@@ -1036,163 +1036,6 @@
             {
               "interfaceInstance" : {
                 "InterfaceComponentInstance" : {
-                  "astNodeId" : 22
-                }
-              },
-              "portInstance" : {
-                "General" : {
-                  "aNode" : {
-                    "astNodeId" : 4
-                  },
-                  "specifier" : {
-                    "kind" : {
-                      "SyncInput" : {
-                        
-                      }
-                    },
-                    "name" : "pIn",
-                    "size" : "None",
-                    "port" : {
-                      "Some" : {
-                        "astNodeId" : 3
-                      }
-                    },
-                    "priority" : "None",
-                    "queueFull" : "None"
-                  },
-                  "kind" : "SyncInput",
-                  "size" : 1,
-                  "ty" : {
-                    "DefPort" : {
-                      "symbol" : {
-                        "Port" : {
-                          "nodeId" : 0,
-                          "unqualifiedName" : "P"
-                        }
-                      }
-                    }
-                  },
-                  "importNodeIds" : [
-                  ]
-                }
-              }
-            },
-            [
-              {
-                "from" : {
-                  "loc" : {
-                    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-                    "pos" : "23.5",
-                    "includingLoc" : "None"
-                  },
-                  "port" : {
-                    "interfaceInstance" : {
-                      "InterfaceComponentInstance" : {
-                        "astNodeId" : 18
-                      }
-                    },
-                    "portInstance" : {
-                      "General" : {
-                        "aNode" : {
-                          "astNodeId" : 13
-                        },
-                        "specifier" : {
-                          "kind" : {
-                            "Output" : {
-                              
-                            }
-                          },
-                          "name" : "pOut",
-                          "size" : "None",
-                          "port" : {
-                            "Some" : {
-                              "astNodeId" : 12
-                            }
-                          },
-                          "priority" : "None",
-                          "queueFull" : "None"
-                        },
-                        "kind" : "Output",
-                        "size" : 1,
-                        "ty" : {
-                          "DefPort" : {
-                            "symbol" : {
-                              "Port" : {
-                                "nodeId" : 0,
-                                "unqualifiedName" : "P"
-                              }
-                            }
-                          }
-                        },
-                        "importNodeIds" : [
-                        ]
-                      }
-                    }
-                  },
-                  "portNumber" : "None",
-                  "topologyPort" : "None"
-                },
-                "to" : {
-                  "loc" : {
-                    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-                    "pos" : "23.16",
-                    "includingLoc" : "None"
-                  },
-                  "port" : {
-                    "interfaceInstance" : {
-                      "InterfaceComponentInstance" : {
-                        "astNodeId" : 22
-                      }
-                    },
-                    "portInstance" : {
-                      "General" : {
-                        "aNode" : {
-                          "astNodeId" : 4
-                        },
-                        "specifier" : {
-                          "kind" : {
-                            "SyncInput" : {
-                              
-                            }
-                          },
-                          "name" : "pIn",
-                          "size" : "None",
-                          "port" : {
-                            "Some" : {
-                              "astNodeId" : 3
-                            }
-                          },
-                          "priority" : "None",
-                          "queueFull" : "None"
-                        },
-                        "kind" : "SyncInput",
-                        "size" : 1,
-                        "ty" : {
-                          "DefPort" : {
-                            "symbol" : {
-                              "Port" : {
-                                "nodeId" : 0,
-                                "unqualifiedName" : "P"
-                              }
-                            }
-                          }
-                        },
-                        "importNodeIds" : [
-                        ]
-                      }
-                    }
-                  },
-                  "portNumber" : "None",
-                  "topologyPort" : "None"
-                },
-                "isUnmatched" : false
-              }
-            ]
-          ],
-          [
-            {
-              "interfaceInstance" : {
-                "InterfaceComponentInstance" : {
                   "astNodeId" : 18
                 }
               },
@@ -1299,6 +1142,163 @@
                     "interfaceInstance" : {
                       "InterfaceComponentInstance" : {
                         "astNodeId" : 18
+                      }
+                    },
+                    "portInstance" : {
+                      "General" : {
+                        "aNode" : {
+                          "astNodeId" : 4
+                        },
+                        "specifier" : {
+                          "kind" : {
+                            "SyncInput" : {
+                              
+                            }
+                          },
+                          "name" : "pIn",
+                          "size" : "None",
+                          "port" : {
+                            "Some" : {
+                              "astNodeId" : 3
+                            }
+                          },
+                          "priority" : "None",
+                          "queueFull" : "None"
+                        },
+                        "kind" : "SyncInput",
+                        "size" : 1,
+                        "ty" : {
+                          "DefPort" : {
+                            "symbol" : {
+                              "Port" : {
+                                "nodeId" : 0,
+                                "unqualifiedName" : "P"
+                              }
+                            }
+                          }
+                        },
+                        "importNodeIds" : [
+                        ]
+                      }
+                    }
+                  },
+                  "portNumber" : "None",
+                  "topologyPort" : "None"
+                },
+                "isUnmatched" : false
+              }
+            ]
+          ],
+          [
+            {
+              "interfaceInstance" : {
+                "InterfaceComponentInstance" : {
+                  "astNodeId" : 22
+                }
+              },
+              "portInstance" : {
+                "General" : {
+                  "aNode" : {
+                    "astNodeId" : 4
+                  },
+                  "specifier" : {
+                    "kind" : {
+                      "SyncInput" : {
+                        
+                      }
+                    },
+                    "name" : "pIn",
+                    "size" : "None",
+                    "port" : {
+                      "Some" : {
+                        "astNodeId" : 3
+                      }
+                    },
+                    "priority" : "None",
+                    "queueFull" : "None"
+                  },
+                  "kind" : "SyncInput",
+                  "size" : 1,
+                  "ty" : {
+                    "DefPort" : {
+                      "symbol" : {
+                        "Port" : {
+                          "nodeId" : 0,
+                          "unqualifiedName" : "P"
+                        }
+                      }
+                    }
+                  },
+                  "importNodeIds" : [
+                  ]
+                }
+              }
+            },
+            [
+              {
+                "from" : {
+                  "loc" : {
+                    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+                    "pos" : "23.5",
+                    "includingLoc" : "None"
+                  },
+                  "port" : {
+                    "interfaceInstance" : {
+                      "InterfaceComponentInstance" : {
+                        "astNodeId" : 18
+                      }
+                    },
+                    "portInstance" : {
+                      "General" : {
+                        "aNode" : {
+                          "astNodeId" : 13
+                        },
+                        "specifier" : {
+                          "kind" : {
+                            "Output" : {
+                              
+                            }
+                          },
+                          "name" : "pOut",
+                          "size" : "None",
+                          "port" : {
+                            "Some" : {
+                              "astNodeId" : 12
+                            }
+                          },
+                          "priority" : "None",
+                          "queueFull" : "None"
+                        },
+                        "kind" : "Output",
+                        "size" : 1,
+                        "ty" : {
+                          "DefPort" : {
+                            "symbol" : {
+                              "Port" : {
+                                "nodeId" : 0,
+                                "unqualifiedName" : "P"
+                              }
+                            }
+                          }
+                        },
+                        "importNodeIds" : [
+                        ]
+                      }
+                    }
+                  },
+                  "portNumber" : "None",
+                  "topologyPort" : "None"
+                },
+                "to" : {
+                  "loc" : {
+                    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+                    "pos" : "23.16",
+                    "includingLoc" : "None"
+                  },
+                  "port" : {
+                    "interfaceInstance" : {
+                      "InterfaceComponentInstance" : {
+                        "astNodeId" : 22
                       }
                     },
                     "portInstance" : {
@@ -1579,118 +1579,6 @@
               "from" : {
                 "loc" : {
                   "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-                  "pos" : "28.5",
-                  "includingLoc" : "None"
-                },
-                "port" : {
-                  "interfaceInstance" : {
-                    "InterfaceComponentInstance" : {
-                      "astNodeId" : 22
-                    }
-                  },
-                  "portInstance" : {
-                    "General" : {
-                      "aNode" : {
-                        "astNodeId" : 13
-                      },
-                      "specifier" : {
-                        "kind" : {
-                          "Output" : {
-                            
-                          }
-                        },
-                        "name" : "pOut",
-                        "size" : "None",
-                        "port" : {
-                          "Some" : {
-                            "astNodeId" : 12
-                          }
-                        },
-                        "priority" : "None",
-                        "queueFull" : "None"
-                      },
-                      "kind" : "Output",
-                      "size" : 1,
-                      "ty" : {
-                        "DefPort" : {
-                          "symbol" : {
-                            "Port" : {
-                              "nodeId" : 0,
-                              "unqualifiedName" : "P"
-                            }
-                          }
-                        }
-                      },
-                      "importNodeIds" : [
-                      ]
-                    }
-                  }
-                },
-                "portNumber" : "None",
-                "topologyPort" : "None"
-              },
-              "to" : {
-                "loc" : {
-                  "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
-                  "pos" : "28.16",
-                  "includingLoc" : "None"
-                },
-                "port" : {
-                  "interfaceInstance" : {
-                    "InterfaceComponentInstance" : {
-                      "astNodeId" : 18
-                    }
-                  },
-                  "portInstance" : {
-                    "General" : {
-                      "aNode" : {
-                        "astNodeId" : 4
-                      },
-                      "specifier" : {
-                        "kind" : {
-                          "SyncInput" : {
-                            
-                          }
-                        },
-                        "name" : "pIn",
-                        "size" : "None",
-                        "port" : {
-                          "Some" : {
-                            "astNodeId" : 3
-                          }
-                        },
-                        "priority" : "None",
-                        "queueFull" : "None"
-                      },
-                      "kind" : "SyncInput",
-                      "size" : 1,
-                      "ty" : {
-                        "DefPort" : {
-                          "symbol" : {
-                            "Port" : {
-                              "nodeId" : 0,
-                              "unqualifiedName" : "P"
-                            }
-                          }
-                        }
-                      },
-                      "importNodeIds" : [
-                      ]
-                    }
-                  }
-                },
-                "portNumber" : "None",
-                "topologyPort" : "None"
-              },
-              "isUnmatched" : false
-            },
-            0
-          ],
-          [
-            {
-              "from" : {
-                "loc" : {
-                  "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
                   "pos" : "23.5",
                   "includingLoc" : "None"
                 },
@@ -1751,6 +1639,118 @@
                   "interfaceInstance" : {
                     "InterfaceComponentInstance" : {
                       "astNodeId" : 22
+                    }
+                  },
+                  "portInstance" : {
+                    "General" : {
+                      "aNode" : {
+                        "astNodeId" : 4
+                      },
+                      "specifier" : {
+                        "kind" : {
+                          "SyncInput" : {
+                            
+                          }
+                        },
+                        "name" : "pIn",
+                        "size" : "None",
+                        "port" : {
+                          "Some" : {
+                            "astNodeId" : 3
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None"
+                      },
+                      "kind" : "SyncInput",
+                      "size" : 1,
+                      "ty" : {
+                        "DefPort" : {
+                          "symbol" : {
+                            "Port" : {
+                              "nodeId" : 0,
+                              "unqualifiedName" : "P"
+                            }
+                          }
+                        }
+                      },
+                      "importNodeIds" : [
+                      ]
+                    }
+                  }
+                },
+                "portNumber" : "None",
+                "topologyPort" : "None"
+              },
+              "isUnmatched" : false
+            },
+            0
+          ],
+          [
+            {
+              "from" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+                  "pos" : "28.5",
+                  "includingLoc" : "None"
+                },
+                "port" : {
+                  "interfaceInstance" : {
+                    "InterfaceComponentInstance" : {
+                      "astNodeId" : 22
+                    }
+                  },
+                  "portInstance" : {
+                    "General" : {
+                      "aNode" : {
+                        "astNodeId" : 13
+                      },
+                      "specifier" : {
+                        "kind" : {
+                          "Output" : {
+                            
+                          }
+                        },
+                        "name" : "pOut",
+                        "size" : "None",
+                        "port" : {
+                          "Some" : {
+                            "astNodeId" : 12
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None"
+                      },
+                      "kind" : "Output",
+                      "size" : 1,
+                      "ty" : {
+                        "DefPort" : {
+                          "symbol" : {
+                            "Port" : {
+                              "nodeId" : 0,
+                              "unqualifiedName" : "P"
+                            }
+                          }
+                        }
+                      },
+                      "importNodeIds" : [
+                      ]
+                    }
+                  }
+                },
+                "portNumber" : "None",
+                "topologyPort" : "None"
+              },
+              "to" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",
+                  "pos" : "28.16",
+                  "includingLoc" : "None"
+                },
+                "port" : {
+                  "interfaceInstance" : {
+                    "InterfaceComponentInstance" : {
+                      "astNodeId" : 18
                     }
                   },
                   "portInstance" : {
@@ -1918,31 +1918,7 @@
       }
     },
     "dictionaryMap" : {
-      "65" : {
-        "usedSymbolSet" : [
-        ],
-        "commandEntryMap" : {
-          
-        },
-        "tlmChannelEntryMap" : {
-          
-        },
-        "eventEntryMap" : {
-          
-        },
-        "paramEntryMap" : {
-          
-        },
-        "recordEntryMap" : {
-          
-        },
-        "containerEntryMap" : {
-          
-        },
-        "tlmPacketSetMap" : {
-          
-        }
-      }
+      
     }
   }
 }

--- a/tests/topology/topology_ast.json
+++ b/tests/topology/topology_ast.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion" : "v3.2.0",
+  "fppVersion" : "v3.3.0a16-110-g291b338cc",
   "ast" : [
     {
       "members" : [
@@ -250,6 +250,7 @@
               "node" : {
                 "AstNode" : {
                   "data" : {
+                    "isDeployment" : false,
                     "name" : "Simple",
                     "members" : [
                       [

--- a/tests/topology/topology_locations.json
+++ b/tests/topology/topology_locations.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion" : "v3.2.0",
+  "fppVersion" : "v3.3.0a16-110-g291b338cc",
   "locationMap" : {
     "0" : {
       "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/simpleTopology.fpp",

--- a/tests/topology_ports/topology_ports_analysis.json
+++ b/tests/topology_ports/topology_ports_analysis.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion" : "v3.2.0",
+  "fppVersion" : "v3.3.0a16-110-g291b338cc",
   "analysis" : {
     "componentInstanceMap" : {
       "18" : {
@@ -1036,163 +1036,6 @@
             {
               "interfaceInstance" : {
                 "InterfaceComponentInstance" : {
-                  "astNodeId" : 22
-                }
-              },
-              "portInstance" : {
-                "General" : {
-                  "aNode" : {
-                    "astNodeId" : 4
-                  },
-                  "specifier" : {
-                    "kind" : {
-                      "SyncInput" : {
-                        
-                      }
-                    },
-                    "name" : "pIn",
-                    "size" : "None",
-                    "port" : {
-                      "Some" : {
-                        "astNodeId" : 3
-                      }
-                    },
-                    "priority" : "None",
-                    "queueFull" : "None"
-                  },
-                  "kind" : "SyncInput",
-                  "size" : 1,
-                  "ty" : {
-                    "DefPort" : {
-                      "symbol" : {
-                        "Port" : {
-                          "nodeId" : 0,
-                          "unqualifiedName" : "P"
-                        }
-                      }
-                    }
-                  },
-                  "importNodeIds" : [
-                  ]
-                }
-              }
-            },
-            [
-              {
-                "from" : {
-                  "loc" : {
-                    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/topologyPorts.fpp",
-                    "pos" : "23.5",
-                    "includingLoc" : "None"
-                  },
-                  "port" : {
-                    "interfaceInstance" : {
-                      "InterfaceComponentInstance" : {
-                        "astNodeId" : 18
-                      }
-                    },
-                    "portInstance" : {
-                      "General" : {
-                        "aNode" : {
-                          "astNodeId" : 13
-                        },
-                        "specifier" : {
-                          "kind" : {
-                            "Output" : {
-                              
-                            }
-                          },
-                          "name" : "pOut",
-                          "size" : "None",
-                          "port" : {
-                            "Some" : {
-                              "astNodeId" : 12
-                            }
-                          },
-                          "priority" : "None",
-                          "queueFull" : "None"
-                        },
-                        "kind" : "Output",
-                        "size" : 1,
-                        "ty" : {
-                          "DefPort" : {
-                            "symbol" : {
-                              "Port" : {
-                                "nodeId" : 0,
-                                "unqualifiedName" : "P"
-                              }
-                            }
-                          }
-                        },
-                        "importNodeIds" : [
-                        ]
-                      }
-                    }
-                  },
-                  "portNumber" : "None",
-                  "topologyPort" : "None"
-                },
-                "to" : {
-                  "loc" : {
-                    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/topologyPorts.fpp",
-                    "pos" : "23.16",
-                    "includingLoc" : "None"
-                  },
-                  "port" : {
-                    "interfaceInstance" : {
-                      "InterfaceComponentInstance" : {
-                        "astNodeId" : 22
-                      }
-                    },
-                    "portInstance" : {
-                      "General" : {
-                        "aNode" : {
-                          "astNodeId" : 4
-                        },
-                        "specifier" : {
-                          "kind" : {
-                            "SyncInput" : {
-                              
-                            }
-                          },
-                          "name" : "pIn",
-                          "size" : "None",
-                          "port" : {
-                            "Some" : {
-                              "astNodeId" : 3
-                            }
-                          },
-                          "priority" : "None",
-                          "queueFull" : "None"
-                        },
-                        "kind" : "SyncInput",
-                        "size" : 1,
-                        "ty" : {
-                          "DefPort" : {
-                            "symbol" : {
-                              "Port" : {
-                                "nodeId" : 0,
-                                "unqualifiedName" : "P"
-                              }
-                            }
-                          }
-                        },
-                        "importNodeIds" : [
-                        ]
-                      }
-                    }
-                  },
-                  "portNumber" : "None",
-                  "topologyPort" : "None"
-                },
-                "isUnmatched" : false
-              }
-            ]
-          ],
-          [
-            {
-              "interfaceInstance" : {
-                "InterfaceComponentInstance" : {
                   "astNodeId" : 18
                 }
               },
@@ -1299,6 +1142,163 @@
                     "interfaceInstance" : {
                       "InterfaceComponentInstance" : {
                         "astNodeId" : 18
+                      }
+                    },
+                    "portInstance" : {
+                      "General" : {
+                        "aNode" : {
+                          "astNodeId" : 4
+                        },
+                        "specifier" : {
+                          "kind" : {
+                            "SyncInput" : {
+                              
+                            }
+                          },
+                          "name" : "pIn",
+                          "size" : "None",
+                          "port" : {
+                            "Some" : {
+                              "astNodeId" : 3
+                            }
+                          },
+                          "priority" : "None",
+                          "queueFull" : "None"
+                        },
+                        "kind" : "SyncInput",
+                        "size" : 1,
+                        "ty" : {
+                          "DefPort" : {
+                            "symbol" : {
+                              "Port" : {
+                                "nodeId" : 0,
+                                "unqualifiedName" : "P"
+                              }
+                            }
+                          }
+                        },
+                        "importNodeIds" : [
+                        ]
+                      }
+                    }
+                  },
+                  "portNumber" : "None",
+                  "topologyPort" : "None"
+                },
+                "isUnmatched" : false
+              }
+            ]
+          ],
+          [
+            {
+              "interfaceInstance" : {
+                "InterfaceComponentInstance" : {
+                  "astNodeId" : 22
+                }
+              },
+              "portInstance" : {
+                "General" : {
+                  "aNode" : {
+                    "astNodeId" : 4
+                  },
+                  "specifier" : {
+                    "kind" : {
+                      "SyncInput" : {
+                        
+                      }
+                    },
+                    "name" : "pIn",
+                    "size" : "None",
+                    "port" : {
+                      "Some" : {
+                        "astNodeId" : 3
+                      }
+                    },
+                    "priority" : "None",
+                    "queueFull" : "None"
+                  },
+                  "kind" : "SyncInput",
+                  "size" : 1,
+                  "ty" : {
+                    "DefPort" : {
+                      "symbol" : {
+                        "Port" : {
+                          "nodeId" : 0,
+                          "unqualifiedName" : "P"
+                        }
+                      }
+                    }
+                  },
+                  "importNodeIds" : [
+                  ]
+                }
+              }
+            },
+            [
+              {
+                "from" : {
+                  "loc" : {
+                    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/topologyPorts.fpp",
+                    "pos" : "23.5",
+                    "includingLoc" : "None"
+                  },
+                  "port" : {
+                    "interfaceInstance" : {
+                      "InterfaceComponentInstance" : {
+                        "astNodeId" : 18
+                      }
+                    },
+                    "portInstance" : {
+                      "General" : {
+                        "aNode" : {
+                          "astNodeId" : 13
+                        },
+                        "specifier" : {
+                          "kind" : {
+                            "Output" : {
+                              
+                            }
+                          },
+                          "name" : "pOut",
+                          "size" : "None",
+                          "port" : {
+                            "Some" : {
+                              "astNodeId" : 12
+                            }
+                          },
+                          "priority" : "None",
+                          "queueFull" : "None"
+                        },
+                        "kind" : "Output",
+                        "size" : 1,
+                        "ty" : {
+                          "DefPort" : {
+                            "symbol" : {
+                              "Port" : {
+                                "nodeId" : 0,
+                                "unqualifiedName" : "P"
+                              }
+                            }
+                          }
+                        },
+                        "importNodeIds" : [
+                        ]
+                      }
+                    }
+                  },
+                  "portNumber" : "None",
+                  "topologyPort" : "None"
+                },
+                "to" : {
+                  "loc" : {
+                    "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/topologyPorts.fpp",
+                    "pos" : "23.16",
+                    "includingLoc" : "None"
+                  },
+                  "port" : {
+                    "interfaceInstance" : {
+                      "InterfaceComponentInstance" : {
+                        "astNodeId" : 22
                       }
                     },
                     "portInstance" : {
@@ -1579,118 +1579,6 @@
               "from" : {
                 "loc" : {
                   "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/topologyPorts.fpp",
-                  "pos" : "28.5",
-                  "includingLoc" : "None"
-                },
-                "port" : {
-                  "interfaceInstance" : {
-                    "InterfaceComponentInstance" : {
-                      "astNodeId" : 22
-                    }
-                  },
-                  "portInstance" : {
-                    "General" : {
-                      "aNode" : {
-                        "astNodeId" : 13
-                      },
-                      "specifier" : {
-                        "kind" : {
-                          "Output" : {
-                            
-                          }
-                        },
-                        "name" : "pOut",
-                        "size" : "None",
-                        "port" : {
-                          "Some" : {
-                            "astNodeId" : 12
-                          }
-                        },
-                        "priority" : "None",
-                        "queueFull" : "None"
-                      },
-                      "kind" : "Output",
-                      "size" : 1,
-                      "ty" : {
-                        "DefPort" : {
-                          "symbol" : {
-                            "Port" : {
-                              "nodeId" : 0,
-                              "unqualifiedName" : "P"
-                            }
-                          }
-                        }
-                      },
-                      "importNodeIds" : [
-                      ]
-                    }
-                  }
-                },
-                "portNumber" : "None",
-                "topologyPort" : "None"
-              },
-              "to" : {
-                "loc" : {
-                  "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/topologyPorts.fpp",
-                  "pos" : "28.16",
-                  "includingLoc" : "None"
-                },
-                "port" : {
-                  "interfaceInstance" : {
-                    "InterfaceComponentInstance" : {
-                      "astNodeId" : 18
-                    }
-                  },
-                  "portInstance" : {
-                    "General" : {
-                      "aNode" : {
-                        "astNodeId" : 4
-                      },
-                      "specifier" : {
-                        "kind" : {
-                          "SyncInput" : {
-                            
-                          }
-                        },
-                        "name" : "pIn",
-                        "size" : "None",
-                        "port" : {
-                          "Some" : {
-                            "astNodeId" : 3
-                          }
-                        },
-                        "priority" : "None",
-                        "queueFull" : "None"
-                      },
-                      "kind" : "SyncInput",
-                      "size" : 1,
-                      "ty" : {
-                        "DefPort" : {
-                          "symbol" : {
-                            "Port" : {
-                              "nodeId" : 0,
-                              "unqualifiedName" : "P"
-                            }
-                          }
-                        }
-                      },
-                      "importNodeIds" : [
-                      ]
-                    }
-                  }
-                },
-                "portNumber" : "None",
-                "topologyPort" : "None"
-              },
-              "isUnmatched" : false
-            },
-            0
-          ],
-          [
-            {
-              "from" : {
-                "loc" : {
-                  "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/topologyPorts.fpp",
                   "pos" : "23.5",
                   "includingLoc" : "None"
                 },
@@ -1751,6 +1639,118 @@
                   "interfaceInstance" : {
                     "InterfaceComponentInstance" : {
                       "astNodeId" : 22
+                    }
+                  },
+                  "portInstance" : {
+                    "General" : {
+                      "aNode" : {
+                        "astNodeId" : 4
+                      },
+                      "specifier" : {
+                        "kind" : {
+                          "SyncInput" : {
+                            
+                          }
+                        },
+                        "name" : "pIn",
+                        "size" : "None",
+                        "port" : {
+                          "Some" : {
+                            "astNodeId" : 3
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None"
+                      },
+                      "kind" : "SyncInput",
+                      "size" : 1,
+                      "ty" : {
+                        "DefPort" : {
+                          "symbol" : {
+                            "Port" : {
+                              "nodeId" : 0,
+                              "unqualifiedName" : "P"
+                            }
+                          }
+                        }
+                      },
+                      "importNodeIds" : [
+                      ]
+                    }
+                  }
+                },
+                "portNumber" : "None",
+                "topologyPort" : "None"
+              },
+              "isUnmatched" : false
+            },
+            0
+          ],
+          [
+            {
+              "from" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/topologyPorts.fpp",
+                  "pos" : "28.5",
+                  "includingLoc" : "None"
+                },
+                "port" : {
+                  "interfaceInstance" : {
+                    "InterfaceComponentInstance" : {
+                      "astNodeId" : 22
+                    }
+                  },
+                  "portInstance" : {
+                    "General" : {
+                      "aNode" : {
+                        "astNodeId" : 13
+                      },
+                      "specifier" : {
+                        "kind" : {
+                          "Output" : {
+                            
+                          }
+                        },
+                        "name" : "pOut",
+                        "size" : "None",
+                        "port" : {
+                          "Some" : {
+                            "astNodeId" : 12
+                          }
+                        },
+                        "priority" : "None",
+                        "queueFull" : "None"
+                      },
+                      "kind" : "Output",
+                      "size" : 1,
+                      "ty" : {
+                        "DefPort" : {
+                          "symbol" : {
+                            "Port" : {
+                              "nodeId" : 0,
+                              "unqualifiedName" : "P"
+                            }
+                          }
+                        }
+                      },
+                      "importNodeIds" : [
+                      ]
+                    }
+                  }
+                },
+                "portNumber" : "None",
+                "topologyPort" : "None"
+              },
+              "to" : {
+                "loc" : {
+                  "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/topologyPorts.fpp",
+                  "pos" : "28.16",
+                  "includingLoc" : "None"
+                },
+                "port" : {
+                  "interfaceInstance" : {
+                    "InterfaceComponentInstance" : {
+                      "astNodeId" : 18
                     }
                   },
                   "portInstance" : {
@@ -1924,31 +1924,7 @@
       }
     },
     "dictionaryMap" : {
-      "67" : {
-        "usedSymbolSet" : [
-        ],
-        "commandEntryMap" : {
-          
-        },
-        "tlmChannelEntryMap" : {
-          
-        },
-        "eventEntryMap" : {
-          
-        },
-        "paramEntryMap" : {
-          
-        },
-        "recordEntryMap" : {
-          
-        },
-        "containerEntryMap" : {
-          
-        },
-        "tlmPacketSetMap" : {
-          
-        }
-      }
+      
     }
   }
 }

--- a/tests/topology_ports/topology_ports_ast.json
+++ b/tests/topology_ports/topology_ports_ast.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion" : "v3.2.0",
+  "fppVersion" : "v3.3.0a16-110-g291b338cc",
   "ast" : [
     {
       "members" : [
@@ -250,6 +250,7 @@
               "node" : {
                 "AstNode" : {
                   "data" : {
+                    "isDeployment" : false,
                     "name" : "TopPorts",
                     "members" : [
                       [

--- a/tests/topology_ports/topology_ports_locations.json
+++ b/tests/topology_ports/topology_ports_locations.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion" : "v3.2.0",
+  "fppVersion" : "v3.3.0a16-110-g291b338cc",
   "locationMap" : {
     "0" : {
       "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/topologyPorts.fpp",

--- a/tests/types/types_analysis.json
+++ b/tests/types/types_analysis.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion" : "v3.2.0",
+  "fppVersion" : "v3.3.0a16-110-g291b338cc",
   "analysis" : {
     "componentInstanceMap" : {
       

--- a/tests/types/types_ast.json
+++ b/tests/types/types_ast.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion" : "v3.2.0",
+  "fppVersion" : "v3.3.0a16-110-g291b338cc",
   "ast" : [
     {
       "members" : [

--- a/tests/types/types_locations.json
+++ b/tests/types/types_locations.json
@@ -1,5 +1,5 @@
 {
-  "fppVersion" : "v3.2.0",
+  "fppVersion" : "v3.3.0a16-110-g291b338cc",
   "locationMap" : {
     "0" : {
       "file" : "[ local path prefix ]/compiler/tools/fpp-to-json/test/types.fpp",


### PR DESCRIPTION
This PR is to make fpp-python-model compatible with the changes in FPP v3.3.0. We'll merge this after FPP v3.3.0 is released.