### PR TITLE
Add support for DefSystem AST node (nasa/fprime#5691)

### DIFF
--- a/fprime_python_model/fpp_ast/fpp_ast.py
+++ b/fprime_python_model/fpp_ast/fpp_ast.py
@@ -525,6 +525,21 @@ class DefStruct(FrozenAstData):
 
 
 @dataclass(frozen=True)
+class DefSystem(FrozenAstData):
+    """
+    System definition
+
+    :param name: Name of the system
+    :type name: Ident
+    :param topology: Deployment topology implementing the system
+    :type topology: AstNode[QualIdent]
+    """
+
+    name: Ident
+    topology: AstNode[QualIdent]
+
+
+@dataclass(frozen=True)
 class DefTopology(FrozenAstData):
     """
     Topology defintion
@@ -954,6 +969,18 @@ class ModuleMemberDefStruct(ModuleMemberNode, FrozenAstData):
     """
 
     node: AstNode["DefStruct"]
+
+
+@dataclass(frozen=True)
+class ModuleMemberDefSystem(ModuleMemberNode, FrozenAstData):
+    """
+    System module member
+
+    :param node: System definition AST node
+    :type node: AstNode[DefSystem]
+    """
+
+    node: AstNode["DefSystem"]
 
 
 @dataclass(frozen=True)

--- a/fprime_python_model/semantics/name_group.py
+++ b/fprime_python_model/semantics/name_group.py
@@ -7,6 +7,7 @@ class NameGroup(Enum):
     COMPONENT = "component"
     PORT = "port"
     STATE_MACHINE = "state machine"
+    SYSTEM = "system"
     TOPOLOGY = "topology"
     PORT_INTERFACE = "interface"
     TYPE = "type"
@@ -22,6 +23,7 @@ name_groups: List[NameGroup] = [
     NameGroup.STATE_MACHINE,
     NameGroup.PORT_INTERFACE_INSTANCE,
     NameGroup.PORT_INTERFACE,
+    NameGroup.SYSTEM,
     NameGroup.TYPE,
     NameGroup.VALUE,
 ]

--- a/fprime_python_model/semantics/symbol.py
+++ b/fprime_python_model/semantics/symbol.py
@@ -49,6 +49,8 @@ class Symbol(SymbolInterface):
             return StateMachineSymbol(node)
         elif node_type == fpp_ast.DefStruct:
             return StructSymbol(node)
+        elif node_type == fpp_ast.DefSystem:
+            return SystemSymbol(node)
         elif node_type == fpp_ast.DefTopology:
             return TopologySymbol(node)
         else:
@@ -225,6 +227,17 @@ class StructSymbol(TypeSymbol):
 
     def is_dictionary_def(self):
         return self.node[1].data.is_dictionary_def
+
+
+@dataclass(frozen=True)
+class SystemSymbol(Symbol):
+    node: fpp_ast.Annotated[AstNode[fpp_ast.DefSystem]]
+
+    def get_node_id(self):
+        return self.node[1]._id
+
+    def get_unqualified_name(self):
+        return self.node[1].data.name
 
 
 @dataclass(frozen=True)

--- a/fprime_python_model/translators/analysis_translator.py
+++ b/fprime_python_model/translators/analysis_translator.py
@@ -22,6 +22,7 @@ from fprime_python_model.semantics.symbol import (
     EnumConstantSymbol,
     EnumSymbol,
     StructSymbol,
+    SystemSymbol,
     TopologySymbol,
     InterfaceSymbol,
     ArraySymbol,
@@ -282,6 +283,8 @@ class AnalysisTranslator:
                 return StateMachineSymbol(a_node)
             case "Struct":
                 return StructSymbol(a_node)
+            case "System":
+                return SystemSymbol(a_node)
             case "Topology":
                 return TopologySymbol(a_node)
             case _:
@@ -339,6 +342,8 @@ class AnalysisTranslator:
                 return "StateMachine"
             case fpp_ast.DefStruct():
                 return "Struct"
+            case fpp_ast.DefSystem():
+                return "System"
             case fpp_ast.DefTopology():
                 return "Topology"
             case _:
@@ -385,6 +390,8 @@ class AnalysisTranslator:
                 return NameGroup.PORT
             case "StateMachine":
                 return NameGroup.STATE_MACHINE
+            case "System":
+                return NameGroup.SYSTEM
             case "Topology":
                 return NameGroup.TOPOLOGY
             case "PortInterface":

--- a/fprime_python_model/translators/ast_translator.py
+++ b/fprime_python_model/translators/ast_translator.py
@@ -1153,6 +1153,16 @@ class AstTranslator:
                     member = fpp_ast.ModuleMemberDefStruct(
                         self.translate_def_struct(data, id)
                     )
+                case "DefSystem":
+                    member = fpp_ast.ModuleMemberDefSystem(
+                        AstNode.create_with_id(
+                            fpp_ast.DefSystem(
+                                data["name"],
+                                self.translate_qual_ident(data["topology"]),
+                            ),
+                            id,
+                        )
+                    )
                 case "DefTopology":
                     member = fpp_ast.ModuleMemberDefTopology(
                         AstNode.create_with_id(

--- a/fprime_python_model/translators/construct_ast_id_map.py
+++ b/fprime_python_model/translators/construct_ast_id_map.py
@@ -194,6 +194,13 @@ class ConstructAstMap(AstVisitor):
         if data.default:
             self.expr_node(data.default)
 
+    def def_system_annotated_node(
+        self, _in: In, a_node: fpp_ast.Annotated[AstNode[fpp_ast.DefSystem]]
+    ) -> Out:
+        _, node, _ = a_node
+        self.add_annotated_node_to_map(a_node)
+        self.qual_ident_node(node.data.topology)
+
     def def_topology_annotated_node(
         self, _in: In, a_node: fpp_ast.Annotated[AstNode[fpp_ast.DefTopology]]
     ) -> Out:

--- a/fprime_python_model/utils/fpp_ast_visitor.py
+++ b/fprime_python_model/utils/fpp_ast_visitor.py
@@ -117,6 +117,11 @@ class AstVisitor(ABC, Generic[In, Out]):
     ) -> Out:
         return self.default(_in)
 
+    def def_system_annotated_node(
+        self, _in: In, node: fpp_ast.Annotated[AstNode[fpp_ast.DefSystem]]
+    ) -> Out:
+        return self.default(_in)
+
     def def_topology_annotated_node(
         self, _in: In, node: fpp_ast.Annotated[AstNode[fpp_ast.DefTopology]]
     ) -> Out:
@@ -451,6 +456,8 @@ class AstVisitor(ABC, Generic[In, Out]):
                 )
             case fpp_ast.ModuleMemberDefStruct():
                 return self.def_struct_annotated_node(_in, (pre, node.node, post))
+            case fpp_ast.ModuleMemberDefSystem():
+                return self.def_system_annotated_node(_in, (pre, node.node, post))
             case fpp_ast.ModuleMemberDefTopology():
                 return self.def_topology_annotated_node(_in, (pre, node.node, post))
             case fpp_ast.ModuleMemberSpecInclude():

--- a/fprime_python_model/utils/fpp_ast_writer.py
+++ b/fprime_python_model/utils/fpp_ast_writer.py
@@ -282,6 +282,17 @@ class AstWriter(AstVisitor, LineUtils):
         return result + [self.indent_in(line) for line in concat_list]
 
     @override
+    def def_system_annotated_node(
+        self, _in: In, a_node: fpp_ast.Annotated[AstNode[fpp_ast.DefSystem]]
+    ):
+        _, node, _ = a_node
+        data = node.data
+        return self.lines("def system") + [
+            self.indent_in(line)
+            for line in self.ident(data.name) + self.qual_ident(data.topology.data)
+        ]
+
+    @override
     def def_topology_annotated_node(
         self, _in: In, a_node: fpp_ast.Annotated[AstNode[fpp_ast.DefTopology]]
     ):

--- a/fprime_python_model/utils/fpp_writer.py
+++ b/fprime_python_model/utils/fpp_writer.py
@@ -506,6 +506,20 @@ class FppWriter(AstVisitor, LineUtils):
             .join_opt(data.default, " default ", self.expr_node)
         )
 
+    def def_system_annotated_node(
+        self, _in, a_node: fpp_ast.Annotated[AstNode[fpp_ast.DefSystem]]
+    ):
+        _, node, _ = a_node
+        data = node.data
+        return Lines(
+            [
+                self.line(
+                    f"system {self.ident(data.name)}: "
+                    + self.qual_ident_string(data.topology.data)
+                )
+            ]
+        )
+
     def def_topology_annotated_node(
         self, _in, a_node: fpp_ast.Annotated[AstNode[fpp_ast.DefTopology]]
     ):


### PR DESCRIPTION
Adds support for the `DefSystem` AST node that `fpp-to-json` emits for `system` definitions (FPP >= 3.3.0a17):

```fpp
module M {
  deployment topology T {
  }
  system S: T
}
```

Without it, translating any such model raises `InvalidFppToJsonField: The "DefSystem" field is not valid.` — which currently breaks the `fprime-python-reference` check on [nasa/fprime#5691](https://github.com/nasa/fprime/pull/5691), where deployments must declare `deployment topology` plus an associated `system`.

Covers the AST node/module member, AST translator, visitor + dispatch, AST id map, AST/FPP writers, `SystemSymbol` and `NameGroup.SYSTEM`. Verified round-tripping the snippet above through `FppWriter` with fpp 3.3.0a17; `pytest` and `mypy` pass. No regression test added because reference fixtures are generated from the FPP repo via `tests/generate_ref_files.py`.

*Pushed by Devin AI*
